### PR TITLE
Fix invalid condition for packet type

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -1612,7 +1612,7 @@ ssh_packet_read_poll2(struct ssh *ssh, u_char *typep, u_int32_t *seqnr_p)
 		goto out;
 	if (ssh_packet_log_type(*typep))
 		debug3("receive packet: type %u", *typep);
-	if (*typep < SSH2_MSG_MIN || *typep >= SSH2_MSG_LOCAL_MIN) {
+	if (*typep < SSH2_MSG_MIN || *typep >= SSH2_MSG_LOCAL_MAX) {
 		if ((r = sshpkt_disconnect(ssh,
 		    "Invalid ssh2 packet type: %d", *typep)) != 0 ||
 		    (r = ssh_packet_write_wait(ssh)) != 0)


### PR DESCRIPTION
The condition as written did not allow for packet types between SSH2_MSG_LOCAL_MIN and SSH2_MSG_LOCAL_MAX as intended