### PR TITLE
Set ldns=yes in configure if using ldns-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1486,6 +1486,7 @@ AC_ARG_WITH(ldns,
 		else
 			LIBS="$LIBS `$LDNSCONFIG --libs`"
 			CPPFLAGS="$CPPFLAGS `$LDNSCONFIG --cflags`"
+			ldns=yes
 		fi
 	elif test "x$withval" != "xno" ; then
 			CPPFLAGS="$CPPFLAGS -I${withval}/include"


### PR DESCRIPTION
If the configure script detects ldns-config it forgets to set ldns=yes.

I also attached this patch in a bugzilla issue at https://bugzilla.mindrot.org/show_bug.cgi?id=2697, but I'm unsure if you prefer github pull requests or not for these kind of patches.