### PR TITLE
Move MAX_DISPLAYS to a configuration option, fix a quirk or bug in MAX_DISPLAYS

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -148,9 +148,6 @@ static int all_opens_permitted = 0;
 
 /* -- X11 forwarding */
 
-/* Maximum number of fake X11 displays to try. */
-#define MAX_DISPLAYS  1000
-
 /* Saved X11 local (client) display. */
 static char *x11_saved_display = NULL;
 
@@ -3890,7 +3887,8 @@ channel_send_window_changes(void)
  */
 int
 x11_create_display_inet(int x11_display_offset, int x11_use_localhost,
-    int single_connection, u_int *display_numberp, int **chanids)
+	int max_displays, int single_connection, u_int *display_numberp, 
+	int **chanids)
 {
 	Channel *nc = NULL;
 	int display_number, sock;
@@ -3902,8 +3900,11 @@ x11_create_display_inet(int x11_display_offset, int x11_use_localhost,
 	if (chanids == NULL)
 		return -1;
 
+	/* Try max_displays ports starting at the range 6000+X11DisplayOffset */
+	max_displays = max_displays + x11_display_offset;
+
 	for (display_number = x11_display_offset;
-	    display_number < MAX_DISPLAYS;
+	    display_number < max_displays;
 	    display_number++) {
 		port = 6000 + display_number;
 		memset(&hints, 0, sizeof(hints));
@@ -3957,7 +3958,7 @@ x11_create_display_inet(int x11_display_offset, int x11_use_localhost,
 		if (num_socks > 0)
 			break;
 	}
-	if (display_number >= MAX_DISPLAYS) {
+	if (display_number >= max_displays) {
 		error("Failed to allocate internet-domain X11 display socket.");
 		return -1;
 	}

--- a/channels.h
+++ b/channels.h
@@ -286,7 +286,7 @@ int	 permitopen_port(const char *);
 
 void	 channel_set_x11_refuse_time(u_int);
 int	 x11_connect_display(void);
-int	 x11_create_display_inet(int, int, int, u_int *, int **);
+int	 x11_create_display_inet(int, int, int, int, u_int *, int **);
 int      x11_input_open(int, u_int32_t, void *);
 void	 x11_request_forwarding_with_spoofing(int, const char *, const char *,
 	     const char *, int);

--- a/servconf.h
+++ b/servconf.h
@@ -29,6 +29,7 @@
 #define MAX_MATCH_GROUPS	256	/* Max # of groups for Match. */
 #define MAX_AUTHKEYS_FILES	256	/* Max # of authorized_keys files. */
 #define MAX_AUTH_METHODS	256	/* Max # of AuthenticationMethods. */
+#define MAX_DISPLAYS  		1000 /* Maximum number of fake X11 displays to try. */
 
 /* permit_root_login */
 #define	PERMIT_NOT_SET		-1
@@ -154,6 +155,7 @@ typedef struct {
 	int	max_startups;
 	int	max_authtries;
 	int	max_sessions;
+	int max_displays;
 	char   *banner;			/* SSH-2 banner message */
 	int	use_dns;
 	int	client_alive_interval;	/*

--- a/session.c
+++ b/session.c
@@ -2701,8 +2701,9 @@ session_setup_x11fwd(Session *s)
 		return 0;
 	}
 	if (x11_create_display_inet(options.x11_display_offset,
-	    options.x11_use_localhost, s->single_connection,
-	    &s->display_number, &s->x11_chanids) == -1) {
+	    options.x11_use_localhost, options.max_displays,
+	    s->single_connection, &s->display_number, 
+	    &s->x11_chanids) == -1) {
 		debug("x11_create_display_inet failed.");
 		return 0;
 	}


### PR DESCRIPTION
- Fixed what appeared to be a bug or a quirk in how MAX_DISPLAYS is handled

When MAX_DISPLAYS is 1000 and X11DisplayOffset is 10, only 990 displays
were actually attempted because the X11DisplayOffset wasn't taken
into consideration. I didn't notice any clear documentation on how this
is supposed to work since it's an internal variable.

- Moved MAX_DISPLAYS to a default value and added MaxDisplays

Added a new MaxDisplays configuration option that override MAX_DISPLAYS

This is very useful in environments where OpenSSH is used as a
gateway for a large number of users, as in the environment where
I manage OpenSSH. The current hard limit of 1000 is not enough
in some cases, and is not configurable.