### PR TITLE
docs: LocalForward and RemoteForward can act on unix-domain sockets

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1086,15 +1086,21 @@ This directive is ignored unless
 .Cm PermitLocalCommand
 has been enabled.
 .It Cm LocalForward
-Specifies that a TCP port on the local machine be forwarded over
-the secure channel to the specified host and port from the remote machine.
-The first argument must be
+Specifies that a TCP port or Unix-domain socket on the local machine
+be forwarded over
+the secure channel to the specified host and port (or Unix-domain socket) from the remote machine.
+For a TCP port, the first argument must be
 .Sm off
 .Oo Ar bind_address : Oc Ar port
 .Sm on
 and the second argument must be
 .Ar host : Ns Ar hostport .
 IPv6 addresses can be specified by enclosing addresses in square brackets.
+.Pp
+If either argument contains a '/' in it, that argument will be
+interpreted as a Unix-domain socket (on the corresponding host) rather
+than a TCP port.
+.Pp
 Multiple forwardings may be specified, and additional forwardings can be
 given on the command line.
 Only the superuser can forward privileged ports.
@@ -1346,9 +1352,10 @@ accept the tokens described in the
 .Sx TOKENS
 section.
 .It Cm RemoteForward
-Specifies that a TCP port on the remote machine be forwarded over
-the secure channel.
+Specifies that a TCP port or Unix-domain socket on the remote machine
+be forwarded over the secure channel.
 The remote port may either be forwarded to a specified host and port
+or Unix-domain socket
 from the local machine, or may act as a SOCKS 4/5 proxy that allows a remote
 client to connect to arbitrary destinations from the local machine.
 The first argument must be
@@ -1361,6 +1368,11 @@ otherwise if no destination argument is specified then the remote forwarding
 will be established as a SOCKS proxy.
 .Pp
 IPv6 addresses can be specified by enclosing addresses in square brackets.
+.Pp
+If either argument contains a '/' in it, that argument will be
+interpreted as a Unix-domain socket (on the corresponding host) rather
+than a TCP port.
+.Pp
 Multiple forwardings may be specified, and additional
 forwardings can be given on the command line.
 Privileged ports can be forwarded only when


### PR DESCRIPTION
this is just a clarification of the documentation, and hopefully isn't controversial