### PR TITLE
Add SyslogFacility setting to 'ssh' client program.

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -152,7 +152,7 @@ typedef enum {
 	oGlobalKnownHostsFile, oUserKnownHostsFile, oConnectionAttempts,
 	oBatchMode, oCheckHostIP, oStrictHostKeyChecking, oCompression,
 	oCompressionLevel, oTCPKeepAlive, oNumberOfPasswordPrompts,
-	oUsePrivilegedPort, oLogLevel, oCiphers, oProtocol, oMacs,
+	oUsePrivilegedPort, oLogLevel, oLogFacility, oCiphers, oProtocol, oMacs,
 	oPubkeyAuthentication,
 	oKbdInteractiveAuthentication, oKbdInteractiveDevices, oHostKeyAlias,
 	oDynamicForward, oPreferredAuthentications, oHostbasedAuthentication,
@@ -246,6 +246,7 @@ static struct {
 	{ "keepalive", oTCPKeepAlive },				/* obsolete */
 	{ "numberofpasswordprompts", oNumberOfPasswordPrompts },
 	{ "loglevel", oLogLevel },
+        { "syslogfacility", oLogFacility },
 	{ "dynamicforward", oDynamicForward },
 	{ "preferredauthentications", oPreferredAuthentications },
 	{ "hostkeyalgorithms", oHostKeyAlgorithms },
@@ -818,6 +819,7 @@ process_config_line_depth(Options *options, struct passwd *pw, const char *host,
 	u_int i, *uintptr, max_entries = 0;
 	int r, oactive, negated, opcode, *intptr, value, value2, cmdline = 0;
 	LogLevel *log_level_ptr;
+        SyslogFacility *log_facility_ptr;
 	long long val64;
 	size_t len;
 	struct Forward fwd;
@@ -1248,6 +1250,17 @@ parse_keytypes:
 			    filename, linenum, arg ? arg : "<NONE>");
 		if (*activep && *log_level_ptr == SYSLOG_LEVEL_NOT_SET)
 			*log_level_ptr = (LogLevel) value;
+		break;
+
+         case oLogFacility:
+		log_facility_ptr = &options->log_facility;
+		arg = strdelim(&s);
+		value = log_facility_number(arg);
+		if (value == SYSLOG_FACILITY_NOT_SET)
+			fatal("%.200s line %d: unsupported log facility '%s'",
+			    filename, linenum, arg ? arg : "<NONE>");
+		if (*log_facility_ptr == -1)
+			*log_facility_ptr = (SyslogFacility) value;
 		break;
 
 	case oLocalForward:
@@ -1817,6 +1830,7 @@ initialize_options(Options * options)
 	options->remote_forwards = NULL;
 	options->num_remote_forwards = 0;
 	options->log_level = SYSLOG_LEVEL_NOT_SET;
+	options->log_facility = SYSLOG_FACILITY_NOT_SET;
 	options->preferred_authentications = NULL;
 	options->bind_address = NULL;
 	options->pkcs11_provider = NULL;
@@ -1992,6 +2006,8 @@ fill_default_options(Options * options)
 	}
 	if (options->log_level == SYSLOG_LEVEL_NOT_SET)
 		options->log_level = SYSLOG_LEVEL_INFO;
+	if (options->log_facility == SYSLOG_FACILITY_NOT_SET)
+		options->log_facility = SYSLOG_FACILITY_USER;
 	if (options->no_host_authentication_for_localhost == - 1)
 		options->no_host_authentication_for_localhost = 0;
 	if (options->identities_only == -1)

--- a/readconf.h
+++ b/readconf.h
@@ -59,6 +59,7 @@ typedef struct {
 	int     tcp_keep_alive;	/* Set SO_KEEPALIVE. */
 	int	ip_qos_interactive;	/* IP ToS/DSCP/class for interactive */
 	int	ip_qos_bulk;		/* IP ToS/DSCP/class for bulk traffic */
+        SyslogFacility log_facility;    /* Facility for system logging. */
 	LogLevel log_level;	/* Level for logging. */
 
 	int     port;		/* Port to connect. */

--- a/ssh.c
+++ b/ssh.c
@@ -1008,7 +1008,8 @@ main(int ac, char **av)
 		log_redirect_stderr_to(logfile);
 	log_init(argv0,
 	    options.log_level == -1 ? SYSLOG_LEVEL_INFO : options.log_level,
-	    SYSLOG_FACILITY_USER, !use_syslog);
+	    options.log_facility == SYSLOG_FACILITY_NOT_SET ? SYSLOG_FACILITY_USER : options.log_facility,
+            !use_syslog);
 
 	if (debug_flag)
 		logit("%s, %s", SSH_RELEASE,
@@ -1150,7 +1151,7 @@ main(int ac, char **av)
 #endif
 
 	/* reinit */
-	log_init(argv0, options.log_level, SYSLOG_FACILITY_USER, !use_syslog);
+	log_init(argv0, options.log_level, options.log_facility, !use_syslog);
 
 	if (options.request_tty == REQUEST_TTY_YES ||
 	    options.request_tty == REQUEST_TTY_FORCE)

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1085,6 +1085,12 @@ indicates that the listening port be bound for local use only, while an
 empty address or
 .Sq *
 indicates that the port should be available from all interfaces.
+.It Cm SyslogFacility
+Gives the facility code that is used when logging messages from
+.Xr ssh 1 .
+The possible values are: DAEMON, USER, AUTH, LOCAL0, LOCAL1, LOCAL2,
+LOCAL3, LOCAL4, LOCAL5, LOCAL6, LOCAL7.
+The default is USER.
 .It Cm LogLevel
 Gives the verbosity level that is used when logging messages from
 .Xr ssh 1 .


### PR DESCRIPTION
Add SyslogFacility setting to 'ssh' client program. Also update ssh_config.5 man page to mention the new command.

I tested this on my local machine to make sure that it worked and everything seemed to work correctly.

I mentioned this + that I would post it on github on the openssh-unix-dev@mindrot.org mailing list and Darren Tucker said it seemed like a reasonable feature.