### PR TITLE
config: add modulifile option to customize moduli file location (bug#2277)

### DIFF
--- a/dh.c
+++ b/dh.c
@@ -143,7 +143,7 @@ parse_prime(int linenum, char *line, struct dhgroup *dhg)
 }
 
 DH *
-choose_dh(int min, int wantbits, int max)
+choose_dh(int min, int wantbits, int max, const char *moduli_file)
 {
 	FILE *f;
 	char line[4096];
@@ -151,10 +151,13 @@ choose_dh(int min, int wantbits, int max)
 	int linenum;
 	struct dhgroup dhg;
 
-	if ((f = fopen(_PATH_DH_MODULI, "r")) == NULL &&
+	if (moduli_file == NULL)
+		moduli_file = _PATH_DH_MODULI;
+
+	if ((f = fopen(moduli_file, "r")) == NULL &&
 	    (f = fopen(_PATH_DH_PRIMES, "r")) == NULL) {
 		logit("WARNING: %s does not exist, using fixed modulus",
-		    _PATH_DH_MODULI);
+		    moduli_file);
 		return (dh_new_group14());
 	}
 

--- a/dh.h
+++ b/dh.h
@@ -32,7 +32,7 @@ struct dhgroup {
 	BIGNUM *p;
 };
 
-DH	*choose_dh(int, int, int);
+DH	*choose_dh(int, int, int, const char *);
 DH	*dh_new_group_asc(const char *, const char *);
 DH	*dh_new_group(BIGNUM *, BIGNUM *);
 DH	*dh_new_group1(void);

--- a/kexgexs.c
+++ b/kexgexs.c
@@ -53,9 +53,12 @@
 #include "dispatch.h"
 #include "ssherr.h"
 #include "sshbuf.h"
+#include "servconf.h"
 
 static int input_kex_dh_gex_request(int, u_int32_t, void *);
 static int input_kex_dh_gex_init(int, u_int32_t, void *);
+
+/*extern ServerOptions options;*/
 
 int
 kexgex_server(struct ssh *ssh)
@@ -114,7 +117,7 @@ input_kex_dh_gex_request(int type, u_int32_t seq, void *ctxt)
 	}
 
 	/* Contact privileged parent */
