### PR TITLE
Normalize incoming user before processing username relying logic

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -567,10 +567,10 @@ getpwnamallow(const char *user)
 	auth_session_t *as;
 #endif
 #endif
-	struct passwd *pw;
+	struct passwd *pw = getpwnam(user);
 	struct connection_info *ci = get_connection_info(1, options.use_dns);
 
-	ci->user = user;
+	ci->user = pw ? pw->pw_name : user;
 	parse_server_match_config(&options, ci);
 	log_change_level(options.log_level);
 	process_permitopen(ssh, &options);
@@ -578,8 +578,6 @@ getpwnamallow(const char *user)
 #if defined(_AIX) && defined(HAVE_SETAUTHDB)
 	aix_setauthdb(user);
 #endif
-
-	pw = getpwnam(user);
 
 #if defined(_AIX) && defined(HAVE_SETAUTHDB)
 	aix_restoreauthdb();


### PR DESCRIPTION
This is to primarily support scenarios in Windows. The changes otherwise have no impact on behavior in Unix. 
  - user names are case insensitive in Windows with multiple valid domain scoping formats (user@domain, domain\user, etc). 
  - Changes include normalizing user name (done by getpwnam on Windows) upfront before processing user name based logic. 