### PR TITLE
[WIP] Support for "permitlisten=..." option for -R style forwarding

### DIFF
--- a/channels.h
+++ b/channels.h
@@ -267,15 +267,18 @@ struct ForwardOptions;
 void	 channel_set_af(int af);
 void     channel_permit_all_opens(void);
 void	 channel_add_permitted_opens(char *, int);
+void	 channel_add_permitted_listens(char *, int);
 int	 channel_add_adm_permitted_opens(char *, int);
 void	 channel_disable_adm_local_opens(void);
 void	 channel_update_permitted_opens(int, int);
 void	 channel_clear_permitted_opens(void);
 void	 channel_clear_adm_permitted_opens(void);
+void	 channel_clear_permitted_listens(void);
 void 	 channel_print_adm_permitted_opens(void);
 Channel	*channel_connect_to_port(const char *, u_short, char *, char *, int *,
 	     const char **);
 Channel *channel_connect_to_path(const char *, char *, char *);
+int channel_connect_check_permitted_listens(const char *host, u_short port);
 Channel	*channel_connect_stdio_fwd(const char*, u_short, int, int);
 Channel	*channel_connect_by_listen_address(const char *, u_short,
 	     char *, char *);

--- a/serverloop.c
+++ b/serverloop.c
@@ -729,11 +729,12 @@ server_input_global_request(int type, u_int32_t seq, void *ctxt)
 		    fwd.listen_host, fwd.listen_port);
 
 		/* check permissions */
-		if ((options.allow_tcp_forwarding & FORWARD_REMOTE) == 0 ||
+		if (channel_connect_check_permitted_listens(fwd.listen_host, fwd.listen_port) < 0 &&
+		    ((options.allow_tcp_forwarding & FORWARD_REMOTE) == 0 ||
 		    no_port_forwarding_flag || options.disable_forwarding ||
 		    (!want_reply && fwd.listen_port == 0) ||
 		    (fwd.listen_port != 0 &&
-		     !bind_permitted(fwd.listen_port, pw->pw_uid))) {
+		     !bind_permitted(fwd.listen_port, pw->pw_uid)))) {
 			success = 0;
 			packet_send_debug("Server has disabled port forwarding.");
 		} else {


### PR DESCRIPTION
**I am aware that this is not the right place for patches, but it's makes it easier to review while it's WIP.**

Adds support for `permitlisten=...` for -R style forwarding:

authorized_keys file:
```
restrict,command="echo 'Port forwarding only account.'",permitlisten="localhost:8080" ssh-rsa AAAAB3Nza...
```

This is allowed:
```
ssh -o ExitOnForwardFailure=yes -R 8080:localhost:80 root@localhost -p 2222 -N
```

This is not:

 ```
ssh -o ExitOnForwardFailure=yes -R 8081:localhost:80 root@localhost -p 2222 -N
Error: remote port forwarding failed for listen port 8081
```