-	kex->dh = PRIVSEP(choose_dh(min, nbits, max));
+	kex->dh = PRIVSEP(choose_dh(min, nbits, max, NULL/*options.moduli_file*/));
 	if (kex->dh == NULL) {
 		sshpkt_disconnect(ssh, "no matching DH grp found");
 		r = SSH_ERR_ALLOC_FAIL;

--- a/monitor.c
+++ b/monitor.c
@@ -653,10 +653,13 @@ mm_answer_moduli(int sock, Buffer *m)
 {
 	DH *dh;
 	int min, want, max;
+	const char *moduli_file;
+	u_int datlen;
 
 	min = buffer_get_int(m);
 	want = buffer_get_int(m);
 	max = buffer_get_int(m);
+	moduli_file = buffer_get_string(m, &datlen);
 
 	debug3("%s: got parameters: %d %d %d",
 	    __func__, min, want, max);
@@ -667,7 +670,7 @@ mm_answer_moduli(int sock, Buffer *m)
 
 	buffer_clear(m);
 
-	dh = choose_dh(min, want, max);
+	dh = choose_dh(min, want, max, moduli_file);
 	if (dh == NULL) {
 		buffer_put_char(m, 0);
 		return (0);

--- a/monitor_wrap.c
+++ b/monitor_wrap.c
@@ -184,7 +184,7 @@ mm_request_receive_expect(int sock, enum monitor_reqtype type, Buffer *m)
 
 #ifdef WITH_OPENSSL
 DH *
-mm_choose_dh(int min, int nbits, int max)
+mm_choose_dh(int min, int nbits, int max, const char *moduli_file)
 {
 	BIGNUM *p, *g;
 	int success = 0;
@@ -194,6 +194,7 @@ mm_choose_dh(int min, int nbits, int max)
 	buffer_put_int(&m, min);
 	buffer_put_int(&m, nbits);
 	buffer_put_int(&m, max);
+	buffer_put_string(&m, moduli_file, strlen(moduli_file)+1);
 
 	mm_request_send(pmonitor->m_recvfd, MONITOR_REQ_MODULI, &m);
 

--- a/monitor_wrap.h
+++ b/monitor_wrap.h
@@ -39,7 +39,7 @@ struct Authctxt;
 
 void mm_log_handler(LogLevel, const char *, void *);
 int mm_is_monitor(void);
-DH *mm_choose_dh(int, int, int);
+DH *mm_choose_dh(int, int, int, const char *);
 int mm_key_sign(Key *, u_char **, u_int *, const u_char *, u_int);
 void mm_inform_authserv(char *, char *);
 struct passwd *mm_getpwnamallow(const char *);

--- a/servconf.c
+++ b/servconf.c
@@ -83,6 +83,7 @@ initialize_server_options(ServerOptions *options)
 	options->num_host_key_files = 0;
 	options->num_host_cert_files = 0;
 	options->host_key_agent = NULL;
+	options->moduli_file = NULL;
 	options->pid_file = NULL;
 	options->server_key_bits = -1;
 	options->login_grace_time = -1;
@@ -207,6 +208,8 @@ fill_default_server_options(ServerOptions *options)
 		options->ports[options->num_ports++] = SSH_DEFAULT_PORT;
 	if (options->listen_addrs == NULL)
 		add_listen_addr(options, NULL, 0);
+	if (options->moduli_file == NULL)
+		options->moduli_file = _PATH_DH_MODULI;
 	if (options->pid_file == NULL)
 		options->pid_file = xstrdup(_PATH_SSH_DAEMON_PID_FILE);
 	if (options->server_key_bits == -1)
@@ -385,7 +388,7 @@ typedef enum {
 	sPermitTTY, sStrictModes, sEmptyPasswd, sTCPKeepAlive,
 	sPermitUserEnvironment, sUseLogin, sAllowTcpForwarding, sCompression,
 	sRekeyLimit, sAllowUsers, sDenyUsers, sAllowGroups, sDenyGroups,
-	sIgnoreUserKnownHosts, sCiphers, sMacs, sProtocol, sPidFile,
+	sIgnoreUserKnownHosts, sCiphers, sMacs, sProtocol, sModuliFile, sPidFile,
 	sGatewayPorts, sPubkeyAuthentication, sPubkeyAcceptedKeyTypes,
 	sXAuthLocation, sSubsystem, sMaxStartups, sMaxAuthTries, sMaxSessions,
 	sBanner, sUseDNS, sHostbasedAuthentication,
@@ -426,6 +429,7 @@ static struct {
 	{ "hostkey", sHostKeyFile, SSHCFG_GLOBAL },
 	{ "hostdsakey", sHostKeyFile, SSHCFG_GLOBAL },		/* alias */
 	{ "hostkeyagent", sHostKeyAgent, SSHCFG_GLOBAL },
+	{ "modulifile", sModuliFile, SSHCFG_GLOBAL },
 	{ "pidfile", sPidFile, SSHCFG_GLOBAL },
 	{ "serverkeybits", sServerKeyBits, SSHCFG_GLOBAL },
 	{ "logingracetime", sLoginGraceTime, SSHCFG_GLOBAL },
@@ -1075,6 +1079,10 @@ process_server_config_line(ServerOptions *options, char *line,
 		charptr = &options->host_cert_files[*intptr];
 		goto parse_filename;
 		break;
+
+	case sModuliFile:
+		charptr = &options->moduli_file;
+		goto parse_filename;
 
 	case sPidFile:
 		charptr = &options->pid_file;
@@ -2152,6 +2160,7 @@ dump_config(ServerOptions *o)
 	dump_cfg_fmtint(sFingerprintHash, o->fingerprint_hash);
 
 	/* string arguments */
+	dump_cfg_string(sModuliFile, o->moduli_file);
 	dump_cfg_string(sPidFile, o->pid_file);
 	dump_cfg_string(sXAuthLocation, o->xauth_location);
 	dump_cfg_string(sCiphers, o->ciphers ? o->ciphers : KEX_SERVER_ENCRYPT);

--- a/servconf.h
+++ b/servconf.h
@@ -16,6 +16,8 @@
 #ifndef SERVCONF_H
 #define SERVCONF_H
 
+#include "misc.h"
+
 #define MAX_PORTS		256	/* Max # ports. */
 
 #define MAX_ALLOW_USERS		256	/* Max # users on allow list. */

--- a/servconf.h
+++ b/servconf.h
@@ -68,6 +68,7 @@ typedef struct {
 	char   *host_cert_files[MAX_HOSTCERTS];	/* Files containing host certs. */
 	int     num_host_cert_files;     /* Number of files for host certs. */
 	char   *host_key_agent;		 /* ssh-agent socket for host keys. */
+	char   *moduli_file;		 /* DH Moduli file. */
 	char   *pid_file;	/* Where to put our pid */
 	int     server_key_bits;/* Size of the server key. */
 	int     login_grace_time;	/* Disconnect if no auth in this time

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1044,6 +1044,9 @@ The probability increases linearly and all connection attempts
 are refused if the number of unauthenticated connections reaches
 .Dq full
 (60).
+.It Cm ModuliFile
+Specifies where moduli file is located.  The default is
+.Pa /etc/ssh/moduli .
 .It Cm PasswordAuthentication
 Specifies whether password authentication is allowed.
 The default is


### PR DESCRIPTION
Currently all files can be customized via sshd_config, however, the
moduli file cannot.

Running sshd in unprivileged context requires customization of all
resources, especially when some distributions sets the moduli as world
unreadable.
