### PR TITLE
Set BROKEN_STRNVIS on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -646,6 +646,8 @@ main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
 	AC_CHECK_LIB([sandbox], [sandbox_apply], [
 	    SSHDLIBS="$SSHDLIBS -lsandbox"
 	])
+	AC_DEFINE([BROKEN_STRNVIS], [1],
+	    [macOS strnvis argument order is swapped compared to OpenBSD])
 	;;
 *-*-dragonfly*)
 	SSHDLIBS="$SSHDLIBS -lcrypt"


### PR DESCRIPTION
macOS 10.12 ships with its own copy of strnvis().