### PR TITLE
update default Ciphers config

### DIFF
--- a/ssh_config
+++ b/ssh_config
@@ -35,7 +35,7 @@
 #   IdentityFile ~/.ssh/id_ed25519
 #   Port 22
 #   Protocol 2
-#   Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc
+#   Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
 #   MACs hmac-md5,hmac-sha1,umac-64@openssh.com
 #   EscapeChar ~
 #   Tunnel no


### PR DESCRIPTION
Git-for-Windows re-enables CBC ciphers by uncommenting the Ciphers
option in ssh_config and appending ",aes256-cbc,aes192-cbc" [*1*]. This
inadvertently disables GCM ciphers and Chacha20 [*2*].

Instead of relying on the contents of the default ssh_config, a better
solution would be an option to retrieve a list of default ciphers from
ssh. Currently, it is only possible to print a list of available ciphers
using `ssh -Q cipher`, but this includes ciphers which are not offered
by default.

[*1*] https://github.com/git-for-windows/build-extra/commit/b46fba6f44b3680210b19ef5fc9ce22ca1dcda55
[*2*] https://github.com/git-for-windows/git/issues/1723