### PR TITLE
ssh: allow multiple `-l` options and `user@host` to override one another (fixes regression)

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -907,8 +907,8 @@ main(int ac, char **av)
 			}
 			break;
 		case 'l':
-			if (options.user == NULL)
-				options.user = optarg;
+			free(options.user);
+			options.user = xstrdup(optarg);
 			break;
 
 		case 'L':
@@ -998,13 +998,9 @@ main(int ac, char **av)
 			usage();
 			break;
 		case 0:
-			if (options.user == NULL) {
-				options.user = tuser;
-				tuser = NULL;
-			}
-			free(tuser);
-			if (options.port == -1 && tport != -1)
-				options.port = tport;
+			free(options.user);
+			options.user = tuser;
+			options.port = tport;
 			break;
 		default:
 			p = xstrdup(*av);
@@ -1012,13 +1008,10 @@ main(int ac, char **av)
 			if (cp != NULL) {
 				if (cp == p)
 					usage();
-				if (options.user == NULL) {
-					options.user = p;
-					p = NULL;
-				}
+				free(options.user);
+				options.user = p;
 				*cp++ = '\0';
 				host = xstrdup(cp);
-				free(p);
 			} else
 				host = p;
 			break;
@@ -1260,8 +1253,10 @@ main(int ac, char **av)
 
 	seed_rng();
 
-	if (options.user == NULL)
+	if (!options.user) {
+		free(options.user);
 		options.user = xstrdup(pw->pw_name);
+	}
 
 	/* Set up strings used to percent_expand() arguments */
 	if (gethostname(thishost, sizeof(thishost)) == -1)


### PR DESCRIPTION
887669e (upstream commit, 2017-10-21) introduced a regression: while
OpenSSH v7.6p1's SSH client would happily let the last command-line
argument specifying a user name override previous ones, this is no longer
true in OpenSSH v7.7p1:

	ssh -l narf -l egads pinkie@brain

would try to connect as `pinkie` in v7.6p1, but as `narf` in v7.7p1.

Since this change was not covered in the release notes of v7.7p1, it can
be considered an unwanted regression, and this patch fixes that
regression.

This fixes https://github.com/git-for-windows/git/issues/1616.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>