### PR TITLE
fix for ubuntu-15.10 pty

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -1670,8 +1670,8 @@ channel_handle_rfd(Channel *c, fd_set *readset, fd_set *writeset)
 	if (c->rfd != -1 && (force || FD_ISSET(c->rfd, readset))) {
 		errno = 0;
 		len = read(c->rfd, buf, sizeof(buf));
-		if (len < 0 && (errno == EINTR ||
-		    ((errno == EAGAIN || errno == EWOULDBLOCK) && !force)))
+		if (len < 0 && (errno == EINTR || errno == EAGAIN ||
+		    (errno == EWOULDBLOCK && !force)))
 			return 1;
 #ifndef PTY_ZEROREAD
 		if (len <= 0) {


### PR DESCRIPTION
I noticed that on Ubuntu-15.10 read() inside channel_handle_rfd() may return EAGAIN after the child process is exited.
OpenSSH server considers this as an error and breaks the connection without reading the whole output.
It looks like:
 http://i.imgur.com/mLMk66c.png  <-- using openssh-client
 http://i.imgur.com/LNdNSRq.png  <-- using Apache Mina ssh client
It happens only if pty is allocated.
I managed to fix the problem with the following patch: https://github.com/volth/openssh-portable/commit/4d284a3024f38726a8b8c53ac39ca5bf037fe0d0
Would be nice to see this bug fixed one way or another as it is a very annoing bug, it breaks the workflow of automated deployment tools.

PS. If you need a playground to reproduce the bug, you may try Ubuntu-15.10 instances on Google Cloud or DigitalOcean. The bug happens more often on the cloud machines. It happens on dedicated hardware as well but not so often.
