### PR TITLE
Fix incorrect recursion on Hostname via %h

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -562,7 +562,7 @@ match_cfg_line(Options *options, char **condition, struct passwd *pw,
 	} else if (options->hostname != NULL) {
 		/* NB. Please keep in sync with ssh.c:main() */
 		host = percent_expand(options->hostname,
-		    "h", host_arg, (char *)NULL);
+		    "n", host_arg, (char *)NULL);
 	} else {
 		host = xstrdup(host_arg);
 	}

--- a/ssh.c
+++ b/ssh.c
@@ -1007,7 +1007,7 @@ main(int ac, char **av)
 	if (options.hostname != NULL) {
 		/* NB. Please keep in sync with readconf.c:match_cfg_line() */
 		cp = percent_expand(options.hostname,
-		    "h", host, (char *)NULL);
+		    "n", host_arg, (char *)NULL);
 		free(host);
 		host = cp;
 		free(options.hostname);

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1699,7 +1699,7 @@ accepts the tokens %%, %d, %h, %l, %r, and %u.
 accepts the tokens %%, %C, %h, %i, %L, %l, %n, %p, %r, and %u.
 .Pp
 .Cm HostName
-accepts the tokens %% and %h.
+accepts the tokens %% and %n.
 .Pp
 .Cm IdentityAgent
 and


### PR DESCRIPTION
The %n token is defined as the original host value as specified on the command-line. It stands to reason that `hostname %h` is gratuitous and benign by virtue of being a NOOP, `hostname %h.domain` makes no sense. Only `hostname %n.domain` complies with the documentation. Perhaps when %n was added to the list of tokens, nobody went back to update the code. Also ssh.c and readconf.c were not kept in sync despite the comment in both locations.

Given the age of this defect, and the world-wide use of '%h' we may want to run both incarnations of percent_expand back to back so as to not break a billion configuration files.
