### PR TITLE
bcrypt_pbkdf: Fix out-of-bounds read

### DIFF
--- a/auth-options.c
+++ b/auth-options.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: auth-options.c,v 1.66 2015/04/22 01:24:01 djm Exp $ */
+/* $OpenBSD: auth-options.c,v 1.67 2015/05/01 03:20:54 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -209,8 +209,7 @@ auth_parse_options(struct passwd *pw, char *opts, char *file, u_long linenum)
 			goto next_option;
 		}
 		cp = "environment=\"";
-		if (options.permit_user_env &&
-		    strncasecmp(opts, cp, strlen(cp)) == 0) {
+		if (strncasecmp(opts, cp, strlen(cp)) == 0) {
 			char *s;
 			struct envstring *new_envstring;
 
@@ -236,13 +235,19 @@ auth_parse_options(struct passwd *pw, char *opts, char *file, u_long linenum)
 				goto bad_option;
 			}
 			s[i] = '\0';
-			auth_debug_add("Adding to environment: %.900s", s);
-			debug("Adding to environment: %.900s", s);
 			opts++;
-			new_envstring = xcalloc(1, sizeof(struct envstring));
-			new_envstring->s = s;
-			new_envstring->next = custom_environment;
-			custom_environment = new_envstring;
+			if (options.permit_user_env) {
+				auth_debug_add("Adding to environment: "
+				    "%.900s", s);
+				debug("Adding to environment: %.900s", s);
+				new_envstring = xcalloc(1,
+				    sizeof(*new_envstring));
+				new_envstring->s = s;
+				new_envstring->next = custom_environment;
+				custom_environment = new_envstring;
+				s = NULL;
+			}
+			free(s);
 			goto next_option;
 		}
 		cp = "from=\"";

--- a/auth.c
+++ b/auth.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: auth.c,v 1.110 2015/02/25 17:29:38 djm Exp $ */
+/* $OpenBSD: auth.c,v 1.111 2015/05/01 04:17:51 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  *
@@ -400,8 +400,7 @@ expand_authorized_keys(const char *filename, struct passwd *pw)
 char *
 authorized_principals_file(struct passwd *pw)
 {
-	if (options.authorized_principals_file == NULL ||
-	    strcasecmp(options.authorized_principals_file, "none") == 0)
+	if (options.authorized_principals_file == NULL)
 		return NULL;
 	return expand_authorized_keys(options.authorized_principals_file, pw);
 }

--- a/auth.h
+++ b/auth.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: auth.h,v 1.82 2015/02/16 22:13:32 djm Exp $ */
+/* $OpenBSD: auth.h,v 1.83 2015/05/01 03:23:51 djm Exp $ */
 
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
@@ -126,7 +126,7 @@ int	 auth_rsa_key_allowed(struct passwd *, BIGNUM *, Key **);
 
 int	 auth_rhosts_rsa_key_allowed(struct passwd *, char *, char *, Key *);
 int	 hostbased_key_allowed(struct passwd *, const char *, char *, Key *);
-int	 user_key_allowed(struct passwd *, Key *);
+int	 user_key_allowed(struct passwd *, Key *, int);
 void	 pubkey_auth_info(Authctxt *, const Key *, const char *, ...)
 	    __attribute__((__format__ (printf, 3, 4)));
 void	 auth2_record_userkey(Authctxt *, struct sshkey *);

--- a/auth2-hostbased.c
+++ b/auth2-hostbased.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: auth2-hostbased.c,v 1.24 2015/01/28 22:36:00 djm Exp $ */
+/* $OpenBSD: auth2-hostbased.c,v 1.25 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  *
@@ -109,8 +109,7 @@ userauth_hostbased(Authctxt *authctxt)
 		goto done;
 	}
 	if (match_pattern_list(sshkey_ssh_name(key),
-	    options.hostbased_key_types,
-	    strlen(options.hostbased_key_types), 0) != 1) {
+	    options.hostbased_key_types, 0) != 1) {
 		logit("%s: key type %s not in HostbasedAcceptedKeyTypes",
 		    __func__, sshkey_type(key));
 		goto done;

--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: auth2-pubkey.c,v 1.47 2015/02/17 00:14:05 djm Exp $ */
+/* $OpenBSD: auth2-pubkey.c,v 1.48 2015/05/01 03:23:51 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  *
@@ -169,7 +169,7 @@ userauth_pubkey(Authctxt *authctxt)
 
 		/* test for correct signature */
 		authenticated = 0;
