### PR TITLE
Add dynamic lock decision hook to agent

### DIFF
--- a/ssh-agent.1
+++ b/ssh-agent.1
@@ -48,6 +48,7 @@
 .Op Fl E Ar fingerprint_hash
 .Op Fl P Ar pkcs11_whitelist
 .Op Fl t Ar life
+.Op Fl l Ar lock_script
 .Op Ar command Op Ar arg ...
 .Nm ssh-agent
 .Op Fl c | s
@@ -148,6 +149,9 @@ A lifetime specified for an identity with
 .Xr ssh-add 1
 overrides this value.
 Without this option the default maximum lifetime is forever.
+.It Fl l Ar lock_script
+Use a script to dynamically decide whether the agent is locked or not.
+Scripts return exit code 0 for unlocked, non-zero for locked.
 .El
 .Pp
 If a command line is given, this is executed as a subprocess of the agent.

--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -154,6 +154,7 @@ static char *pkcs11_whitelist;
 int locked = 0;
 u_char lock_pwhash[LOCK_SIZE];
 u_char lock_salt[LOCK_SALT_SIZE];
+char *lock_script = NULL;
 
 extern char *__progname;
 
@@ -652,6 +653,40 @@ send:
 }
 #endif /* ENABLE_PKCS11 */
 
+/* dynamic lock query - should return 0 for unlocked, 1 for locked */
+static int
+query_lock_script()
+{
+	FILE *plock;
+	int rc;
+
+	if (!lock_script)
+		return 0; /* not locked */
+	debug("calling lock script '%s'", lock_script);
+	plock = popen(lock_script, "r");
+	if (!plock) {
+		error("lock script execution failed: %s", strerror(errno));
+		return -1; /* locked */
+	}
+
+	/* output is ignored. we only want the exit code. */
+
+	rc = pclose(plock); /* waits for process to finish */
+	if (rc == -1) {
+		error("lock script reaping failed: %s", strerror(errno));
+		return -1; /* locked */
+	}
+	if (!WIFEXITED(rc)) {
+		error("lock script exited abnormally");
+		return -1; /* locked */
+	}
+	debug("lock script '%s' returned exit code %d",
+	    lock_script, WEXITSTATUS(rc));
+	if (WEXITSTATUS(rc) != 0)
+		return -1; /* locked */
+	return 0; /* not locked */
+}
+
 /* dispatch incoming messages */
 
 static int
@@ -695,8 +730,8 @@ process_message(u_int socknum)
 
 	debug("%s: socket %u (fd=%d) type %d", __func__, socknum, e->fd, type);
 
-	/* check wheter agent is locked */
-	if (locked && type != SSH_AGENTC_UNLOCK) {
+	/* check whether agent is locked */
+	if ((locked && type != SSH_AGENTC_UNLOCK) || query_lock_script()) {
 		sshbuf_reset(e->request);
 		switch (type) {
 		case SSH2_AGENTC_REQUEST_IDENTITIES:
@@ -1022,7 +1057,8 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: ssh-agent [-c | -s] [-Dd] [-a bind_address] [-E fingerprint_hash]\n"
-	    "                 [-P pkcs11_whitelist] [-t life] [command [arg ...]]\n"
+	    "                 [-P pkcs11_whitelist] [-t life] [-l lock_script]\n"
+	    "                 [command [arg ...]]\n"
 	    "       ssh-agent [-c | -s] -k\n");
 	exit(1);
 }
@@ -1063,7 +1099,7 @@ main(int ac, char **av)
 	__progname = ssh_get_progname(av[0]);
 	seed_rng();
 
-	while ((ch = getopt(ac, av, "cDdksE:a:P:t:")) != -1) {
+	while ((ch = getopt(ac, av, "cDdksE:a:P:t:l:")) != -1) {
 		switch (ch) {
 		case 'E':
 			fingerprint_hash = ssh_digest_alg_by_name(optarg);
@@ -1106,6 +1142,9 @@ main(int ac, char **av)
 				fprintf(stderr, "Invalid lifetime\n");
 				usage();
 			}
+			break;
+		case 'l':
+			lock_script = optarg;
 			break;
 		default:
 			usage();


### PR DESCRIPTION
Using a new option (-l) the ssh-agent can be told to call an
external program as a source for locked vs. unlocked state
information. Useful to lock the agent when the screensafer
is active or the tmux session is detached.