### PR TITLE
ssh-keygen PKCS11: Find CKA_PRIVATE keys by logging in

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -774,7 +774,7 @@ do_download(struct passwd *pw)
 	fptype = print_bubblebabble ? SSH_DIGEST_SHA1 : fingerprint_hash;
 	rep =    print_bubblebabble ? SSH_FP_BUBBLEBABBLE : SSH_FP_DEFAULT;
 
-	pkcs11_init(0);
+	pkcs11_init(1);
 	nkeys = pkcs11_add_provider(pkcs11provider, NULL, &keys);
 	if (nkeys <= 0)
 		fatal("cannot read public key from pkcs11");


### PR DESCRIPTION
pkcs11-tool --module /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so --login --list-objects
Using slot 0 with a present token (0x0)
Logging in to "YubiHSM".
Please enter User PIN:
Private Key Object; RSA
  label:      sshrsakey
  ID:         1bba
  Usage:      sign
Public Key Object; RSA 2048 bits
  label:      sshrsakey
  ID:         1bba
  Usage:      verify
Certificate Object; type = X.509 cert
  label:      sshrsakey
  ID:         1bba

./ssh-keygen -D /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so
Enter PIN for 'YubiHSM':
C_GetAttributeValue failed: 18
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrkLmhqJ0DtSGU+zBBlM0JdkziETKvfwfkU4e9i+WftuuZpNld5N6RzlN7xGflVxYv/J4CigwWKTdGuoTPWgbCrANmYGCvEft+B5oBm6hL09zcHxNOWpjfUTJdWISLZx3pgbbT1Zxt0nNYOgn8GrKjG3+im3RINnzlJp0SjptoDOfV90CZNCSQsmXFnWFoPmtQvL+LLJgJUbJbyMUmtJGPijADeSNH07x2ge+zxjzyshC6x3nBZ63BIBUl4y7KlvwU+hs/J2oLT6ZyRUFu6TprSwML6Dxe0DAFr/0hp1LNuKomCYxmdcuV/BHGjScs5BjLmK3z7ABVzpLZBB/gtnGD

cat ~/.ssh/authorized_keys
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrkLmhqJ0DtSGU+zBBlM0JdkziETKvfwfkU4e9i+WftuuZpNld5N6RzlN7xGflVxYv/J4CigwWKTdGuoTPWgbCrANmYGCvEft+B5oBm6hL09zcHxNOWpjfUTJdWISLZx3pgbbT1Zxt0nNYOgn8GrKjG3+im3RINnzlJp0SjptoDOfV90CZNCSQsmXFnWFoPmtQvL+LLJgJUbJbyMUmtJGPijADeSNH07x2ge+zxjzyshC6x3nBZ63BIBUl4y7KlvwU+hs/J2oLT6ZyRUFu6TprSwML6Dxe0DAFr/0hp1LNuKomCYxmdcuV/BHGjScs5BjLmK3z7ABVzpLZBB/gtnGD

./ssh -I /usr/lib/x86_64-linux-gnu/pkcs11/yubihsm_pkcs11.so XXXX@127.0.0.1
Enter PIN for 'YubiHSM':
C_GetAttributeValue failed: 18
*** log in successfull ***

Note:
* yubihsm debug seems to indicate the certificate was imported without CKA_SUBJECT, causing the C_GetAttributeValue failure.
* ssh-pkcs11.c spews C_GetAttributeValue warnings if any ECDSA key is in the HSM.