### PR TITLE
sshconnect2.c: only re-order keys when resetting keys (instead of destroying the list and failing to rebuild it)

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -496,7 +496,7 @@ ssh_agent_sign(int sock, struct sshkey *key,
 
 #ifdef WITH_SSH1
 static int
-ssh_encode_identity_rsa1(struct sshbuf *b, RSA *key, const char *comment)
+ssh_encode_identity_rsa1(struct sshbuf *b, const RSA *key, const char *comment)
 {
 	int r;
 
@@ -515,7 +515,7 @@ ssh_encode_identity_rsa1(struct sshbuf *b, RSA *key, const char *comment)
 #endif
 
 static int
-ssh_encode_identity_ssh2(struct sshbuf *b, struct sshkey *key,
+ssh_encode_identity_ssh2(struct sshbuf *b, const struct sshkey *key,
     const char *comment)
 {
 	int r;
@@ -550,8 +550,8 @@ encode_constraints(struct sshbuf *m, u_int life, u_int confirm)
  * This call is intended only for use by ssh-add(1) and like applications.
  */
 int
-ssh_add_identity_constrained(int sock, struct sshkey *key, const char *comment,
-    u_int life, u_int confirm)
+ssh_add_identity_constrained(int sock, const struct sshkey *key,
+    const char *comment, u_int life, u_int confirm)
 {
 	struct sshbuf *msg;
 	int r, constrained = (life || confirm);

--- a/authfd.c
+++ b/authfd.c
@@ -428,7 +428,7 @@ ssh_decrypt_challenge(int sock, struct sshkey* key, BIGNUM *challenge,
 
 /* encode signature algoritm in flag bits, so we can keep the msg format */
 static u_int
-agent_encode_alg(struct sshkey *key, const char *alg)
+agent_encode_alg(const struct sshkey *key, const char *alg)
 {
 	if (alg != NULL && key->type == KEY_RSA) {
 		if (strcmp(alg, "rsa-sha2-256") == 0)
@@ -441,7 +441,7 @@ agent_encode_alg(struct sshkey *key, const char *alg)
 
 /* ask agent to sign data, returns err.h code on error, 0 on success */
 int
-ssh_agent_sign(int sock, struct sshkey *key,
+ssh_agent_sign(int sock, const struct sshkey *key,
     u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, const char *alg, u_int compat)
 {

--- a/authfd.h
+++ b/authfd.h
@@ -30,7 +30,7 @@ int	ssh_lock_agent(int sock, int lock, const char *password);
 int	ssh_fetch_identitylist(int sock, int version,
 	    struct ssh_identitylist **idlp);
 void	ssh_free_identitylist(struct ssh_identitylist *idl);
-int	ssh_add_identity_constrained(int sock, struct sshkey *key,
+int	ssh_add_identity_constrained(int sock, const struct sshkey *key,
 	    const char *comment, u_int life, u_int confirm);
 int	ssh_remove_identity(int sock, struct sshkey *key);
 int	ssh_update_card(int sock, int add, const char *reader_id,

--- a/authfd.h
+++ b/authfd.h
@@ -39,7 +39,7 @@ int	ssh_remove_all_identities(int sock, int version);
 
 int	ssh_decrypt_challenge(int sock, struct sshkey* key, BIGNUM *challenge,
 	    u_char session_id[16], u_char response[16]);
-int	ssh_agent_sign(int sock, struct sshkey *key,
+int	ssh_agent_sign(int sock, const struct sshkey *key,
 	    u_char **sigp, size_t *lenp,
 	    const u_char *data, size_t datalen, const char *alg, u_int compat);
 

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1516,8 +1516,8 @@ ssh_local_cmd(const char *args)
 }
 
 void
-maybe_add_key_to_agent(char *authfile, Key *private, char *comment,
-    char *passphrase)
+maybe_add_key_to_agent(const char *authfile, const Key *private,
+    const char *comment, const char *passphrase)
 {
 	int auth_sock = -1, r;
 

--- a/sshconnect.h
+++ b/sshconnect.h
@@ -55,7 +55,8 @@ void	 ssh_userauth2(const char *, const char *, char *, Sensitive *);
 void	 ssh_put_password(char *);
 int	 ssh_local_cmd(const char *);
 
-void	 maybe_add_key_to_agent(char *, Key *, char *, char *);
+void	 maybe_add_key_to_agent(const char *, const Key *, const char *,
+    const char *);
 
 /*
  * Macros to raise/lower permissions.

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -315,10 +315,10 @@ int	input_gssapi_errtok(int, u_int32_t, void *);
 
 void	userauth(Authctxt *, char *);
 
-static int sign_and_send_pubkey(Authctxt *, Identity *);
+static int sign_and_send_pubkey(Authctxt *, const Identity *);
 static void pubkey_prepare(Authctxt *);
 static void pubkey_cleanup(Authctxt *);
-static Key *load_identity_file(Identity *);
+static Key *load_identity_file(const Identity *);
 
 static Authmethod *authmethod_get(char *authlist);
 static Authmethod *authmethod_lookup(const char *name);
@@ -996,7 +996,7 @@ input_userauth_passwd_changereq(int type, u_int32_t seqnr, void *ctxt)
 }
 
 static const char *
-identity_sign_encode(struct identity *id)
+identity_sign_encode(const struct identity *id)
 {
 	struct ssh *ssh = active_state;
 
@@ -1012,7 +1012,7 @@ identity_sign_encode(struct identity *id)
 }
 
 static int
-identity_sign(struct identity *id, u_char **sigp, size_t *lenp,
+identity_sign(const struct identity *id, u_char **sigp, size_t *lenp,
     const u_char *data, size_t datalen, u_int compat)
 {
 	Key *prv;
@@ -1042,7 +1042,7 @@ identity_sign(struct identity *id, u_char **sigp, size_t *lenp,
 }
 
 static int
-sign_and_send_pubkey(Authctxt *authctxt, Identity *id)
+sign_and_send_pubkey(Authctxt *authctxt, const Identity *id)
 {
 	Buffer b;
 	Identity *private_id;
@@ -1160,7 +1160,7 @@ sign_and_send_pubkey(Authctxt *authctxt, Identity *id)
 }
 
 static int
-send_pubkey_test(Authctxt *authctxt, Identity *id)
+send_pubkey_test(Authctxt *authctxt, const Identity *id)
 {
 	u_char *blob;
 	u_int bloblen, have_sig = 0;
@@ -1189,7 +1189,7 @@ send_pubkey_test(Authctxt *authctxt, Identity *id)
 }
 
 static Key *
-load_identity_file(Identity *id)
+load_identity_file(const Identity *id)
 {
 	Key *private = NULL;
 	char prompt[300], *passphrase, *comment;
@@ -1415,7 +1415,7 @@ pubkey_cleanup(Authctxt *authctxt)
 }
 
 static int
-try_identity(Identity *id)
+try_identity(const Identity *id)
 {
 	if (!id->key)
 		return (0);


### PR DESCRIPTION
sshconnect2.c whipes all keys and close the agent fd between each authentication before trying to rebuild the list (but failing because building the list modifies its sources) and reconnecting to the agent.
However, during an authentication:
- Almost all access to the keys/key list do not modify them
- The only modification to them is in userauth_pubkey, which:
   * Re-order the key, increasing the `tries` count (up to 2)
   * Set the `isprivate` flag
   * All other functions called do not modify the keys

This PR proposes a solution by:
- Modifying userauth_pubkey so that it cleans up `isprivate` when it cleans up the key
- Adding a `pubkey_reset` function that:
   * Reverts the re-ordering (this could  even be skipped as the order does not seem to carry much importance...)
   * Resets the `tries` to 0

This PR also include some function argument constification, to make it simpler to see that these function do not modify their arguments

Should fix https://bugzilla.mindrot.org/show_bug.cgi?id=2642