### PR TITLE
AuthorizedKeysCommand: add an option for alternate owner (bug#2276)

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -155,6 +155,7 @@ initialize_server_options(ServerOptions *options)
 	options->adm_forced_command = NULL;
 	options->chroot_directory = NULL;
 	options->authorized_keys_command = NULL;
+	options->authorized_keys_command_owner = NULL;
 	options->authorized_keys_command_user = NULL;
 	options->revoked_keys_file = NULL;
 	options->trusted_user_ca_keys = NULL;
@@ -397,7 +398,7 @@ typedef enum {
 	sHostCertificate,
 	sRevokedKeys, sTrustedUserCAKeys, sAuthorizedPrincipalsFile,
 	sKexAlgorithms, sIPQoS, sVersionAddendum,
-	sAuthorizedKeysCommand, sAuthorizedKeysCommandUser,
+	sAuthorizedKeysCommand, sAuthorizedKeysCommandOwner, sAuthorizedKeysCommandUser,
 	sAuthenticationMethods, sHostKeyAgent, sPermitUserRC,
 	sStreamLocalBindMask, sStreamLocalBindUnlink,
 	sAllowStreamLocalForwarding, sFingerprintHash,
@@ -527,6 +528,7 @@ static struct {
 	{ "kexalgorithms", sKexAlgorithms, SSHCFG_GLOBAL },
 	{ "ipqos", sIPQoS, SSHCFG_ALL },
 	{ "authorizedkeyscommand", sAuthorizedKeysCommand, SSHCFG_ALL },
+	{ "authorizedkeyscommandowner", sAuthorizedKeysCommandOwner, SSHCFG_ALL },
 	{ "authorizedkeyscommanduser", sAuthorizedKeysCommandUser, SSHCFG_ALL },
 	{ "versionaddendum", sVersionAddendum, SSHCFG_GLOBAL },
 	{ "authenticationmethods", sAuthenticationMethods, SSHCFG_ALL },
@@ -1686,6 +1688,14 @@ process_server_config_line(ServerOptions *options, char *line,
 		}
 		return 0;
 
+	case sAuthorizedKeysCommandOwner:
+		charptr = &options->authorized_keys_command_owner;
+
+		arg = strdelim(&cp);
+		if (*activep && *charptr == NULL)
+			*charptr = xstrdup(arg);
+		break;
+
 	case sAuthorizedKeysCommandUser:
 		charptr = &options->authorized_keys_command_user;
 
@@ -2165,6 +2175,7 @@ dump_config(ServerOptions *o)
 	    o->authorized_principals_file);
 	dump_cfg_string(sVersionAddendum, o->version_addendum);
 	dump_cfg_string(sAuthorizedKeysCommand, o->authorized_keys_command);
+	dump_cfg_string(sAuthorizedKeysCommandOwner, o->authorized_keys_command_owner);
 	dump_cfg_string(sAuthorizedKeysCommandUser, o->authorized_keys_command_user);
 	dump_cfg_string(sHostKeyAgent, o->host_key_agent);
 	dump_cfg_string(sKexAlgorithms,

--- a/servconf.h
+++ b/servconf.h
@@ -178,6 +178,7 @@ typedef struct {
 	char   *trusted_user_ca_keys;
 	char   *authorized_principals_file;
 	char   *authorized_keys_command;
+	char   *authorized_keys_command_owner;
 	char   *authorized_keys_command_user;
 
 	int64_t rekey_limit;
@@ -216,6 +217,7 @@ struct connection_info {
 		M_CP_STROPT(revoked_keys_file); \
 		M_CP_STROPT(authorized_principals_file); \
 		M_CP_STROPT(authorized_keys_command); \
+		M_CP_STROPT(authorized_keys_command_owner); \
 		M_CP_STROPT(authorized_keys_command_user); \
 		M_CP_STROPT(hostbased_key_types); \
 		M_CP_STROPT(pubkey_key_types); \

--- a/sshd_config
+++ b/sshd_config
@@ -56,6 +56,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #AuthorizedPrincipalsFile none
 
 #AuthorizedKeysCommand none
+#AuthorizedKeysCommandOwner root
 #AuthorizedKeysCommandUser nobody
 
 # For this to work you will also need host keys in /etc/ssh/ssh_known_hosts

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -230,7 +230,9 @@ The default is not to require multiple authentication; successful completion
 of a single authentication method is sufficient.
 .It Cm AuthorizedKeysCommand
 Specifies a program to be used to look up the user's public keys.
-The program must be owned by root and not writable by group or others.
+The program must be owned by value of
+.Cm AuthorizedKeysCommandOwner
+and not writable by group or others.
 It will be invoked with a single argument of the username
 being authenticated, and should produce on standard output zero or
 more lines of authorized_keys output (see AUTHORIZED_KEYS in
@@ -240,6 +242,9 @@ and authorize the user then public key authentication continues using the usual
 .Cm AuthorizedKeysFile
 files.
 By default, no AuthorizedKeysCommand is run.
+.It Cm AuthorizedKeysCommandOwner
+Specifies the user who should own the file referred by
+AuthorizedKeysCommand. By default, root.
 .It Cm AuthorizedKeysCommandUser
 Specifies the user under whose account the AuthorizedKeysCommand is run.
 It is recommended to use a dedicated user that has no other role on the host


### PR DESCRIPTION
Currently the owner of AuthorizedKeysCommand must be root.

A setup in which sshd is running as non root, can enjoy a complete
and secure environment even if the AuthorizedKeysCommand is owned by a
different user.

This patch adds AuthorizedKeysCommandOwner option to control the
ownership check of the AuthorizedKeysCommand. Default is root, so no
change is done without explicit request.
