### PR TITLE
Support usernames in UPN format

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -791,8 +791,11 @@ parse_uri(const char *scheme, const char *uri, char **userp, char **hostp,
 
 	uridup = tmp = xstrdup(uri);
 
-	/* Extract optional ssh-info (username + connection params) */
-	if ((cp = strchr(tmp, '@')) != NULL) {
+	/*
+	 * Extract optional ssh-info (username + connection params)
+	 * Accomodate username in upn format - user@domain@host
+	 */
+	if ((cp = strrchr(tmp, '@')) != NULL) {
 		char *delim;
 
 		*cp = '\0';


### PR DESCRIPTION
These are supported via parse_user_host_path and parse_user_host_port but not in parse_uri. 