### PR TITLE
openssh.spec fixes reported by 'rpmlint'

### DIFF
--- a/contrib/redhat/openssh.spec
+++ b/contrib/redhat/openssh.spec
@@ -257,7 +257,7 @@ install -d $RPM_BUILD_ROOT%{_libexecdir}/openssh
 %if %{build6x}
 install -m644 contrib/redhat/sshd.pam.old $RPM_BUILD_ROOT/etc/pam.d/sshd
 %else
-install -m644 contrib/redhat/sshd.pam     $RPM_BUILD_ROOT/etc/pam.d/sshd
+install -m644 contrib/redhat/sshd.pam $RPM_BUILD_ROOT/etc/pam.d/sshd
 %endif
 install -m755 contrib/redhat/sshd.init $RPM_BUILD_ROOT/etc/rc.d/init.d/sshd
 
@@ -414,7 +414,7 @@ fi
 - Don't install profile.d scripts when not building with GNOME/GTK askpass
   (patch from bet@rahul.net)
 
-* Wed Oct 01 2002 Damien Miller <djm@mindrot.org>
+* Tue Oct 01 2002 Damien Miller <djm@mindrot.org>
 - Install ssh-agent setgid nobody to prevent ptrace() key theft attacks
 
 * Mon Sep 30 2002 Damien Miller <djm@mindrot.org>
@@ -460,7 +460,7 @@ fi
 - remove dependency on db1-devel, which has just been swallowed up whole
   by gnome-libs-devel
 
-* Sun Dec 29 2001 Nalin Dahyabhai <nalin@redhat.com>
+* Sat Dec 29 2001 Nalin Dahyabhai <nalin@redhat.com>
 - adjust build dependencies so that build6x actually works right (fix
   from Hugo van der Kooij)
 

--- a/contrib/redhat/openssh.spec
+++ b/contrib/redhat/openssh.spec
@@ -80,7 +80,7 @@ Source1: http://www.jmknoble.net/software/x11-ssh-askpass/x11-ssh-askpass-%{aver
 License: BSD
 Group: Applications/Internet
 BuildRoot: %{_tmppath}/%{name}-%{version}-buildroot
-Obsoletes: ssh
+Obsoletes: ssh <= %{version}
 %if %{build6x}
 PreReq: initscripts >= 5.00
 %else
@@ -108,12 +108,12 @@ BuildRequires: krb5-libs
 Summary: OpenSSH clients.
 Requires: openssh = %{version}-%{release}
 Group: Applications/Internet
-Obsoletes: ssh-clients
+Obsoletes: ssh-clients <= %{version}
 
 %package server
 Summary: The OpenSSH server daemon.
 Group: System Environment/Daemons
-Obsoletes: ssh-server
+Obsoletes: ssh-server <= %{version}
 Requires: openssh = %{version}-%{release}, chkconfig >= 0.9
 %if ! %{build6x}
 Requires: /etc/pam.d/system-auth
@@ -123,13 +123,13 @@ Requires: /etc/pam.d/system-auth
 Summary: A passphrase dialog for OpenSSH and X.
 Group: Applications/Internet
 Requires: openssh = %{version}-%{release}
-Obsoletes: ssh-extras
+Obsoletes: ssh-extras <= %{version}
 
 %package askpass-gnome
 Summary: A passphrase dialog for OpenSSH, X, and GNOME.
 Group: Applications/Internet
 Requires: openssh = %{version}-%{release}
-Obsoletes: ssh-extras
+Obsoletes: ssh-extras <= %{version}
 
 %description
 SSH (Secure SHell) is a program for logging into and executing


### PR DESCRIPTION
Those commits fix some warnings reported by 'rpmlint', version 1.8-6.
Before the changes:
$ rpmlint contrib/redhat/openssh.spec
openssh.spec:83: W: unversioned-explicit-obsoletes ssh
openssh.spec:111: W: unversioned-explicit-obsoletes ssh-clients
openssh.spec:116: W: unversioned-explicit-obsoletes ssh-server
openssh.spec:126: W: unversioned-explicit-obsoletes ssh-extras
openssh.spec:132: W: unversioned-explicit-obsoletes ssh-extras
openssh.spec:260: W: mixed-use-of-spaces-and-tabs (spaces: line 260, tab: line 192)
openssh.spec: E: specfile-error warning: bogus date in %changelog: Wed Oct 01 2002 Damien Miller djm@mindrot.org
openssh.spec: E: specfile-error warning: bogus date in %changelog: Sun Dec 29 2001 Nalin Dahyabhai nalin@redhat.com
0 packages and 1 specfiles checked; 2 errors, 6 warnings.

After the changes:
$ rpmlint contrib/redhat/openssh.spec
openssh.spec: W: invalid-url Source1: http://www.jmknoble.net/software/x11-ssh-askpass/x11-ssh-askpass-1.2.4.1.tar.gz <urlopen error [Errno -5] No address associated with hostname>
openssh.spec: W: invalid-url Source0: ftp://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.2p1.tar.gz <urlopen error ftp error: ConnectionRefusedError(111, 'Connection refused')>
0 packages and 1 specfiles checked; 0 errors, 2 warnings.
