### PR TITLE
Fix scp in case of RemoteCommand in ssh_config

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -418,6 +418,8 @@ main(int argc, char **argv)
 	addargs(&args, "-oForwardAgent=no");
 	addargs(&args, "-oPermitLocalCommand=no");
 	addargs(&args, "-oClearAllForwardings=yes");
+	addargs(&args, "-oRemoteCommand=none");
+	addargs(&args, "-oRequestTTY=no");
 
 	fflag = tflag = 0;
 	while ((ch = getopt(argc, argv, "dfl:prtvBCc:i:P:q12346S:o:F:")) != -1)


### PR DESCRIPTION
This is based off of the `PermitLocalCommand=no` above the new lines, and seems to work for me.