### PR TITLE
Fix: ssh-keygen SSHKEY_CERT_MAX_PRINCIPALS check on create

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -1718,6 +1718,11 @@ do_ca_sign(struct passwd *pw, int argc, char **argv)
 					fatal("Empty principal name");
 			}
 			free(otmp);
+			if (n > SSHKEY_CERT_MAX_PRINCIPALS) {
+				fatal("%s: invalid format: too many principals (%u)"
+				" for this certificate identity, specify at most %i.",
+				__func__,  n, SSHKEY_CERT_MAX_PRINCIPALS);
+			}
 		}
 	
 		tmp = tilde_expand_filename(argv[i], pw->pw_uid);


### PR DESCRIPTION
> This is a copy for convenience - fix is at: https://bugzilla.mindrot.org/show_bug.cgi?id=2779

ssh-keygen would allow creation of signed certificate for keys with more
principal values in the certificate identity than the sshkey_read()
would allow, causing the user to potentially create an unusable
certificate.

Before:
```
⚡ ssh-keygen -s ca_user_key  -I groups -n "$(seq -s ',' 1 257)" /dev/shm/ssh/key_file
Signed user key /dev/shm/ssh/key_file-cert.pub: id "groups" serial 0 for 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257 valid forever
⚡ ssh-keygen -L -f /dev/shm/ssh/key_file-cert.pub 
/dev/shm/ssh/key_file-cert.pub:1: invalid key: invalid format
```

After:
```
⚡ ./ssh-keygen -s ~/git/accessproxy/scripts/ca_user_key  -I groups -n "$(seq -s ',' 1 257)" /dev/shm/ssh/key_file
do_ca_sign: invalid format: too many principals (257) for this certificate identity, specify at most 256.
```