### PR TITLE
Don't pass loginmsg by address now that it's an sshbuf*

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -258,7 +258,7 @@ allowed_user(struct passwd * pw)
 	}
 
 #ifdef CUSTOM_SYS_AUTH_ALLOWED_USER
-	if (!sys_auth_allowed_user(pw, &loginmsg))
+	if (!sys_auth_allowed_user(pw, loginmsg))
 		return 0;
 #endif
 
@@ -362,7 +362,7 @@ auth_log(Authctxt *authctxt, int authenticated, int partial,
 	if (authenticated)
 		sys_auth_record_login(authctxt->user,
 		    auth_get_canonical_hostname(ssh, options.use_dns), "ssh",
-		    &loginmsg);
+		    loginmsg);
 # endif
 #endif
 #ifdef SSH_AUDIT_EVENTS

--- a/loginrec.c
+++ b/loginrec.c
@@ -467,7 +467,7 @@ login_write(struct logininfo *li)
 #ifdef CUSTOM_SYS_AUTH_RECORD_LOGIN
 	if (li->type == LTYPE_LOGIN &&
 	    !sys_auth_record_login(li->username,li->hostname,li->line,
-	    &loginmsg))
+	    loginmsg))
 		logit("Writing login record failed for %s", li->username);
 #endif
 #ifdef SSH_AUDIT_EVENTS


### PR DESCRIPTION
In 120a1ec74, loginmsg was changed from the legacy Buffer type to struct sshbuf*, but it missed changing calls to sys_auth_allowed_user and sys_auth_record_login which passed loginmsg by address. Now that it's a pointer, just pass it directly.

This only affects AIX, unless there are out of tree users.