### PR TITLE
Surround host name with brackets to allow literal IPv6 addresses.

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -1103,7 +1103,7 @@ main(int ac, char **av)
 		options.proxy_use_fdpass = 0;
 		snprintf(port_s, sizeof(port_s), "%d", options.jump_port);
 		xasprintf(&options.proxy_command,
-		    "ssh%s%s%s%s%s%s%s%s%s%.*s -W %%h:%%p %s",
+		    "ssh%s%s%s%s%s%s%s%s%s%.*s -W [%%h]:%%p %s",
 		    /* Optional "-l user" argument if jump_user set */
 		    options.jump_user == NULL ? "" : " -l ",
 		    options.jump_user == NULL ? "" : options.jump_user,


### PR DESCRIPTION
The `ProxyJump` directive in `ssh_config` implicitly sets a `ProxyCommand`, which in turn sets the `-W` option to `%h:%p`: 

```debug1: Setting implicit ProxyCommand from ProxyJump: ssh -v -W %h:%p jumphost1```

When the hostname is a literal IPv6 address, for instance:

```
# ssh_config
Host imapsync
   Hostname 2001:610:148:f00d:20c:29ff:fe14:ccfe
```

Then this will fail because the colon and the subsequent port number are considered part of the hostname:

```Bad stdio forwarding specification '2001:610:148:f00d:20c:29ff:fe14:ccfe:22'```

By surrounding the host name in brackets things will work again.

