### PR TITLE
Fixed comment about const qualifier on certain systems regarding PAM

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -67,7 +67,7 @@
 
 /* OpenGroup RFC86.0 and XSSO specify no "const" on arguments */
 #ifdef PAM_SUN_CODEBASE
-# define sshpam_const		/* Solaris, HP-UX, AIX */
+# define sshpam_const		/* Solaris, HP-UX, SunOS */
 #else
 # define sshpam_const	const	/* LinuxPAM, OpenPAM */
 #endif


### PR DESCRIPTION
Normally I wouldn't have given the comment a second thought, but it led me down a rabbit hole when compiling on AIX :)

If we look at `configure.ac` we see that `PAM_SUN_CODEBASE` is only defined for HP-UX 11, Solaris, and SunOS 4, not AIX.