### PR TITLE
get / put struct passwd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3498,10 +3498,10 @@ fi
 AC_CHECK_TYPES([long long, unsigned long long, long double])
 
 # Check datatype sizes
-AC_CHECK_SIZEOF([short int], [2])
-AC_CHECK_SIZEOF([int], [4])
-AC_CHECK_SIZEOF([long int], [4])
-AC_CHECK_SIZEOF([long long int], [8])
+AC_CHECK_SIZEOF([short int])
+AC_CHECK_SIZEOF([int])
+AC_CHECK_SIZEOF([long int])
+AC_CHECK_SIZEOF([long long int])
 
 # Sanity check long long for some platforms (AIX)
 if test "x$ac_cv_sizeof_long_long_int" = "x4" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -3502,6 +3502,8 @@ AC_CHECK_SIZEOF([short int])
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long int])
 AC_CHECK_SIZEOF([long long int])
+AC_CHECK_SIZEOF([size_t])
+AC_CHECK_SIZEOF([time_t])
 
 # Sanity check long long for some platforms (AIX)
 if test "x$ac_cv_sizeof_long_long_int" = "x4" ; then

--- a/monitor.c
+++ b/monitor.c
@@ -745,19 +745,8 @@ mm_answer_pwnamallow(int sock, struct sshbuf *m)
 	authctxt->pw = pwent;
 	authctxt->valid = 1;
 
-	/* XXX don't sent pwent to unpriv; send fake class/dir/shell too */
 	if ((r = sshbuf_put_u8(m, 1)) != 0 ||
-	    (r = sshbuf_put_string(m, pwent, sizeof(*pwent))) != 0 ||
-	    (r = sshbuf_put_cstring(m, pwent->pw_name)) != 0 ||
-	    (r = sshbuf_put_cstring(m, "*")) != 0 ||
-#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
-	    (r = sshbuf_put_cstring(m, pwent->pw_gecos)) != 0 ||
-#endif
-#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
-	    (r = sshbuf_put_cstring(m, pwent->pw_class)) != 0 ||
-#endif
-	    (r = sshbuf_put_cstring(m, pwent->pw_dir)) != 0 ||
-	    (r = sshbuf_put_cstring(m, pwent->pw_shell)) != 0)
+	    (r = sshbuf_put_passwd(m, pwent)) != 0)
 		fatal("%s: buffer error: %s", __func__, ssh_err(r));
 
  out:

--- a/monitor_wrap.c
+++ b/monitor_wrap.c
@@ -279,25 +279,9 @@ mm_getpwnamallow(const char *username)
 		goto out;
 	}
 
-	/* XXX don't like passing struct passwd like this */
-	pw = xcalloc(sizeof(*pw), 1);
-	if ((r = sshbuf_get_string_direct(m, &p, &len)) != 0)
-		fatal("%s: buffer error: %s", __func__, ssh_err(r));
-	if (len != sizeof(*pw))
-		fatal("%s: struct passwd size mismatch", __func__);
-	memcpy(pw, p, sizeof(*pw));
-
-	if ((r = sshbuf_get_cstring(m, &pw->pw_name, NULL)) != 0 ||
-	    (r = sshbuf_get_cstring(m, &pw->pw_passwd, NULL)) != 0 ||
-#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
-	    (r = sshbuf_get_cstring(m, &pw->pw_gecos, NULL)) != 0 ||
-#endif
-#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
-	    (r = sshbuf_get_cstring(m, &pw->pw_class, NULL)) != 0 ||
-#endif
-	    (r = sshbuf_get_cstring(m, &pw->pw_dir, NULL)) != 0 ||
-	    (r = sshbuf_get_cstring(m, &pw->pw_shell, NULL)) != 0)
-		fatal("%s: buffer error: %s", __func__, ssh_err(r));
+	pw = sshbuf_get_passwd(m);
+	if (pw == NULL)
+		fatal("%s: receive get struct passwd failed", __func__);
 
 out:
 	/* copy options block as a Match directive may have changed some */

--- a/sshbuf-getput-basic.c
+++ b/sshbuf-getput-basic.c
@@ -27,6 +27,7 @@
 
 #include "ssherr.h"
 #include "sshbuf.h"
+#include "xmalloc.h"
 
 int
 sshbuf_get(struct sshbuf *buf, void *v, size_t len)
@@ -461,4 +462,104 @@ sshbuf_get_bignum2_bytes_direct(struct sshbuf *buf,
 		return SSH_ERR_INTERNAL_ERROR;
 	}
 	return 0;
