### PR TITLE
Don't require a working DISPLAY for confirmation

### DIFF
--- a/readpass.c
+++ b/readpass.c
@@ -177,7 +177,7 @@ ask_permission(const char *fmt, ...)
 	vsnprintf(prompt, sizeof(prompt), fmt, args);
 	va_end(args);
 
-	p = read_passphrase(prompt, RP_USE_ASKPASS|RP_ALLOW_EOF);
+	p = read_passphrase(prompt, RP_ALLOW_EOF);
 	if (p != NULL) {
 		/*
 		 * Accept empty responses and responses consisting


### PR DESCRIPTION
Anyone who uses 'ssh-add -c' (which appears to be few people) on a non-graphical system is greatly inconvenienced until they replace ssh-askpass with something that can use the terminal and sets DISPLAY before launching ssh-agent.

This appears to be a mistake from refactoring back in 2004. If certain cases need to force the use of SSH_ASKPASS instead of trying the tty the callers and this function will need to be changed to pass their own flags again.

I hit this again recently when using bash on Windows 10.