### PR TITLE
Allow to use AuthorizedKeysCommand on CYGWIN.

### DIFF
--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -372,6 +372,12 @@ assemble_argv(int argc, char **argv)
 	return ret;
 }
 
+#ifdef HAVE_CYGWIN
+#define ROOT_OR_SYSTEM_UID 18
+#else
+#define ROOT_OR_SYSTEM_UID 0
+#endif
+
 /*
  * Runs command in a subprocess. Returns pid on success and a FILE* to the
  * subprocess' stdout or 0 on failure.
@@ -406,7 +412,7 @@ subprocess(const char *tag, struct passwd *pw, const char *command,
 		restore_uid();
 		return 0;
 	}
-	if (auth_secure_path(av[0], &st, NULL, 0,
+	if (auth_secure_path(av[0], &st, NULL, ROOT_OR_SYSTEM_UID,
 	    errmsg, sizeof(errmsg)) != 0) {
 		error("Unsafe %s \"%s\": %s", tag, av[0], errmsg);
 		restore_uid();

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -227,8 +227,8 @@ Note that each authentication method listed should also be explicitly enabled
 in the configuration.
 .It Cm AuthorizedKeysCommand
 Specifies a program to be used to look up the user's public keys.
-The program must be owned by root, not writable by group or others and
-specified by an absolute path.
+The program must be owned by root (or SYSTEM on Windows), not writable by group
+or others and specified by an absolute path.
 Arguments to
 .Cm AuthorizedKeysCommand
 accept the tokens described in the


### PR DESCRIPTION
On CYGWIN, no user has uid = 0, but SYSTEM has uid = 18.
Since AuthorizedKeysCommand checks for uid=0 for permissions, it
is now possible to use the feature on Windows.

Section about SYSTEM UID (and binding to uid = 18):
https://cygwin.com/cygwin-ug-net/ntsec.html