### PR TITLE
Ignore missing keys unless explicitly configured.

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -233,12 +233,16 @@ array_append(const char *file, const int line, const char *directive,
 	(*lp)++;
 }
 
+static const char *defaultkey = "[default]";
+
 void
 servconf_add_hostkey(const char *file, const int line,
     ServerOptions *options, const char *path)
 {
 	char *apath = derelativise_path(path);
 
+	if (file == defaultkey && access(path, R_OK) != 0)
+		return;
 	array_append(file, line, "HostKey",
 	    &options->host_key_files, &options->num_host_key_files, apath);
 	free(apath);
@@ -267,19 +271,23 @@ fill_default_server_options(ServerOptions *options)
 	/* Standard Options */
 	if (options->num_host_key_files == 0) {
 		/* fill default hostkeys for protocols */
-		servconf_add_hostkey("[default]", 0, options,
+		servconf_add_hostkey(defaultkey, 0, options,
 		    _PATH_HOST_RSA_KEY_FILE);
+		servconf_add_hostkey(defaultkey, 0, options,
+		    _PATH_HOST_DSA_KEY_FILE);
 #ifdef OPENSSL_HAS_ECC
-		servconf_add_hostkey("[default]", 0, options,
+		servconf_add_hostkey(defaultkey, 0, options,
 		    _PATH_HOST_ECDSA_KEY_FILE);
 #endif
-		servconf_add_hostkey("[default]", 0, options,
+		servconf_add_hostkey(defaultkey, 0, options,
 		    _PATH_HOST_ED25519_KEY_FILE);
 #ifdef WITH_XMSS
-		servconf_add_hostkey("[default]", 0, options,
+		servconf_add_hostkey(defaultkey, 0, options,
 		    _PATH_HOST_XMSS_KEY_FILE);
 #endif /* WITH_XMSS */
 	}
+	if (options->num_host_key_files == 0)
+		fatal("No host key files found");
 	/* No certificates by default */
 	if (options->num_ports == 0)
 		options->ports[options->num_ports++] = SSH_DEFAULT_PORT;
@@ -384,11 +392,11 @@ fill_default_server_options(ServerOptions *options)
 	if (options->client_alive_count_max == -1)
 		options->client_alive_count_max = 3;
 	if (options->num_authkeys_files == 0) {
-		array_append("[default]", 0, "AuthorizedKeysFiles",
+		array_append(defaultkey, 0, "AuthorizedKeysFiles",
 		    &options->authorized_keys_files,
 		    &options->num_authkeys_files,
 		    _PATH_SSH_USER_PERMITTED_KEYS);
-		array_append("[default]", 0, "AuthorizedKeysFiles",
+		array_append(defaultkey, 0, "AuthorizedKeysFiles",
 		    &options->authorized_keys_files,
 		    &options->num_authkeys_files,
 		    _PATH_SSH_USER_PERMITTED_KEYS2);


### PR DESCRIPTION
When adding a host key file to the list, if `file` refers to our `"[default]"` constant and `path` does not exist, ignore it. This silences warnings on systems where certain keys are intentionally not present without requiring the administrator to explicitly list those that are. We will still get an error if no keys were found at all.