+}
+
+/*
+ * store struct pwd
+ */
+int
+sshbuf_put_passwd(struct sshbuf *buf, const struct passwd *pwent)
+{
+	int r;
+
+	/*
+	 * We never send pointer values of struct passwd.
+	 * It is safe from wild pointer even if a new pointer member is added.
+	 */
+
+	if ((r = sshbuf_put_size(buf, sizeof(*pwent)) != 0) ||
+	    (r = sshbuf_put_cstring(buf, pwent->pw_name)) != 0 ||
+	    (r = sshbuf_put_cstring(buf, "*")) != 0 ||
+	    (r = sshbuf_put_u32(buf, pwent->pw_uid)) != 0 ||
+	    (r = sshbuf_put_u32(buf, pwent->pw_gid)) != 0 ||
+#ifdef HAVE_STRUCT_PASSWD_PW_CHANGE
+	    (r = sshbuf_put_time(buf, pwent->pw_change)) != 0 ||
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
+	    (r = sshbuf_put_cstring(buf, pwent->pw_gecos)) != 0 ||
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
+	    (r = sshbuf_put_cstring(buf, pwent->pw_class)) != 0 ||
+#endif
+	    (r = sshbuf_put_cstring(buf, pwent->pw_dir)) != 0 ||
+	    (r = sshbuf_put_cstring(buf, pwent->pw_shell)) != 0 ||
+#ifdef HAVE_STRUCT_PASSWD_PW_EXPIRE
+	    (r = sshbuf_put_time(buf, pwent->pw_expire)) != 0 ||
+#endif
+	    (r = sshbuf_put_u32(buf, pwent->pw_fields)) != 0) {
+		return r;
+	}
+	return 0;
+}
+
+/*
+ * extract struct pwd
+ */
+struct passwd *
+sshbuf_get_passwd(struct sshbuf *buf)
+{
+	struct passwd *pw;
+	size_t len;
+	int r;
+
+	/* check if size of struct passwd is as same as sender's size */
+	r = sshbuf_get_size(buf, &len);
+	if (r != 0 || len != sizeof(*pw))
+		return NULL;
+
+	pw = xcalloc(1, sizeof(*pw));
+	if (sshbuf_get_cstring(buf, &pw->pw_name, NULL) != 0 ||
+	    sshbuf_get_cstring(buf, &pw->pw_passwd, NULL) != 0 ||
+	    sshbuf_get_u32(buf, &pw->pw_uid) != 0 ||
+	    sshbuf_get_u32(buf, &pw->pw_gid) != 0 ||
+#ifdef HAVE_STRUCT_PASSWD_PW_CHANGE
+	    sshbuf_get_time(buf, &pw->pw_change) != 0 ||
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
+	    sshbuf_get_cstring(buf, &pw->pw_gecos, NULL) != 0 ||
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
+	    sshbuf_get_cstring(buf, &pw->pw_class, NULL) != 0 ||
+#endif
+	    sshbuf_get_cstring(buf, &pw->pw_dir, NULL) != 0 ||
+	    sshbuf_get_cstring(buf, &pw->pw_shell, NULL) != 0 ||
+#ifdef HAVE_STRUCT_PASSWD_PW_EXPIRE
+	    sshbuf_get_time(buf, &pw->pw_expire) != 0 ||
+#endif
+	    sshbuf_get_u32(buf, &pw->pw_fields) != 0) {
+		sshbuf_free_passwd(pw);
+		return NULL;
+	}
+	return pw;
+}
+
+/*
+ * free struct passwd obtained from sshbuf_get_passwd.
+ */
+void
+sshbuf_free_passwd(struct passwd *pwent)
+{
+	if (pwent == NULL)
+		return;
+	free(pwent->pw_shell);
+	free(pwent->pw_dir);
+#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
+	free(pwent->pw_class);
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
+	free(pwent->pw_gecos);
+#endif
+	free(pwent->pw_passwd);
+	free(pwent->pw_name);
+	free(pwent);
 }

--- a/sshbuf.h
+++ b/sshbuf.h
@@ -176,6 +176,22 @@ int	sshbuf_put_u32(struct sshbuf *buf, u_int32_t val);
 int	sshbuf_put_u16(struct sshbuf *buf, u_int16_t val);
 int	sshbuf_put_u8(struct sshbuf *buf, u_char val);
 
+#if SIZEOF_SIZE_T == 4
+#define sshbuf_get_size(b, vp) sshbuf_get_u32((b), (u_int32_t *)(vp))
+#define sshbuf_put_size(b, v) sshbuf_put_u32((b), (u_int32_t)(v))
+#else
+#define sshbuf_get_size(b, vp) sshbuf_get_u64((b), (u_int64_t *)(vp))
+#define sshbuf_put_size(b, v) sshbuf_put_u64((b), (u_int64_t)(v))
+#endif
+
+#if SIZEOF_TIME_T == 4
+#define sshbuf_get_time(b, vp) sshbuf_get_u32((b), (u_int32_t *)(vp))
+#define sshbuf_put_time(b, v) sshbuf_put_u32((b), (u_int32_t)(v))
+#else
+#define sshbuf_get_time(b, vp) sshbuf_get_u64((b), (u_int64_t *)(vp))
+#define sshbuf_put_time(b, v) sshbuf_put_u64((b), (u_int64_t)(v))
+#endif
+
 /*
  * Functions to extract or store SSH wire encoded strings (u32 len || data)
  * The "cstring" variants admit no \0 characters in the string contents.
@@ -245,6 +261,21 @@ int	sshbuf_b64tod(struct sshbuf *buf, const char *b64);
  * nul character.
  */
 char *sshbuf_dup_string(struct sshbuf *buf);
+
+/*
+ * store struct pwd
+ */
+int sshbuf_put_passwd(struct sshbuf *buf, const struct passwd *pwent);
+
+/*
+ * extract struct pwd
+ */
+struct passwd *sshbuf_get_passwd(struct sshbuf *buf);
+
+/*
+ * free struct passwd obtained from sshbuf_get_passwd.
+ */
+void sshbuf_free_passwd(struct passwd *pwent);
 
 /* Macros for decoding/encoding integers */
 #define PEEK_U64(p) \


### PR DESCRIPTION
Add `sshbuf_{get,put}_passwd()` for `struct passwd`.  Since both `size_t` and `time_t` can vary in size from one system to another, add wrappers for both which use either `u32` or `u64` depending on what autoconf says.
