### PR TITLE
Implementing RFC 4254 section 6.9 : Signals

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -84,7 +84,8 @@ LTESTS= 	connect \
 		cert-file \
 		cfginclude \
 		allow-deny-users \
-		authinfo
+		authinfo \
+		signal
 
 
 #		dhgex \

--- a/regress/signal.sh
+++ b/regress/signal.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+tid="escape char ~ST"
+
+start_sshd
+
+{ sleep 5; printf ~ST;} | ${SSH} -F $OBJ/ssh_config -tt somehost "alarm(){ echo \"ALARM\"; exit 124; };
+
+expected(){ echo \"TERM\"; exit 0; };
+
+trap alarm ALRM;
+trap expected TERM;
+(sleep 10 && kill -ALRM \$\$) &
+wait \$!;
+"
+
+ret=$?
+
+if [ $ret -ne 0 ]
+then
+  fail "Fail escape char with exitcode : $ret"
+fi


### PR DESCRIPTION
Hello every one,

Following the discussion “trying to resurrect discussion about "Cannot signal a process over a channel (rfc 4254, section 6.9)"” on the mailing list (link: https://marc.info/?t=153077282000003&r=1&w=2), I would like to put an eventual patch here so it is not forgotten.

The code is a gathering of other codes that were proposed on Bugzilla with some modifications.

This patch allows the ssh client to send “signal” messages (Section 6.9 of RFC 4254) via the mechanism of escape characters, eg : ‘~ST’ to send a SIGTERM to the remote process.

Upon reception of such message, the server will send the chosen signal to the process group of the last forked process or the process on the foreground depending if it is in exec or shell mode.


There is also a rudimentary test for these functionalities in the test suite.


Best regards