### PR TITLE
Expose authentication information to PAM

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -466,6 +466,8 @@ sshpam_thread(void *ctxtp)
 	    (const void *)&sshpam_conv);
 	if (sshpam_err != PAM_SUCCESS)
 		goto auth_fail;
+  if (sshpam_authctxt->last_auth_methods)
+    do_pam_putenv("SSH_SUCCESSFUL_AUTH_METHODS", sshpam_authctxt->last_auth_methods);
 	sshpam_err = pam_authenticate(sshpam_handle, flags);
 	if (sshpam_err != PAM_SUCCESS)
 		goto auth_fail;
@@ -1203,6 +1205,8 @@ sshpam_auth_passwd(Authctxt *authctxt, const char *password)
 		fatal("PAM: %s: failed to set PAM_CONV: %s", __func__,
 		    pam_strerror(sshpam_handle, sshpam_err));
 
+  if (authctxt->last_auth_methods)
+    do_pam_putenv("SSH_SUCCESSFUL_AUTH_METHODS", authctxt->last_auth_methods);
 	sshpam_err = pam_authenticate(sshpam_handle, flags);
 	sshpam_password = NULL;
 	if (sshpam_err == PAM_SUCCESS && authctxt->valid) {

--- a/auth-pam.c
+++ b/auth-pam.c
@@ -334,6 +334,14 @@ import_environments(Buffer *b)
 #endif
 }
 
+/* Sets SSH_USER_AUTH PAM environment variable */
+static void
+sshpam_expose_auth_info()
+{
+  if (sshpam_authctxt->last_auth_methods != NULL)
+    do_pam_putenv("SSH_USER_AUTH", sshpam_authctxt->last_auth_methods);
+}
+
 /*
  * Conversation function for authentication thread.
  */
@@ -466,8 +474,9 @@ sshpam_thread(void *ctxtp)
 	    (const void *)&sshpam_conv);
 	if (sshpam_err != PAM_SUCCESS)
 		goto auth_fail;
-  if (sshpam_authctxt->last_auth_methods)
-    do_pam_putenv("SSH_SUCCESSFUL_AUTH_METHODS", sshpam_authctxt->last_auth_methods);
+
+  sshpam_expose_auth_info();
+
 	sshpam_err = pam_authenticate(sshpam_handle, flags);
 	if (sshpam_err != PAM_SUCCESS)
 		goto auth_fail;
@@ -1205,8 +1214,8 @@ sshpam_auth_passwd(Authctxt *authctxt, const char *password)
 		fatal("PAM: %s: failed to set PAM_CONV: %s", __func__,
 		    pam_strerror(sshpam_handle, sshpam_err));
 