-		if (PRIVSEP(user_key_allowed(authctxt->pw, key)) &&
+		if (PRIVSEP(user_key_allowed(authctxt->pw, key, 1)) &&
 		    PRIVSEP(key_verify(key, sig, slen, buffer_ptr(&b),
 		    buffer_len(&b))) == 1) {
 			authenticated = 1;
@@ -191,7 +191,7 @@ userauth_pubkey(Authctxt *authctxt)
 		 * if a user is not allowed to login. is this an
 		 * issue? -markus
 		 */
-		if (PRIVSEP(user_key_allowed(authctxt->pw, key))) {
+		if (PRIVSEP(user_key_allowed(authctxt->pw, key, 0))) {
 			packet_start(SSH2_MSG_USERAUTH_PK_OK);
 			packet_put_string(pkalg, alen);
 			packet_put_string(pkblob, blen);
@@ -671,7 +671,7 @@ user_key_command_allowed2(struct passwd *user_pw, Key *key)
  * Check whether key authenticates and authorises the user.
  */
 int
-user_key_allowed(struct passwd *pw, Key *key)
+user_key_allowed(struct passwd *pw, Key *key, int auth_attempt)
 {
 	u_int success, i;
 	char *file;

--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: auth2-pubkey.c,v 1.48 2015/05/01 03:23:51 djm Exp $ */
+/* $OpenBSD: auth2-pubkey.c,v 1.49 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  *
@@ -127,8 +127,8 @@ userauth_pubkey(Authctxt *authctxt)
 		logit("refusing previously-used %s key", key_type(key));
 		goto done;
 	}
-	if (match_pattern_list(sshkey_ssh_name(key), options.pubkey_key_types,
-	    strlen(options.pubkey_key_types), 0) != 1) {
+	if (match_pattern_list(sshkey_ssh_name(key),
+	    options.pubkey_key_types, 0) != 1) {
 		logit("%s: key type %s not in PubkeyAcceptedKeyTypes",
 		    __func__, sshkey_ssh_name(key));
 		goto done;

--- a/clientloop.c
+++ b/clientloop.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: clientloop.c,v 1.272 2015/02/25 19:54:02 djm Exp $ */
+/* $OpenBSD: clientloop.c,v 1.273 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -2352,8 +2352,7 @@ client_input_hostkeys(void)
 		/* Check that the key is accepted in HostkeyAlgorithms */
 		if (options.hostkeyalgorithms != NULL &&
 		    match_pattern_list(sshkey_ssh_name(key),
-		    options.hostkeyalgorithms,
-		    strlen(options.hostkeyalgorithms), 0) != 1) {
+		    options.hostkeyalgorithms, 0) != 1) {
 			debug3("%s: %s key not permitted by HostkeyAlgorithms",
 			    __func__, sshkey_ssh_name(key));
 			continue;

--- a/compat.c
+++ b/compat.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: compat.c,v 1.90 2015/04/13 02:04:08 djm Exp $ */
+/* $OpenBSD: compat.c,v 1.91 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 1999, 2000, 2001, 2002 Markus Friedl.  All rights reserved.
  *
@@ -184,8 +184,7 @@ compat_datafellows(const char *version)
 
 	/* process table, return first match */
 	for (i = 0; check[i].pat; i++) {
-		if (match_pattern_list(version, check[i].pat,
-		    strlen(check[i].pat), 0) == 1) {
+		if (match_pattern_list(version, check[i].pat, 0) == 1) {
 			debug("match: %s pat %s compat 0x%08x",
 			    version, check[i].pat, check[i].bugs);
 			datafellows = check[i].bugs;	/* XXX for now */
@@ -243,7 +242,7 @@ filter_proposal(char *proposal, const char *filter)
 	buffer_init(&b);
 	tmp = orig_prop = xstrdup(proposal);
 	while ((cp = strsep(&tmp, ",")) != NULL) {
-		if (match_pattern_list(cp, filter, strlen(cp), 0) != 1) {
+		if (match_pattern_list(cp, filter, 0) != 1) {
 			if (buffer_len(&b) > 0)
 				buffer_append(&b, ",", 1);
 			buffer_append(&b, cp, strlen(cp));

--- a/dispatch.c
+++ b/dispatch.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: dispatch.c,v 1.26 2015/02/12 20:34:19 dtucker Exp $ */
+/* $OpenBSD: dispatch.c,v 1.27 2015/05/01 07:10:01 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  *
@@ -137,22 +137,6 @@ ssh_dispatch_run_fatal(struct ssh *ssh, int mode, volatile sig_atomic_t *done,
 {
 	int r;
 
-	if ((r = ssh_dispatch_run(ssh, mode, done, ctxt)) != 0) {
-		switch (r) {
-		case SSH_ERR_CONN_CLOSED:
-			logit("Connection closed by %.200s",
-			    ssh_remote_ipaddr(ssh));
-			cleanup_exit(255);
-		case SSH_ERR_CONN_TIMEOUT:
-			logit("Connection to %.200s timed out while "
-			    "waiting to read", ssh_remote_ipaddr(ssh));
-			cleanup_exit(255);
-		case SSH_ERR_DISCONNECTED:
-			logit("Disconnected from %.200s",
-			    ssh_remote_ipaddr(ssh));
-			cleanup_exit(255);
-		default:
-			fatal("%s: %s", __func__, ssh_err(r));
-		}
-	}
+	if ((r = ssh_dispatch_run(ssh, mode, done, ctxt)) != 0)
+		sshpkt_fatal(ssh, __func__, r);
 }

--- a/groupaccess.c
+++ b/groupaccess.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: groupaccess.c,v 1.15 2015/01/20 23:14:00 deraadt Exp $ */
+/* $OpenBSD: groupaccess.c,v 1.16 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 2001 Kevin Steves.  All rights reserved.
  *
@@ -97,11 +97,9 @@ int
 ga_match_pattern_list(const char *group_pattern)
 {
 	int i, found = 0;
-	size_t len = strlen(group_pattern);
 
 	for (i = 0; i < ngroups; i++) {
-		switch (match_pattern_list(groups_byname[i],
-		    group_pattern, len, 0)) {
+		switch (match_pattern_list(groups_byname[i], group_pattern, 0)) {
 		case -1:
 			return 0;	/* Negated match wins */
 		case 0:

--- a/hostfile.c
+++ b/hostfile.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: hostfile.c,v 1.65 2015/03/31 22:57:06 djm Exp $ */
+/* $OpenBSD: hostfile.c,v 1.66 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -663,7 +663,7 @@ match_maybe_hashed(const char *host, const char *names, int *was_hashed)
 		return nlen == strlen(hashed_host) &&
 		    strncmp(hashed_host, names, nlen) == 0;
 	}
-	return match_hostname(host, names, nlen) == 1;
+	return match_hostname(host, names) == 1;
 }
 
 int

--- a/match.c
+++ b/match.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: match.c,v 1.29 2013/11/20 20:54:10 deraadt Exp $ */
+/* $OpenBSD: match.c,v 1.30 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -115,15 +115,13 @@ match_pattern(const char *s, const char *pattern)
  * indicate negation).  Returns -1 if negation matches, 1 if there is
  * a positive match, 0 if there is no match at all.
  */
-
 int
-match_pattern_list(const char *string, const char *pattern, u_int len,
-    int dolower)
+match_pattern_list(const char *string, const char *pattern, int dolower)
 {
 	char sub[1024];
 	int negated;
 	int got_positive;
-	u_int i, subi;
+	u_int i, subi, len = strlen(pattern);
 
 	got_positive = 0;
 	for (i = 0; i < len;) {
@@ -177,9 +175,9 @@ match_pattern_list(const char *string, const char *pattern, u_int len,
  * a positive match, 0 if there is no match at all.
  */
 int
-match_hostname(const char *host, const char *pattern, u_int len)
+match_hostname(const char *host, const char *pattern)
 {
-	return match_pattern_list(host, pattern, len, 1);
+	return match_pattern_list(host, pattern, 1);
 }
 
 /*
@@ -200,7 +198,7 @@ match_host_and_ip(const char *host, const char *ipaddr,
 		return 0;
 
 	/* negative hostname match */
-	if ((mhost = match_hostname(host, patterns, strlen(patterns))) == -1)
+	if ((mhost = match_hostname(host, patterns)) == -1)
 		return 0;
 	/* no match at all */
 	if (mhost == 0 && mip == 0)

--- a/match.h
+++ b/match.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: match.h,v 1.15 2010/02/26 20:29:54 djm Exp $ */
+/* $OpenBSD: match.h,v 1.16 2015/05/04 06:10:48 djm Exp $ */
 
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
@@ -15,8 +15,8 @@
 #define MATCH_H
 
 int	 match_pattern(const char *, const char *);
-int	 match_pattern_list(const char *, const char *, u_int, int);
-int	 match_hostname(const char *, const char *, u_int);
+int	 match_pattern_list(const char *, const char *, int);
+int	 match_hostname(const char *, const char *);
 int	 match_host_and_ip(const char *, const char *, const char *);
 int	 match_user(const char *, const char *, const char *, const char *);
 char	*match_list(const char *, const char *, u_int *);

--- a/monitor.c
+++ b/monitor.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: monitor.c,v 1.148 2015/05/01 03:23:51 djm Exp $ */
+/* $OpenBSD: monitor.c,v 1.149 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
  * Copyright 2002 Markus Friedl <markus@openbsd.org>
@@ -1216,8 +1216,7 @@ mm_answer_keyallowed(int sock, Buffer *m)
 			allowed = options.pubkey_authentication &&
 			    !auth2_userkey_already_used(authctxt, key) &&
 			    match_pattern_list(sshkey_ssh_name(key),
-			    options.pubkey_key_types,
-			    strlen(options.pubkey_key_types), 0) == 1 &&
+			    options.pubkey_key_types, 0) == 1 &&
 			    user_key_allowed(authctxt->pw, key,
 			    pubkey_auth_attempt);
 			pubkey_auth_info(authctxt, key, NULL);
@@ -1229,8 +1228,7 @@ mm_answer_keyallowed(int sock, Buffer *m)
 		case MM_HOSTKEY:
 			allowed = options.hostbased_authentication &&
 			    match_pattern_list(sshkey_ssh_name(key),
-			    options.hostbased_key_types,
-			    strlen(options.hostbased_key_types), 0) == 1 &&
+			    options.hostbased_key_types, 0) == 1 &&
 			    hostbased_key_allowed(authctxt->pw,
 			    cuser, chost, key);
 			pubkey_auth_info(authctxt, key,

--- a/monitor.c
+++ b/monitor.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: monitor.c,v 1.147 2015/04/27 01:52:30 djm Exp $ */
+/* $OpenBSD: monitor.c,v 1.148 2015/05/01 03:23:51 djm Exp $ */
 /*
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
  * Copyright 2002 Markus Friedl <markus@openbsd.org>
@@ -1185,7 +1185,7 @@ mm_answer_keyallowed(int sock, Buffer *m)
 	Key *key;
 	char *cuser, *chost;
 	u_char *blob;
-	u_int bloblen;
+	u_int bloblen, pubkey_auth_attempt;
 	enum mm_keytype type = 0;
 	int allowed = 0;
 
@@ -1195,6 +1195,7 @@ mm_answer_keyallowed(int sock, Buffer *m)
 	cuser = buffer_get_string(m, NULL);
 	chost = buffer_get_string(m, NULL);
 	blob = buffer_get_string(m, &bloblen);
+	pubkey_auth_attempt = buffer_get_int(m);
 
 	key = key_from_blob(blob, bloblen);
 
@@ -1217,10 +1218,12 @@ mm_answer_keyallowed(int sock, Buffer *m)
 			    match_pattern_list(sshkey_ssh_name(key),
 			    options.pubkey_key_types,
 			    strlen(options.pubkey_key_types), 0) == 1 &&
-			    user_key_allowed(authctxt->pw, key);
+			    user_key_allowed(authctxt->pw, key,
+			    pubkey_auth_attempt);
 			pubkey_auth_info(authctxt, key, NULL);
 			auth_method = "publickey";
-			if (options.pubkey_authentication && allowed != 1)
+			if (options.pubkey_authentication &&
+			    (!pubkey_auth_attempt || allowed != 1))
 				auth_clear_options();
 			break;
 		case MM_HOSTKEY:

--- a/monitor_wrap.c
+++ b/monitor_wrap.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: monitor_wrap.c,v 1.84 2015/02/16 22:13:32 djm Exp $ */
+/* $OpenBSD: monitor_wrap.c,v 1.85 2015/05/01 03:23:51 djm Exp $ */
 /*
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
  * Copyright 2002 Markus Friedl <markus@openbsd.org>
@@ -371,16 +371,17 @@ mm_auth_password(Authctxt *authctxt, char *password)
 }
 
 int
-mm_user_key_allowed(struct passwd *pw, Key *key)
+mm_user_key_allowed(struct passwd *pw, Key *key, int pubkey_auth_attempt)
 {
-	return (mm_key_allowed(MM_USERKEY, NULL, NULL, key));
+	return (mm_key_allowed(MM_USERKEY, NULL, NULL, key,
+	    pubkey_auth_attempt));
 }
 
 int
 mm_hostbased_key_allowed(struct passwd *pw, char *user, char *host,
     Key *key)
 {
-	return (mm_key_allowed(MM_HOSTKEY, user, host, key));
+	return (mm_key_allowed(MM_HOSTKEY, user, host, key, 0));
 }
 
 int
@@ -390,13 +391,14 @@ mm_auth_rhosts_rsa_key_allowed(struct passwd *pw, char *user,
 	int ret;
 
 	key->type = KEY_RSA; /* XXX hack for key_to_blob */
-	ret = mm_key_allowed(MM_RSAHOSTKEY, user, host, key);
+	ret = mm_key_allowed(MM_RSAHOSTKEY, user, host, key, 0);
 	key->type = KEY_RSA1;
 	return (ret);
 }
 
 int
-mm_key_allowed(enum mm_keytype type, char *user, char *host, Key *key)
+mm_key_allowed(enum mm_keytype type, char *user, char *host, Key *key,
+    int pubkey_auth_attempt)
 {
 	Buffer m;
 	u_char *blob;
@@ -414,6 +416,7 @@ mm_key_allowed(enum mm_keytype type, char *user, char *host, Key *key)
 	buffer_put_cstring(&m, user ? user : "");
 	buffer_put_cstring(&m, host ? host : "");
 	buffer_put_string(&m, blob, len);
+	buffer_put_int(&m, pubkey_auth_attempt);
 	free(blob);
 
 	mm_request_send(pmonitor->m_recvfd, MONITOR_REQ_KEYALLOWED, &m);

--- a/monitor_wrap.h
+++ b/monitor_wrap.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: monitor_wrap.h,v 1.26 2015/02/16 22:13:32 djm Exp $ */
+/* $OpenBSD: monitor_wrap.h,v 1.27 2015/05/01 03:23:51 djm Exp $ */
 
 /*
  * Copyright 2002 Niels Provos <provos@citi.umich.edu>
@@ -45,8 +45,8 @@ void mm_inform_authserv(char *, char *);
 struct passwd *mm_getpwnamallow(const char *);
 char *mm_auth2_read_banner(void);
 int mm_auth_password(struct Authctxt *, char *);
-int mm_key_allowed(enum mm_keytype, char *, char *, Key *);
-int mm_user_key_allowed(struct passwd *, Key *);
+int mm_key_allowed(enum mm_keytype, char *, char *, Key *, int);
+int mm_user_key_allowed(struct passwd *, Key *, int);
 int mm_hostbased_key_allowed(struct passwd *, char *, char *, Key *);
 int mm_auth_rhosts_rsa_key_allowed(struct passwd *, char *, char *, Key *);
 int mm_key_verify(Key *, u_char *, u_int, u_char *, u_int);

--- a/mux.c
+++ b/mux.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: mux.c,v 1.52 2015/05/01 04:01:58 djm Exp $ */
+/* $OpenBSD: mux.c,v 1.53 2015/05/01 04:03:20 djm Exp $ */
 /*
  * Copyright (c) 2002-2008 Damien Miller <djm@openbsd.org>
  *
@@ -593,7 +593,9 @@ mux_confirm_remote_forward(int type, u_int32_t seq, void *ctxt)
 		return;
 	}
 	buffer_init(&out);
-	if (fctx->fid >= options.num_remote_forwards) {
+	if (fctx->fid >= options.num_remote_forwards ||
+	    (options.remote_forwards[fctx->fid].connect_path == NULL &&
+	    options.remote_forwards[fctx->fid].connect_host == NULL)) {
 		xasprintf(&failmsg, "unknown forwarding id %d", fctx->fid);
 		goto fail;
 	}
@@ -627,6 +629,17 @@ mux_confirm_remote_forward(int type, u_int32_t seq, void *ctxt)
 		else
 			xasprintf(&failmsg, "remote port forwarding failed for "
 			    "listen port %d", rfwd->listen_port);
+
+                debug2("%s: clearing registered forwarding for listen %d, "
+		    "connect %s:%d", __func__, rfwd->listen_port,
+		    rfwd->connect_path ? rfwd->connect_path :
+		    rfwd->connect_host, rfwd->connect_port);
+
+		free(rfwd->listen_host);
+		free(rfwd->listen_path);
+		free(rfwd->connect_host);
+		free(rfwd->connect_path);
+		memset(rfwd, 0, sizeof(*rfwd));
 	}
  fail:
 	error("%s: %s", __func__, failmsg);

--- a/mux.c
+++ b/mux.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: mux.c,v 1.51 2015/04/24 01:36:00 deraadt Exp $ */
+/* $OpenBSD: mux.c,v 1.52 2015/05/01 04:01:58 djm Exp $ */
 /*
  * Copyright (c) 2002-2008 Damien Miller <djm@openbsd.org>
  *
@@ -605,7 +605,7 @@ mux_confirm_remote_forward(int type, u_int32_t seq, void *ctxt)
 	if (type == SSH2_MSG_REQUEST_SUCCESS) {
 		if (rfwd->listen_port == 0) {
 			rfwd->allocated_port = packet_get_int();
-			logit("Allocated port %u for mux remote forward"
+			debug("Allocated port %u for mux remote forward"
 			    " to %s:%d", rfwd->allocated_port,
 			    rfwd->connect_host, rfwd->connect_port);
 			buffer_put_int(&out, MUX_S_REMOTE_PORT);
@@ -1722,7 +1722,7 @@ mux_client_forward(int fd, int cancel_flag, u_int ftype, struct Forward *fwd)
 		if (cancel_flag)
 			fatal("%s: got MUX_S_REMOTE_PORT for cancel", __func__);
 		fwd->allocated_port = buffer_get_int(&m);
-		logit("Allocated port %u for remote forward to %s:%d",
+		verbose("Allocated port %u for remote forward to %s:%d",
 		    fwd->allocated_port,
 		    fwd->connect_host ? fwd->connect_host : "",
 		    fwd->connect_port);

--- a/openbsd-compat/bcrypt_pbkdf.c
+++ b/openbsd-compat/bcrypt_pbkdf.c
@@ -161,7 +161,7 @@ bcrypt_pbkdf(const char *pass, size_t passlen, const u_int8_t *salt, size_t salt
 		amt = MIN(amt, keylen);
 		for (i = 0; i < amt; i++) {
 			size_t dest = i * stride + (count - 1);
-			if (dest >= origkeylen)
+			if (dest >= origkeylen || i >= BCRYPT_HASHSIZE)
 				break;
 			key[dest] = out[i];
 		}

--- a/packet.c
+++ b/packet.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: packet.c,v 1.211 2015/04/27 01:52:30 djm Exp $ */
+/* $OpenBSD: packet.c,v 1.212 2015/05/01 07:10:01 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -1920,9 +1920,19 @@ sshpkt_fatal(struct ssh *ssh, const char *tag, int r)
 		logit("Connection closed by %.200s", ssh_remote_ipaddr(ssh));
 		cleanup_exit(255);
 	case SSH_ERR_CONN_TIMEOUT:
-		logit("Connection to %.200s timed out while "
-		    "waiting to write", ssh_remote_ipaddr(ssh));
+		logit("Connection to %.200s timed out", ssh_remote_ipaddr(ssh));
 		cleanup_exit(255);
+	case SSH_ERR_DISCONNECTED:
+		logit("Disconnected from %.200s",
+		    ssh_remote_ipaddr(ssh));
+		cleanup_exit(255);
+	case SSH_ERR_SYSTEM_ERROR:
+		if (errno == ECONNRESET) {
+			logit("Connection reset by %.200s",
+			    ssh_remote_ipaddr(ssh));
+			cleanup_exit(255);
+		}
+		/* FALLTHROUGH */
 	default:
 		fatal("%s%sConnection to %.200s: %s",
 		    tag != NULL ? tag : "", tag != NULL ? ": " : "",

--- a/readconf.c
+++ b/readconf.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: readconf.c,v 1.234 2015/04/24 01:36:00 deraadt Exp $ */
+/* $OpenBSD: readconf.c,v 1.235 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -492,7 +492,6 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 	char *arg, *oattrib, *attrib, *cmd, *cp = *condition, *host, *criteria;
 	const char *ruser;
 	int r, port, this_result, result = 1, attributes = 0, negate;
-	size_t len;
 	char thishost[NI_MAXHOST], shorthost[NI_MAXHOST], portstr[NI_MAXSERV];
 
 	/*
@@ -545,25 +544,24 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 			result = -1;
 			goto out;
 		}
-		len = strlen(arg);
 		if (strcasecmp(attrib, "host") == 0) {
 			criteria = xstrdup(host);
-			r = match_hostname(host, arg, len) == 1;
+			r = match_hostname(host, arg) == 1;
 			if (r == (negate ? 1 : 0))
 				this_result = result = 0;
 		} else if (strcasecmp(attrib, "originalhost") == 0) {
 			criteria = xstrdup(original_host);
-			r = match_hostname(original_host, arg, len) == 1;
+			r = match_hostname(original_host, arg) == 1;
 			if (r == (negate ? 1 : 0))
 				this_result = result = 0;
 		} else if (strcasecmp(attrib, "user") == 0) {
 			criteria = xstrdup(ruser);
-			r = match_pattern_list(ruser, arg, len, 0) == 1;
+			r = match_pattern_list(ruser, arg, 0) == 1;
 			if (r == (negate ? 1 : 0))
 				this_result = result = 0;
 		} else if (strcasecmp(attrib, "localuser") == 0) {
 			criteria = xstrdup(pw->pw_name);
-			r = match_pattern_list(pw->pw_name, arg, len, 0) == 1;
+			r = match_pattern_list(pw->pw_name, arg, 0) == 1;
 			if (r == (negate ? 1 : 0))
 				this_result = result = 0;
 		} else if (strcasecmp(attrib, "exec") == 0) {
@@ -665,8 +663,8 @@ parse_token(const char *cp, const char *filename, int linenum,
 	for (i = 0; keywords[i].name; i++)
 		if (strcmp(cp, keywords[i].name) == 0)
 			return keywords[i].opcode;
-	if (ignored_unknown != NULL && match_pattern_list(cp, ignored_unknown,
-	    strlen(ignored_unknown), 1) == 1)
+	if (ignored_unknown != NULL &&
+	    match_pattern_list(cp, ignored_unknown, 1) == 1)
 		return oIgnoredUnknownOption;
 	error("%s: line %d: Bad configuration option: %s",
 	    filename, linenum, cp);

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -1,4 +1,4 @@
-#	$OpenBSD: Makefile,v 1.79 2015/03/16 22:46:14 djm Exp $
+#	$OpenBSD: Makefile,v 1.80 2015/04/23 05:01:19 dtucker Exp $
 
 REGRESS_TARGETS=	unit t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 t11 t12 t-exec
 tests:		prep $(REGRESS_TARGETS)
@@ -54,6 +54,7 @@ LTESTS= 	connect \
 		multiplex \
 		reexec \
 		brokenkeys \
+		cfgparse \
 		cfgmatch \
 		addrmatch \
 		localcommand \

--- a/regress/cfgparse.sh
+++ b/regress/cfgparse.sh
@@ -1,0 +1,51 @@
+#	$OpenBSD: cfgparse.sh,v 1.2 2015/04/29 05:23:27 dtucker Exp $
+#	Placed in the Public Domain.
+
+tid="config parse"
+
+verbose "reparse default config"
+($SUDO ${SSHD} -T -f /dev/null >$OBJ/sshd_config.1 &&
+ $SUDO ${SSHD} -T -f $OBJ/sshd_config.1 >$OBJ/sshd_config.2 &&
+ diff $OBJ/sshd_config.1 $OBJ/sshd_config.2) || fail "reparse default config"
+
+verbose "reparse regress config"
+($SUDO ${SSHD} -T -f $OBJ/sshd_config >$OBJ/sshd_config.1 &&
+ $SUDO ${SSHD} -T -f $OBJ/sshd_config.1 >$OBJ/sshd_config.2 &&
+ diff $OBJ/sshd_config.1 $OBJ/sshd_config.2) || fail "reparse regress config"
+
+verbose "listenaddress order"
+# expected output
+cat > $OBJ/sshd_config.0 <<EOD
+listenaddress 1.2.3.4:1234
+listenaddress 1.2.3.4:5678
+listenaddress [::1]:1234
+listenaddress [::1]:5678
+EOD
+# test input sets.  should all result in the output above.
+# test 1: addressfamily and port first
+cat > $OBJ/sshd_config.1 <<EOD
+addressfamily any
+port 1234
+port 5678
+listenaddress 1.2.3.4
+listenaddress ::1
+EOD
+($SUDO ${SSHD} -T -f $OBJ/sshd_config.1 | \
+ grep 'listenaddress ' >$OBJ/sshd_config.2 &&
+ diff -u $OBJ/sshd_config.0 $OBJ/sshd_config.2) || \
+ fail "listenaddress order 1"
+# test 2: listenaddress first
+cat > $OBJ/sshd_config.1 <<EOD
+listenaddress 1.2.3.4
+listenaddress ::1
+port 1234
+port 5678
+addressfamily any
+EOD
+($SUDO ${SSHD} -T -f $OBJ/sshd_config.1 | \
+ grep 'listenaddress ' >$OBJ/sshd_config.2 &&
+ diff -u $OBJ/sshd_config.0 $OBJ/sshd_config.2) || \
+ fail "listenaddress order 2"
+
+# cleanup
+rm -f $OBJ/sshd_config.[012]

--- a/regress/unittests/sshkey/test_sshkey.c
+++ b/regress/unittests/sshkey/test_sshkey.c
@@ -1,4 +1,4 @@
-/* 	$OpenBSD: test_sshkey.c,v 1.3 2015/01/26 06:11:28 djm Exp $ */
+/* 	$OpenBSD: test_sshkey.c,v 1.4 2015/04/22 01:38:36 djm Exp $ */
 /*
  * Regress test for sshkey.h key management API
  *
@@ -505,7 +505,7 @@ sshkey_tests(void)
 	ASSERT_INT_EQ(sshkey_load_cert(test_data_file("rsa_1"), &k1), 0);
 	ASSERT_INT_EQ(sshkey_load_public(test_data_file("rsa_1.pub"), &k2,
 	    NULL), 0);
-	k3 = get_private("ed25519_2");
+	k3 = get_private("rsa_1");
 	build_cert(b, k2, "ssh-rsa-cert-v01@openssh.com", k3, k1);
 	ASSERT_INT_EQ(sshkey_from_blob(sshbuf_ptr(b), sshbuf_len(b), &k4),
 	    SSH_ERR_KEY_CERT_INVALID_SIGN_KEY);

--- a/servconf.c
+++ b/servconf.c
@@ -1,5 +1,5 @@
 
-/* $OpenBSD: servconf.c,v 1.268 2015/05/01 07:08:08 djm Exp $ */
+/* $OpenBSD: servconf.c,v 1.269 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
  *                    All rights reserved
@@ -755,7 +755,6 @@ match_cfg_line(char **condition, int line, struct connection_info *ci)
 {
 	int result = 1, attributes = 0, port;
 	char *arg, *attrib, *cp = *condition;
-	size_t len;
 
 	if (ci == NULL)
 		debug3("checking syntax for 'Match %s'", cp);
@@ -782,13 +781,12 @@ match_cfg_line(char **condition, int line, struct connection_info *ci)
 			error("Missing Match criteria for %s", attrib);
 			return -1;
 		}
-		len = strlen(arg);
 		if (strcasecmp(attrib, "user") == 0) {
 			if (ci == NULL || ci->user == NULL) {
 				result = 0;
 				continue;
 			}
-			if (match_pattern_list(ci->user, arg, len, 0) != 1)
+			if (match_pattern_list(ci->user, arg, 0) != 1)
 				result = 0;
 			else
 				debug("user %.100s matched 'User %.100s' at "
@@ -809,7 +807,7 @@ match_cfg_line(char **condition, int line, struct connection_info *ci)
 				result = 0;
 				continue;
 			}
-			if (match_hostname(ci->host, arg, len) != 1)
+			if (match_hostname(ci->host, arg) != 1)
 				result = 0;
 			else
 				debug("connection from %.100s matched 'Host "

--- a/servconf.c
+++ b/servconf.c
@@ -1,5 +1,5 @@
 
-/* $OpenBSD: servconf.c,v 1.267 2015/05/01 04:17:51 djm Exp $ */
+/* $OpenBSD: servconf.c,v 1.268 2015/05/01 07:08:08 djm Exp $ */
 /*
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
  *                    All rights reserved
@@ -1021,7 +1021,7 @@ process_server_config_line(ServerOptions *options, char *line,
 		if ((value = convtime(arg)) == -1)
 			fatal("%s line %d: invalid time value.",
 			    filename, linenum);
-		if (*intptr == -1)
+		if (*activep && *intptr == -1)
 			*intptr = value;
 		break;
 
@@ -1599,7 +1599,7 @@ process_server_config_line(ServerOptions *options, char *line,
 		if (value == -1)
 			fatal("%s line %d: Bad yes/point-to-point/ethernet/"
 			    "no argument: %s", filename, linenum, arg);
-		if (*intptr == -1)
+		if (*activep && *intptr == -1)
 			*intptr = value;
 		break;
 
@@ -1738,7 +1738,7 @@ process_server_config_line(ServerOptions *options, char *line,
 		break;
 
 	case sAuthenticationMethods:
-		if (*activep && options->num_auth_methods == 0) {
+		if (options->num_auth_methods == 0) {
 			while ((arg = strdelim(&cp)) && *arg != '\0') {
 				if (options->num_auth_methods >=
 				    MAX_AUTH_METHODS)
@@ -1749,6 +1749,8 @@ process_server_config_line(ServerOptions *options, char *line,
 					fatal("%s line %d: invalid "
 					    "authentication method list.",
 					    filename, linenum);
+				if (!*activep)
+					continue;
 				options->auth_methods[
 				    options->num_auth_methods++] = xstrdup(arg);
 			}
@@ -1758,13 +1760,14 @@ process_server_config_line(ServerOptions *options, char *line,
 	case sStreamLocalBindMask:
 		arg = strdelim(&cp);
 		if (!arg || *arg == '\0')
-			fatal("%s line %d: missing StreamLocalBindMask argument.",
-			    filename, linenum);
+			fatal("%s line %d: missing StreamLocalBindMask "
+			    "argument.", filename, linenum);
 		/* Parse mode in octal format */
 		value = strtol(arg, &p, 8);
 		if (arg == p || value < 0 || value > 0777)
 			fatal("%s line %d: Bad mask.", filename, linenum);
-		options->fwd_opts.streamlocal_bind_mask = (mode_t)value;
+		if (*activep)
+			options->fwd_opts.streamlocal_bind_mask = (mode_t)value;
 		break;
 
 	case sStreamLocalBindUnlink:

--- a/servconf.c
+++ b/servconf.c
@@ -1,5 +1,5 @@
 
-/* $OpenBSD: servconf.c,v 1.266 2015/04/29 03:48:56 dtucker Exp $ */
+/* $OpenBSD: servconf.c,v 1.267 2015/05/01 04:17:51 djm Exp $ */
 /*
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
  *                    All rights reserved
@@ -353,6 +353,7 @@ fill_default_server_options(ServerOptions *options)
 	CLEAR_ON_NONE(options->banner);
 	CLEAR_ON_NONE(options->trusted_user_ca_keys);
 	CLEAR_ON_NONE(options->revoked_keys_file);
+	CLEAR_ON_NONE(options->authorized_principals_file);
 	for (i = 0; i < options->num_host_key_files; i++)
 		CLEAR_ON_NONE(options->host_key_files[i]);
 	for (i = 0; i < options->num_host_cert_files; i++)

--- a/ssh.c
+++ b/ssh.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: ssh.c,v 1.417 2015/04/17 13:16:48 djm Exp $ */
+/* $OpenBSD: ssh.c,v 1.418 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -356,10 +356,8 @@ check_follow_cname(char **namep, const char *cname)
 	debug3("%s: check \"%s\" CNAME \"%s\"", __func__, *namep, cname);
 	for (i = 0; i < options.num_permitted_cnames; i++) {
 		rule = options.permitted_cnames + i;
-		if (match_pattern_list(*namep, rule->source_list,
-		    strlen(rule->source_list), 1) != 1 ||
-		    match_pattern_list(cname, rule->target_list,
-		    strlen(rule->target_list), 1) != 1)
+		if (match_pattern_list(*namep, rule->source_list, 1) != 1 ||
+		    match_pattern_list(cname, rule->target_list, 1) != 1)
 			continue;
 		verbose("Canonicalized DNS aliased hostname "
 		    "\"%s\" => \"%s\"", *namep, cname);

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshconnect2.c,v 1.223 2015/01/30 11:43:14 djm Exp $ */
+/* $OpenBSD: sshconnect2.c,v 1.224 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 2000 Markus Friedl.  All rights reserved.
  * Copyright (c) 2008 Damien Miller.  All rights reserved.
@@ -1610,8 +1610,7 @@ userauth_hostbased(Authctxt *authctxt)
 				continue;
 			if (match_pattern_list(
 			    sshkey_ssh_name(authctxt->sensitive->keys[i]),
-			    authctxt->active_ktype,
-			    strlen(authctxt->active_ktype), 0) != 1)
+			    authctxt->active_ktype, 0) != 1)
 				continue;
 			/* we take and free the key */
 			private = authctxt->sensitive->keys[i];

--- a/sshd.8
+++ b/sshd.8
@@ -33,8 +33,8 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.\" $OpenBSD: sshd.8,v 1.278 2014/11/15 14:41:03 bentley Exp $
-.Dd $Mdocdate: November 15 2014 $
+.\" $OpenBSD: sshd.8,v 1.279 2015/05/01 07:11:47 djm Exp $
+.Dd $Mdocdate: May 1 2015 $
 .Dt SSHD 8
 .Os
 .Sh NAME
@@ -424,6 +424,8 @@ See
 below.
 .It
 Runs user's shell or command.
+All commands are run under the user's login shell as specified in the
+system password database.
 .El
 .Sh SSHRC
 If the file

--- a/sshkey.c
+++ b/sshkey.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshkey.c,v 1.16 2015/04/03 22:17:27 djm Exp $ */
+/* $OpenBSD: sshkey.c,v 1.17 2015/05/04 06:10:48 djm Exp $ */
 /*
  * Copyright (c) 2000, 2001 Markus Friedl.  All rights reserved.
  * Copyright (c) 2008 Alexander von Gernler.  All rights reserved.
@@ -251,7 +251,7 @@ sshkey_names_valid2(const char *names, int allow_wildcard)
 					if (kt->type == KEY_RSA1)
 						continue;
 					if (match_pattern_list(kt->name,
-					    p, strlen(p), 0) != 0)
+					    p, 0) != 0)
 						break;
 				}
 				if (kt->type != -1)


### PR DESCRIPTION
We are overrunning the array 'out' of 32 bytes at byte offset 1022 using
index i.
