### PR TITLE
Constify maybe_add_key_to_agent@sshconnect.h + dependencies

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -496,7 +496,7 @@ ssh_agent_sign(int sock, struct sshkey *key,
 
 #ifdef WITH_SSH1
 static int
-ssh_encode_identity_rsa1(struct sshbuf *b, RSA *key, const char *comment)
+ssh_encode_identity_rsa1(struct sshbuf *b, const RSA *key, const char *comment)
 {
 	int r;
 
@@ -515,7 +515,7 @@ ssh_encode_identity_rsa1(struct sshbuf *b, RSA *key, const char *comment)
 #endif
 
 static int
-ssh_encode_identity_ssh2(struct sshbuf *b, struct sshkey *key,
+ssh_encode_identity_ssh2(struct sshbuf *b, const struct sshkey *key,
     const char *comment)
 {
 	int r;
@@ -550,8 +550,8 @@ encode_constraints(struct sshbuf *m, u_int life, u_int confirm)
  * This call is intended only for use by ssh-add(1) and like applications.
  */
 int
-ssh_add_identity_constrained(int sock, struct sshkey *key, const char *comment,
-    u_int life, u_int confirm)
+ssh_add_identity_constrained(int sock, const struct sshkey *key,
+    const char *comment, u_int life, u_int confirm)
 {
 	struct sshbuf *msg;
 	int r, constrained = (life || confirm);

--- a/authfd.h
+++ b/authfd.h
@@ -30,7 +30,7 @@ int	ssh_lock_agent(int sock, int lock, const char *password);
 int	ssh_fetch_identitylist(int sock, int version,
 	    struct ssh_identitylist **idlp);
 void	ssh_free_identitylist(struct ssh_identitylist *idl);
-int	ssh_add_identity_constrained(int sock, struct sshkey *key,
+int	ssh_add_identity_constrained(int sock, const struct sshkey *key,
 	    const char *comment, u_int life, u_int confirm);
 int	ssh_remove_identity(int sock, struct sshkey *key);
 int	ssh_update_card(int sock, int add, const char *reader_id,

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1516,8 +1516,8 @@ ssh_local_cmd(const char *args)
 }
 
 void
-maybe_add_key_to_agent(char *authfile, Key *private, char *comment,
-    char *passphrase)
+maybe_add_key_to_agent(const char *authfile, const Key *private,
+    const char *comment, const char *passphrase)
 {
 	int auth_sock = -1, r;
 

--- a/sshconnect.h
+++ b/sshconnect.h
@@ -55,7 +55,8 @@ void	 ssh_userauth2(const char *, const char *, char *, Sensitive *);
 void	 ssh_put_password(char *);
 int	 ssh_local_cmd(const char *);
 
-void	 maybe_add_key_to_agent(char *, Key *, char *, char *);
+void	 maybe_add_key_to_agent(const char *, const Key *, const char *,
+    const char *);
 
 /*
  * Macros to raise/lower permissions.


### PR DESCRIPTION
maybe_add_key_to_agent and its dependencies only read their variable arguments: they can be _constifyed_ to reflect it.