### PR TITLE
Correct error message when OpenSSL doesn't support certain ECDSA key lenghts

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -243,7 +243,11 @@ type_bits_valid(int type, const char *name, u_int32_t *bitsp)
 	case KEY_ECDSA:
 		if (sshkey_ecdsa_bits_to_nid(*bitsp) == -1)
 			fatal("Invalid ECDSA key length: valid lengths are "
+#ifdef OPENSSL_HAS_NISTP521
 			    "256, 384 or 521 bits");
+#else
+			    "256 or 384 bits");
+#endif
 	}
 #endif
 }


### PR DESCRIPTION
Minor fix to an issue reported in Windows fork of OpenSSH. 