### PR TITLE
Windows support: Account for path differences

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -437,7 +437,7 @@ expand_authorized_keys(const char *filename, struct passwd *pw)
 	 * Ensure that filename starts anchored. If not, be backward
 	 * compatible and prepend the '%h/'
 	 */
-	if (*file == '/')
+	if (path_absolute(file))
 		return (file);
 
 	i = snprintf(ret, sizeof(ret), "%s/%s", pw->pw_dir, file);

--- a/misc.c
+++ b/misc.c
@@ -2037,3 +2037,10 @@ format_absolute_time(uint64_t t, char *buf, size_t len)
 	localtime_r(&tt, &tm);
 	strftime(buf, len, "%Y-%m-%dT%H:%M:%S", &tm);
 }
+
+/* check if path is absolute */
+int
+path_absolute(const char *path)
+{
+	return (*path == '/') ? 1 : 0;
+}

--- a/misc.h
+++ b/misc.h
@@ -78,6 +78,7 @@ int	 valid_env_name(const char *);
 const char *atoi_err(const char *, int *);
 int	 parse_absolute_time(const char *, uint64_t *);
 void	 format_absolute_time(uint64_t, char *, size_t);
+int	 path_absolute(const char *);
 
 void	 sock_set_v6only(int);
 

--- a/servconf.c
+++ b/servconf.c
@@ -702,7 +702,7 @@ derelativise_path(const char *path)
 	if (strcasecmp(path, "none") == 0)
 		return xstrdup("none");
 	expanded = tilde_expand_filename(path, getuid());
-	if (*expanded == '/')
+	if (path_absolute(expanded))
 		return expanded;
 	if (getcwd(cwd, sizeof(cwd)) == NULL)
 		fatal("%s: getcwd: %s", __func__, strerror(errno));

--- a/sftp.c
+++ b/sftp.c
@@ -389,7 +389,7 @@ make_absolute(char *p, const char *pwd)
 	char *abs_str;
 
 	/* Derelativise */
-	if (p && p[0] != '/') {
+	if (p && !path_absolute(p)) {
 		abs_str = path_append(pwd, p);
 		free(p);
 		return(abs_str);


### PR DESCRIPTION
Issue: 
Unix and Windows have different file system path rules. While Unix paths start with '/', Windows start with a drive letter and ':'. There are a handful of places where this checks for "absolute paths" are made. If we can route these checks via a unitity function, we could overload the utility for Windows and keep the rest of the calls clean (from #ifdef logic). 

Fix:
Changes include utility function that could be overloaded for Windows in one place.