### PR TITLE
Added FWD_PERMIT_ANY_HOST to add the ability to use an asterisk to

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -138,6 +138,9 @@ static int num_adm_permitted_opens = 0;
 /* special-case port number meaning allow any port */
 #define FWD_PERMIT_ANY_PORT	0
 
+/* special-case port number meaning allow any host */
+#define FWD_PERMIT_ANY_HOST	"*"
+
 /*
  * If this is true, all opens are permitted.  This is the case on the server
  * on which we have to trust the client anyway, and the user could do
@@ -3296,10 +3299,13 @@ open_match(ForwardPermission *allowed_open, const char *requestedhost,
 	if (allowed_open->host_to_connect == NULL)
 		return 0;
 	if (allowed_open->port_to_connect != FWD_PERMIT_ANY_PORT &&
-	    allowed_open->port_to_connect != requestedport)
-		return 0;
-	if (strcmp(allowed_open->host_to_connect, requestedhost) != 0)
-		return 0;
+		allowed_open->port_to_connect != requestedport)
+			return 0;
+
+	if (strcmp(allowed_open->host_to_connect, FWD_PERMIT_ANY_HOST) != 0 &&
+		strcmp(allowed_open->host_to_connect, requestedhost) != 0)
+			return 0;
+
 	return 1;
 }
 


### PR DESCRIPTION
mean any hostname matches in a PermitOpen rule. This is simple and
looks like this:

PermitOpen *:443

One use case here is when OpenSSH is used to broker connectivity to
a specific TCP based service in a trusted network when the client
is in an untrusted network. This allows a simple configuration that
can allow all forwards to service X without the need to provide a
large list of every server on the trusted network in the sshd_config
file. Doing doing so is impractical when the trusted network is
larger than a few hosts as a large list of hosts in sshd_config
would be unwieldy and would need to be updated constantly if the
trusted network changes often.

This is a real use case for me- I need to provide this type of
access to several thousand systems. In any given week there
might be 2-3 new servers and there might be 2-3 servers that have
been decommissioned.

This patch is a huge improvement over allowing all ports to all
hosts, which is all that I can do at this point without having
a huge management headache. I was very surprised this wasn't
supported alongside FWD_PERMIT_ANY_PORT. It's a simple enough
change. I wonder if there was any debate on this or if it just
slipped through the cracks as an uncommon use case?

Note that this doesn't go down the more complex road of allowing
more finegrained cases. The '*' is NOT actually a pattern, it is
a symbol that means any host. Using *.bah.org will not work and
is not intended to work.