### PR TITLE
kexc25519.c fixed all-zero test

### DIFF
--- a/kexc25519.c
+++ b/kexc25519.c
@@ -64,14 +64,16 @@ kexc25519_shared_key(const u_char key[CURVE25519_SIZE],
     const u_char pub[CURVE25519_SIZE], struct sshbuf *out)
 {
 	u_char shared_key[CURVE25519_SIZE];
+	u_char zero[CURVE25519_SIZE];
 	int r;
 
-	/* Check for all-zero public key */
-	explicit_bzero(shared_key, CURVE25519_SIZE);
-	if (timingsafe_bcmp(pub, shared_key, CURVE25519_SIZE) == 0)
+	crypto_scalarmult_curve25519(shared_key, key, pub);
+
+	/* Check for all-zero shared secret */
+	explicit_bzero(zero, CURVE25519_SIZE);
+	if (timingsafe_bcmp(zero, shared_key, CURVE25519_SIZE) == 0)
 		return SSH_ERR_KEY_INVALID_EC_VALUE;
 
-	crypto_scalarmult_curve25519(shared_key, key, pub);
 #ifdef DEBUG_KEXECDH
 	dump_digest("shared secret", shared_key, CURVE25519_SIZE);
 #endif


### PR DESCRIPTION
Hello,
there is bug in "curve25519-sha256" implementation.
In the file kexc25519.c, in function kexc25519_shared_key is 'all-zero-pk' check which checks
if the public-key is not zero. But the check is not complete.
You shoud check if the public key is not zero, p (2^255-19), 2p, ...

Is much better to check the scalar product after scalar multiplication (shared-secret) because if pk modulo p is zero, then the shared secret is also zero.

You can check it using script (autopkgtest for TinySSH server):
https://salsa.debian.org/debian/tinyssh/blob/master/debian/tests/02handshake

run (before and after patch) e.g.:
./02handshake 127.0.0.1 22

Jan.