### PR TITLE
permitopen but for -R

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -3444,6 +3444,27 @@ channel_request_rforward_cancel(struct Forward *fwd)
 }
 
 /*
+ * checks if host/port are allowed for remote forward
+ */
+int
+channel_permitted_remote_fwd(char *host, int port)
+{
+	int i;
+	if(all_opens_permitted){
+		debug("no rule found for permitopen, allowed by default");
+		return 1;
+	}
+	for (i = 0; i < num_permitted_opens; i++) {
+		if((permitted_opens[i].port_to_connect==port)
+			&&(strcmp(permitted_opens[i].host_to_connect,host)==0)
+			){
+			debug("allowed host: %s port %i",host,port);
+			return 1;
+		}
+	}
+return 0;
+}
+/*
  * Permits opening to any host/port if permitted_opens[] is empty.  This is
  * usually called by the server, because the user could connect to any port
  * anyway, and the server has no way to know but to trust the client anyway.

--- a/channels.h
+++ b/channels.h
@@ -265,6 +265,7 @@ struct Forward;
 struct ForwardOptions;
 void	 channel_set_af(int af);
 void     channel_permit_all_opens(void);
+int    channel_permitted_remote_fwd(char *host, int port);
 void	 channel_add_permitted_opens(char *, int);
 int	 channel_add_adm_permitted_opens(char *, int);
 void	 channel_disable_adm_local_opens(void);

--- a/serverloop.c
+++ b/serverloop.c
@@ -736,6 +736,9 @@ server_input_global_request(int type, u_int32_t seq, struct ssh *ssh)
 		     !bind_permitted(fwd.listen_port, pw->pw_uid))) {
 			success = 0;
 			packet_send_debug("Server has disabled port forwarding.");
+		} else if(!channel_permitted_remote_fwd(fwd.listen_host, fwd.listen_port)) {
+			success = 0;
+			packet_send_debug("Server has disabled remote forwarding for this port.");
 		} else {
 			/* Start listening on the port */
 			success = channel_setup_remote_fwd_listener(&fwd,


### PR DESCRIPTION
restricts which ports are available for a given user on a remote server when opening remote forwarding ports 
use case: NAT traversing limited to a specified port for each user
on the remote server, on the users  .ssh/authorized_keys , add: permitopen="host:port" and user's public key. it helps mitigate a DoS in case a user's private key is lost 
** if no permitopen is found for the user, all ports are allowed as usual
useful to limit tunneling for nat traversing to a specified port on a by user base