### PR TITLE
Bug 2377 - ssh-keygen: Add ssh-agent support for key signing

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -121,7 +121,7 @@ ssh_get_authentication_socket(int *fdp)
 }
 
 /* Communicate with agent: send request and read reply */
-static int
+int
 ssh_request_reply(int sock, struct sshbuf *request, struct sshbuf *reply)
 {
 	int r;

--- a/authfd.h
+++ b/authfd.h
@@ -42,6 +42,7 @@ int	ssh_decrypt_challenge(int sock, struct sshkey* key, BIGNUM *challenge,
 int	ssh_agent_sign(int sock, struct sshkey *key,
 	    u_char **sigp, size_t *lenp,
 	    const u_char *data, size_t datalen, const char *alg, u_int compat);
+int	ssh_request_reply(int sock, struct sshbuf *request, struct sshbuf *reply);
 
 /* Messages for the authentication agent connection. */
 #define SSH_AGENTC_REQUEST_RSA_IDENTITIES	1

--- a/sshkey.h
+++ b/sshkey.h
@@ -137,6 +137,7 @@ int	 sshkey_type_is_cert(int);
 int	 sshkey_type_plain(int);
 int	 sshkey_to_certified(struct sshkey *);
 int	 sshkey_drop_cert(struct sshkey *);
+int	 sshkey_cert_prepare_sign(struct sshkey *, struct sshkey *);
 int	 sshkey_certify(struct sshkey *, struct sshkey *, const char *);
 int	 sshkey_cert_copy(const struct sshkey *, struct sshkey *);
 int	 sshkey_cert_check_authority(const struct sshkey *, int, int,


### PR DESCRIPTION
Communicate with the ssh-agent to sign certificates if agent is present
and is loaded with the specified certificate authority.
In order for the agent to sign, the certificate authority public key
must be alongside the private key with the same file name but a .pub
extension.

Closes: https://bugzilla.mindrot.org/show_bug.cgi?id=2377

Patch developed against 7.1p by Meghana Bhat.
Patch adapted to master branch at 010359b (post 7.3p1) by @volans-.