### PR TITLE
kex_send_ext_info: return error properly

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -354,7 +354,7 @@ kex_send_ext_info(struct ssh *ssh)
 	r = 0;
  out:
 	free(algs);
-	return 0;
+	return r;
 }
 
 int


### PR DESCRIPTION
Why it returns 0 on those errors?
Return r instead.
