### PR TITLE
sshd: make "-c" option usable

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -1495,7 +1495,7 @@ main(int ac, char **av)
 	initialize_server_options(&options);
 
 	/* Parse command-line arguments. */
-	while ((opt = getopt(ac, av, "f:p:b:k:h:g:u:o:C:dDeE:iqrtQRT46")) != -1) {
+	while ((opt = getopt(ac, av, "f:c:p:b:k:h:g:u:o:C:dDeE:iqrtQRT46")) != -1) {
 		switch (opt) {
 		case '4':
 			options.address_family = AF_INET;


### PR DESCRIPTION
the command line option was introduced in commit [0a80ca190a39943029719facf7edb990def7ae62](https://github.com/openssh/openssh-portable/commit/0a80ca190a39943029719facf7edb990def7ae62), however a proper getopt parsing is missing ...