### PR TITLE
Don't free DH priv_key when DH_generate_key() fails

### DIFF
--- a/dh.c
+++ b/dh.c
@@ -278,7 +278,6 @@ dh_gen_key(DH *dh, int need)
 	dh->length = MINIMUM(need * 2, pbits - 1);
 	if (DH_generate_key(dh) == 0 ||
 	    !dh_pub_is_valid(dh, dh->pub_key)) {
-		BN_clear_free(dh->priv_key);
 		return SSH_ERR_LIBCRYPTO_ERROR;
 	}
 	return 0;


### PR DESCRIPTION
The call to BN_clear_free() on dh->priv_key leaves a dangling pointer
that will be freed again when the caller of dh_gen_key() calls
DH_free().

Fortunately, AFAIK failrues in DH_generate_key() are very unlikely,
so this should not be observed in practice.