### PR TITLE
getgrouplist can return with ngroups > _SC_NGROUPS_MAX

### DIFF
--- a/groupaccess.c
+++ b/groupaccess.c
@@ -40,6 +40,7 @@
 #include "log.h"
 
 static int ngroups;
+static int ngroups;
 static char **groups_byname;
 
 /*
@@ -52,13 +53,14 @@ ga_init(const char *user, gid_t base)
 	gid_t *groups_bygid;
 	int i, j;
 	struct group *gr;
+	int allocated_ngroups;
 
 	if (ngroups > 0)
 		ga_free();
 
 	ngroups = NGROUPS_MAX;
 #if defined(HAVE_SYSCONF) && defined(_SC_NGROUPS_MAX)
-	ngroups = MAX(NGROUPS_MAX, sysconf(_SC_NGROUPS_MAX));
+	allocated_ngroups = ngroups = MAX(NGROUPS_MAX, sysconf(_SC_NGROUPS_MAX));
 #endif
 
 	groups_bygid = xcalloc(ngroups, sizeof(*groups_bygid));
@@ -66,6 +68,8 @@ ga_init(const char *user, gid_t base)
 
 	if (getgrouplist(user, base, groups_bygid, &ngroups) == -1)
 		logit("getgrouplist: groups list too small");
+	if (ngroups > allocated_ngroups)
+		ngroups = allocated_ngroups;
 	for (i = 0, j = 0; i < ngroups; i++)
 		if ((gr = getgrgid(groups_bygid[i])) != NULL)
 			groups_byname[j++] = xstrdup(gr->gr_name);

--- a/groupaccess.c
+++ b/groupaccess.c
@@ -40,7 +40,6 @@
 #include "log.h"
 
 static int ngroups;
-static int ngroups;
 static char **groups_byname;
 
 /*


### PR DESCRIPTION
On Solaris, and maybe on other platforms too, getgrouplist() can return with ngroups set to a value greater than the value that sysconf returned for _SC_NGROUPS_MAX.  This can happen when the name service has more entries available.

For example Solaris 11.4 _SC_NGROUPS_MAX is 1024 but if I put 1028 entries for a user into the nameservice (files is fine LDAP isn't needed for this) then after the call to getgrouplist() ngroups will
be 1028.

The current code expects that can can log "getgrouplist: groups list too small" in this case.  However
ngroups is now set to a value larger than was allocated with xcalloc, this can result in ga_free() attempting to free more entries than we actually allocated.

A possible fix is to reset the global ngroups to be the value allocated so that ga_free() will
have the correct size array.
