### PR TITLE
Add option to compile with no zlib support

### DIFF
--- a/myproposal.h
+++ b/myproposal.h
@@ -180,7 +180,11 @@
 
 #endif /* WITH_OPENSSL */
 
+#ifdef NO_ZLIB
+#define	KEX_DEFAULT_COMP	"none"
+#else
 #define	KEX_DEFAULT_COMP	"none,zlib@openssh.com"
+#endif
 #define	KEX_DEFAULT_LANG	""
 
 #define KEX_CLIENT \

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -172,9 +172,14 @@ ssh_kex2(char *host, struct sockaddr *hostaddr, u_short port)
 	    compat_cipher_proposal(options.ciphers);
 	myproposal[PROPOSAL_ENC_ALGS_STOC] =
 	    compat_cipher_proposal(options.ciphers);
+#ifdef NO_ZLIB
+	myproposal[PROPOSAL_COMP_ALGS_CTOS] =
+	    myproposal[PROPOSAL_COMP_ALGS_STOC] = "none";
+#else
 	myproposal[PROPOSAL_COMP_ALGS_CTOS] =
 	    myproposal[PROPOSAL_COMP_ALGS_STOC] = options.compression ?
 	    "zlib@openssh.com,zlib,none" : "none,zlib@openssh.com,zlib";
+#endif
 	myproposal[PROPOSAL_MAC_ALGS_CTOS] =
 	    myproposal[PROPOSAL_MAC_ALGS_STOC] = options.macs;
 	if (options.hostkeyalgorithms != NULL) {


### PR DESCRIPTION
Issue: In Windows, zlib isn't officially supported yet. Truly compiling without zlib requires a lot of changes, I avoided these by creating a dummy zlib library for Windows. We still need some changes in core code for the client and server stacks to not advertise zlib support on the wire.

Fix: Add a macro to opt out zlib support. By default, if the macro is not defined, zlib compression support is included, so it makes no difference when compiling/building for Unix flavors