### PR TITLE
unknown hosts: display a list of accepted hosts using the same key

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -417,7 +417,7 @@ check_key_in_hostfiles(struct passwd *pw, Key *key, const char *host,
 	const struct hostkey_entry *found;
 
 	hostkeys = init_hostkeys();
-	load_hostkeys(hostkeys, host, sysfile);
+	load_hostkeys(hostkeys, host, NULL, sysfile);
 	if (userfile != NULL) {
 		user_hostfile = tilde_expand_filename(userfile, pw->pw_uid);
 		if (options.strict_modes &&
@@ -431,7 +431,7 @@ check_key_in_hostfiles(struct passwd *pw, Key *key, const char *host,
 			    user_hostfile);
 		} else {
 			temporarily_use_uid(pw);
-			load_hostkeys(hostkeys, host, user_hostfile);
+			load_hostkeys(hostkeys, host, NULL, user_hostfile);
 			restore_uid();
 		}
 		free(user_hostfile);

--- a/hostfile.h
+++ b/hostfile.h
@@ -29,10 +29,14 @@ struct hostkey_entry {
 	Key *key;
 	HostkeyMarker marker;
 };
-struct hostkeys;
+
+struct hostkeys {
+	struct hostkey_entry *entries;
+	u_int num_entries;
+};
 
 struct hostkeys *init_hostkeys(void);
-void	 load_hostkeys(struct hostkeys *, const char *, const char *);
+void	 load_hostkeys(struct hostkeys *, const char *, const Key *, const char *);
 void	 free_hostkeys(struct hostkeys *);
 
 HostStatus check_key_in_hostkeys(struct hostkeys *, Key *,

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -113,9 +113,9 @@ order_hostkeyalgs(char *host, struct sockaddr *hostaddr, u_short port)
 	get_hostfile_hostname_ipaddr(host, hostaddr, port, &hostname, NULL);
 	hostkeys = init_hostkeys();
 	for (i = 0; i < options.num_user_hostfiles; i++)
-		load_hostkeys(hostkeys, hostname, options.user_hostfiles[i]);
+		load_hostkeys(hostkeys, hostname, NULL, options.user_hostfiles[i]);
 	for (i = 0; i < options.num_system_hostfiles; i++)
-		load_hostkeys(hostkeys, hostname, options.system_hostfiles[i]);
+		load_hostkeys(hostkeys, hostname, NULL, options.system_hostfiles[i]);
 
 	oavail = avail = xstrdup(KEX_DEFAULT_PK_ALG);
 	maxlen = strlen(avail) + 1;


### PR DESCRIPTION
When connecting to a host for which there's no known hostkey, check if the
selected key has been accepted for other hostnames.  This is useful when
connecting to a host with a dymamic IP address or multiple names.

An example where the local laptop is using DHCP and has 192.168.3.2 as its
current IP address:

```
% ssh 192.168.3.2
The authenticity of host '192.168.3.2 (192.168.3.2)' can't be established.
ECDSA key fingerprint is 9d:14:4f:ef:0c:0b:b4:1c:62:b0:89:af:e2:43:5c:4b.
You have previously accepted this key for the following hostnames:
        192.168.1.4
        localhost
Are you sure you want to continue connecting (yes/no)?
```