-  if (authctxt->last_auth_methods)
-    do_pam_putenv("SSH_SUCCESSFUL_AUTH_METHODS", authctxt->last_auth_methods);
+  sshpam_expose_auth_info();
+
 	sshpam_err = pam_authenticate(sshpam_handle, flags);
 	sshpam_password = NULL;
 	if (sshpam_err == PAM_SUCCESS && authctxt->valid) {

--- a/auth.h
+++ b/auth.h
@@ -69,6 +69,7 @@ struct Authctxt {
 #endif
 	char		**auth_methods;	/* modified from server config */
 	u_int		 num_auth_methods;
+  char  *last_auth_methods;
 #ifdef KRB5
 	krb5_context	 krb5_ctx;
 	krb5_ccache	 krb5_fwd_ccache;

--- a/auth.h
+++ b/auth.h
@@ -69,7 +69,7 @@ struct Authctxt {
 #endif
 	char		**auth_methods;	/* modified from server config */
 	u_int		 num_auth_methods;
-  char  *last_auth_methods;
+	char*		last_auth_methods;
 #ifdef KRB5
 	krb5_context	 krb5_ctx;
 	krb5_ccache	 krb5_fwd_ccache;

--- a/auth2.c
+++ b/auth2.c
@@ -616,18 +616,13 @@ auth2_update_methods_lists(Authctxt *authctxt, const char *method,
 		fatal("%s: method not in AuthenticationMethods", __func__);
 
   if (authctxt->last_auth_methods == NULL) {
-    authctxt->last_auth_methods = xcalloc(strlen(method) + 2, sizeof(char));
+    authctxt->last_auth_methods = xstrdup(method);
   } else {
-    am_copy = xstrdup(authctxt->last_auth_methods);
-    free(authctxt->last_auth_methods);
-    authctxt->last_auth_methods = xcalloc(strlen(am_copy) + strlen(method) + 2, sizeof(char));
-    strcpy(authctxt->last_auth_methods, am_copy);
+    am_copy = authctxt->last_auth_methods;
+    xasprintf(&authctxt->last_auth_methods, "%s,%s", am_copy, method);
     free(am_copy);
   }
 
-  strcat(authctxt->last_auth_methods, method);
-  if (authctxt->num_auth_methods != 1)
-    strcat(authctxt->last_auth_methods, ",");
 	return 0;
 }
 

--- a/auth2.c
+++ b/auth2.c
@@ -596,6 +596,7 @@ auth2_update_methods_lists(Authctxt *authctxt, const char *method,
     const char *submethod)
 {
 	u_int i, found = 0;
+  char * am_copy = NULL;
 
 	debug3("%s: updating methods list after \"%s\"", __func__, method);
 	for (i = 0; i < authctxt->num_auth_methods; i++) {
@@ -613,6 +614,20 @@ auth2_update_methods_lists(Authctxt *authctxt, const char *method,
 	/* This should not happen, but would be bad if it did */
 	if (!found)
 		fatal("%s: method not in AuthenticationMethods", __func__);
+
+  if (authctxt->last_auth_methods == NULL) {
+    authctxt->last_auth_methods = xcalloc(strlen(method) + 2, sizeof(char));
+  } else {
+    am_copy = xstrdup(authctxt->last_auth_methods);
+    free(authctxt->last_auth_methods);
+    authctxt->last_auth_methods = xcalloc(strlen(am_copy) + strlen(method) + 2, sizeof(char));
+    strcpy(authctxt->last_auth_methods, am_copy);
+    free(am_copy);
+  }
+
+  strcat(authctxt->last_auth_methods, method);
+  if (authctxt->num_auth_methods != 1)
+    strcat(authctxt->last_auth_methods, ",");
 	return 0;
 }
 

--- a/auth2.c
+++ b/auth2.c
@@ -588,7 +588,8 @@ remove_method(char **methods, const char *method, const char *submethod)
 /*
  * Called after successful authentication. Will remove the successful method
  * from the start of each list in which it occurs. If it was the last method
- * in any list, then authentication is deemed successful.
+ * in any list, then authentication is deemed successful. Updates the list of
+ * previously successful authentication methods that can be exposed to PAM.
  * Returns 1 if the method completed any authentication list or 0 otherwise.
  */
 int
@@ -596,9 +597,9 @@ auth2_update_methods_lists(Authctxt *authctxt, const char *method,
     const char *submethod)
 {
 	u_int i, found = 0;
-  char * am_copy = NULL;
-  char * method_details = NULL;
-  char * fp = NULL;
+  char *am_copy = NULL;
+  char *method_details = NULL;
+  char *fp = NULL;
   Key * good_key = NULL;
 
 	debug3("%s: updating methods list after \"%s\"", __func__, method);
@@ -639,7 +640,7 @@ auth2_update_methods_lists(Authctxt *authctxt, const char *method,
     free(fp);
   }
 
-  if (!authctxt->last_auth_methods) {
+  if (authctxt->last_auth_methods == NULL) {
     if (method_details) {
       xasprintf(&authctxt->last_auth_methods, "%s %s", method, method_details);
     } else {

--- a/session.c
+++ b/session.c
@@ -731,7 +731,7 @@ do_exec_pty(Session *s, const char *command)
 
 	/* Enter interactive session. */
 	s->ptymaster = ptymaster;
-	packet_set_interactive(1, 
+	packet_set_interactive(1,
 	    options.ip_qos_interactive, options.ip_qos_bulk);
 	if (compat20) {
 		session_set_fds(s, ptyfd, fdout, -1, 1, 1);
@@ -1458,7 +1458,7 @@ safely_chroot(const char *path, uid_t uid)
 			memcpy(component, path, cp - path);
 			component[cp - path] = '\0';
 		}
-	
+
 		debug3("%s: checking '%s'", __func__, component);
 
 		if (stat(component, &st) != 0)
@@ -1466,7 +1466,7 @@ safely_chroot(const char *path, uid_t uid)
 			    component, strerror(errno));
 		if (st.st_uid != 0 || (st.st_mode & 022) != 0)
 			fatal("bad ownership or modes for chroot "
-			    "directory %s\"%s\"", 
+			    "directory %s\"%s\"",
 			    cp == NULL ? "" : "component ", component);
 		if (!S_ISDIR(st.st_mode))
 			fatal("chroot path %s\"%s\" is not a directory",
@@ -1542,14 +1542,14 @@ do_setusercontext(struct passwd *pw)
 			perror("unable to set user context (setuser)");
 			exit(1);
 		}
-		/* 
+		/*
 		 * FreeBSD's setusercontext() will not apply the user's
 		 * own umask setting unless running with the user's UID.
 		 */
 		(void) setusercontext(lc, pw, pw->pw_uid, LOGIN_SETUMASK);
 #else
 # ifdef USE_LIBIAF
-/* In a chroot environment, the set_id() will always fail; typically 
+/* In a chroot environment, the set_id() will always fail; typically
  * because of the lack of necessary authentication services and runtime
  * such as ./usr/lib/libiaf.so, ./usr/lib/libpam.so.1, and ./etc/passwd
  * We skip it in the internal sftp chroot case.
@@ -2738,6 +2738,8 @@ do_cleanup(Authctxt *authctxt)
 
 	if (authctxt == NULL)
 		return;
+
+  free(authctxt->last_auth_methods);
 
 #ifdef USE_PAM
 	if (options.use_pam) {

--- a/session.c
+++ b/session.c
@@ -2740,6 +2740,7 @@ do_cleanup(Authctxt *authctxt)
 		return;
 
   free(authctxt->last_auth_methods);
+  authctxt->last_auth_methods = NULL;
 
 #ifdef USE_PAM
 	if (options.use_pam) {

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -645,7 +645,7 @@ userauth_gssapi(Authctxt *authctxt)
 	while (mech < gss_supported->count && !ok) {
 		/* My DER encoding requires length<128 */
 		if (gss_supported->elements[mech].length < 128 &&
-		    ssh_gssapi_check_mechanism(&gssctxt, 
+		    ssh_gssapi_check_mechanism(&gssctxt,
 		    &gss_supported->elements[mech], authctxt->host)) {
 			ok = 1; /* Mechanism works */
 		} else {


### PR DESCRIPTION
Implements enhancement described in: https://bugzilla.mindrot.org/show_bug.cgi?id=2408. Exposes information about the previously successful authentication methods to PAM. 
