### PR TITLE
Changes to support Windows

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -437,7 +437,7 @@ expand_authorized_keys(const char *filename, struct passwd *pw)
 	 * Ensure that filename starts anchored. If not, be backward
 	 * compatible and prepend the '%h/'
 	 */
-	if (*file == '/')
+	if (path_absolute(file))
 		return (file);
 
 	i = snprintf(ret, sizeof(ret), "%s/%s", pw->pw_dir, file);
@@ -567,10 +567,10 @@ getpwnamallow(const char *user)
 	auth_session_t *as;
 #endif
 #endif
-	struct passwd *pw;
+	struct passwd *pw = getpwnam(user);
 	struct connection_info *ci = get_connection_info(1, options.use_dns);
 
-	ci->user = user;
+	ci->user = pw ? pw->pw_name : user;
 	parse_server_match_config(&options, ci);
 	log_change_level(options.log_level);
 	process_permitopen(ssh, &options);
@@ -578,8 +578,6 @@ getpwnamallow(const char *user)
 #if defined(_AIX) && defined(HAVE_SETAUTHDB)
 	aix_setauthdb(user);
 #endif
-
-	pw = getpwnam(user);
 
 #if defined(_AIX) && defined(HAVE_SETAUTHDB)
 	aix_restoreauthdb();

--- a/misc.c
+++ b/misc.c
@@ -791,8 +791,11 @@ parse_uri(const char *scheme, const char *uri, char **userp, char **hostp,
 
 	uridup = tmp = xstrdup(uri);
 
-	/* Extract optional ssh-info (username + connection params) */
-	if ((cp = strchr(tmp, '@')) != NULL) {
+	/* 
+	 * Extract optional ssh-info (username + connection params)
+	 * Accomodate username in upn format - user@domain@host
+	 */
+	if ((cp = strrchr(tmp, '@')) != NULL) {
 		char *delim;
 
 		*cp = '\0';

--- a/misc.c
+++ b/misc.c
@@ -2042,5 +2042,5 @@ format_absolute_time(uint64_t t, char *buf, size_t len)
 int
 path_absolute(const char *path)
 {
-	return (*file == '/') ? 1 : 0;
+	return (*path == '/') ? 1 : 0;
 }

--- a/misc.c
+++ b/misc.c
@@ -2037,3 +2037,10 @@ format_absolute_time(uint64_t t, char *buf, size_t len)
 	localtime_r(&tt, &tm);
 	strftime(buf, len, "%Y-%m-%dT%H:%M:%S", &tm);
 }
+
+/* check if path is absolute */
+int
+path_absolute(const char *path)
+{
+	return (*file == '/') ? 1 : 0;
+}

--- a/misc.h
+++ b/misc.h
@@ -78,6 +78,7 @@ int	 valid_env_name(const char *);
 const char *atoi_err(const char *, int *);
 int	 parse_absolute_time(const char *, uint64_t *);
 void	 format_absolute_time(uint64_t, char *, size_t);
+int	 path_absolute(const char *);
 
 void	 sock_set_v6only(int);
 

--- a/myproposal.h
+++ b/myproposal.h
@@ -179,8 +179,12 @@
 #define	SSH_ALLOWED_CA_SIGALGS	"ssh-ed25519"
 
 #endif /* WITH_OPENSSL */
-
+	
+#ifdef NO_ZLIB
+#define	KEX_DEFAULT_COMP	"none"
+#else
 #define	KEX_DEFAULT_COMP	"none,zlib@openssh.com"
+#endif
 #define	KEX_DEFAULT_LANG	""
 
 #define KEX_CLIENT \

--- a/servconf.c
+++ b/servconf.c
@@ -702,7 +702,7 @@ derelativise_path(const char *path)
 	if (strcasecmp(path, "none") == 0)
 		return xstrdup("none");
 	expanded = tilde_expand_filename(path, getuid());
-	if (*expanded == '/')
+	if (path_absolute(expanded))
 		return expanded;
 	if (getcwd(cwd, sizeof(cwd)) == NULL)
 		fatal("%s: getcwd: %s", __func__, strerror(errno));

--- a/sftp.c
+++ b/sftp.c
@@ -389,7 +389,7 @@ make_absolute(char *p, const char *pwd)
 	char *abs_str;
 
 	/* Derelativise */
-	if (p && p[0] != '/') {
+	if (p && !path_absolute(p)) {
 		abs_str = path_append(pwd, p);
 		free(p);
 		return(abs_str);

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -243,7 +243,11 @@ type_bits_valid(int type, const char *name, u_int32_t *bitsp)
 	case KEY_ECDSA:
 		if (sshkey_ecdsa_bits_to_nid(*bitsp) == -1)
 			fatal("Invalid ECDSA key length: valid lengths are "
-			    "256, 384 or 521 bits");
+#ifdef OPENSSL_HAS_NISTP521
+				"256, 384 or 521 bits");
+#else
+				"256 or 384 bits");
+#endif
 	}
 #endif
 }

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -172,9 +172,13 @@ ssh_kex2(char *host, struct sockaddr *hostaddr, u_short port)
 	    compat_cipher_proposal(options.ciphers);
 	myproposal[PROPOSAL_ENC_ALGS_STOC] =
 	    compat_cipher_proposal(options.ciphers);
+#ifdef NO_ZLIB
+	myproposal[PROPOSAL_COMP_ALGS_CTOS] = "none";
+#else
 	myproposal[PROPOSAL_COMP_ALGS_CTOS] =
 	    myproposal[PROPOSAL_COMP_ALGS_STOC] = options.compression ?
 	    "zlib@openssh.com,zlib,none" : "none,zlib@openssh.com,zlib";
+#endif
 	myproposal[PROPOSAL_MAC_ALGS_CTOS] =
 	    myproposal[PROPOSAL_MAC_ALGS_STOC] = options.macs;
 	if (options.hostkeyalgorithms != NULL) {


### PR DESCRIPTION
Requesting to merge the following minor changes to support Windows (forked at https://github.com/PowerShell/openssh-portable). 

Summary of changes:
- Unix Vs Windows path differences
  - Unix paths start with '/' while Windows start with a drive letter and ':'
  - Changes include having a utility function that could be overloaded for Windows in one place.
- Ability to compile without zlib support. 
  - Haven't officially onboarded zlib on Windows yet. 
  - Changes include a macro to opt out zlib support. 
- Normalize incoming user name
  - user names are case insensitive in Windows with multiple valid domain scoping formats (user@domain, domain\user, etc). 
  - Changes include normalizing user name (done by getpwnam on Windows) upfront before processing user name based logic. 
- Other misc changes explained with comments