### PR TITLE
ForwardIdentityAgent - a new ssh option to set a dedicated ssh-agent for ForwardAgent

### DIFF
--- a/authfd.c
+++ b/authfd.c
@@ -82,18 +82,16 @@ decode_reply(u_char type)
 		return SSH_ERR_INVALID_FORMAT;
 }
 
-/* Returns the number of the authentication fd, or -1 if there is none. */
+/* Returns socket fd, or -1 if there is none. */
 int
-ssh_get_authentication_socket(int *fdp)
+get_authentication_socket(const char *authsocket, int *fdp)
 {
-	const char *authsocket;
 	int sock, oerrno;
 	struct sockaddr_un sunaddr;
 
 	if (fdp != NULL)
 		*fdp = -1;
 
-	authsocket = getenv(SSH_AUTHSOCKET_ENV_NAME);
 	if (authsocket == NULL || *authsocket == '\0')
 		return SSH_ERR_AGENT_NOT_PRESENT;
 
@@ -117,6 +115,20 @@ ssh_get_authentication_socket(int *fdp)
 	else
 		close(sock);
 	return 0;
+}
+
+/* Returns the number of the authentication fd, or -1 if there is none. */
+int
+ssh_get_forward_authentication_socket(const char *authsocket, int *fdp)
+{
+	return get_authentication_socket(authsocket, fdp);
+}
+
+/* Returns the number of the authentication fd, or -1 if there is none. */
+int
+ssh_get_authentication_socket(int *fdp)
+{
+	return get_authentication_socket(getenv(SSH_AUTHSOCKET_ENV_NAME), fdp);
 }
 
 /* Communicate with agent: send request and read reply */

--- a/authfd.h
+++ b/authfd.h
@@ -24,8 +24,7 @@ struct ssh_identitylist {
 };
 
 int	ssh_get_authentication_socket(int *fdp);
-int
-ssh_get_forward_authentication_socket(const char *authsocket, int *fdp);
+int ssh_get_forward_authentication_socket(const char *authsocket, int *fdp);
 void	ssh_close_authentication_socket(int sock);
 
 int	ssh_lock_agent(int sock, int lock, const char *password);

--- a/authfd.h
+++ b/authfd.h
@@ -24,6 +24,8 @@ struct ssh_identitylist {
 };
 
 int	ssh_get_authentication_socket(int *fdp);
+int
+ssh_get_forward_authentication_socket(const char *authsocket, int *fdp);
 void	ssh_close_authentication_socket(int sock);
 
 int	ssh_lock_agent(int sock, int lock, const char *password);

--- a/authfd.h
+++ b/authfd.h
@@ -24,7 +24,7 @@ struct ssh_identitylist {
 };
 
 int	ssh_get_authentication_socket(int *fdp);
-int ssh_get_forward_authentication_socket(const char *authsocket, int *fdp);
+int	ssh_get_forward_authentication_socket(const char *authsocket, int *fdp);
 void	ssh_close_authentication_socket(int sock);
 
 int	ssh_lock_agent(int sock, int lock, const char *password);

--- a/clientloop.c
+++ b/clientloop.c
@@ -1619,7 +1619,13 @@ client_request_agent(struct ssh *ssh, const char *request_type, int rchan)
 		    "malicious server.");
 		return NULL;
 	}
-	if ((r = ssh_get_authentication_socket(&sock)) != 0) {
+
+	if (options.forward_identity_agent)
+		r = ssh_get_forward_authentication_socket(options.forward_identity_agent, &sock);
+	else
+		r = ssh_get_authentication_socket(&sock);
+
+	if (r != 0) {
 		if (r != SSH_ERR_AGENT_NOT_PRESENT)
 			debug("%s: ssh_get_authentication_socket: %s",
 			    __func__, ssh_err(r));

--- a/readconf.c
+++ b/readconf.c
@@ -1746,8 +1746,6 @@ parse_keytypes:
 		}
 		if (*activep && *charptr == NULL)
 			*charptr = xstrdup(arg);
-
-		printf("forward_identity_agent: %s\n", options->forward_identity_agent);
 		break;
 
 	case oDeprecated:

--- a/readconf.h
+++ b/readconf.h
@@ -29,7 +29,7 @@ struct allowed_cname {
 
 typedef struct {
 	int     forward_agent;	/* Forward authentication agent. */
-	char   *forward_identity_agent;		/* Optional path to ssh-agent socket */
+	char   *forward_identity_agent;	/* Optional path to ssh-agent socket */
 	int     forward_x11;	/* Forward X11 display. */
 	int     forward_x11_timeout;	/* Expiration for Cookies */
 	int     forward_x11_trusted;	/* Trust Forward X11 display. */

--- a/readconf.h
+++ b/readconf.h
@@ -29,6 +29,7 @@ struct allowed_cname {
 
 typedef struct {
 	int     forward_agent;	/* Forward authentication agent. */
+	char   *forward_identity_agent;		/* Optional path to ssh-agent socket */
 	int     forward_x11;	/* Forward X11 display. */
 	int     forward_x11_timeout;	/* Expiration for Cookies */
 	int     forward_x11_trusted;	/* Trust Forward X11 display. */

--- a/ssh.1
+++ b/ssh.1
@@ -491,6 +491,7 @@ For full details of the options listed below, and their possible values, see
 .It ExitOnForwardFailure
 .It FingerprintHash
 .It ForwardAgent
+.It ForwardIdentityAgent
 .It ForwardX11
 .It ForwardX11Timeout
 .It ForwardX11Trusted

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -676,6 +676,33 @@ can access the local agent through the forwarded connection.
 An attacker cannot obtain key material from the agent,
 however they can perform operations on the keys that enable them to
 authenticate using the identities loaded into the agent.
+.It ForwardIdentityAgent
+Specifies the
+.Ux Ns -domain
+socket used to communicate with the forwarded authentication agent.
+.Pp
+.Cm ForwardIdentityAgent
+is used in conjunction with
+.Cm ForwardAgent
+to configure a separate ssh-agent for agent forwarding.
+If the string
+.Qq SSH_AUTH_SOCK
+is specified, the location of the socket will be read from the
+.Ev SSH_AUTH_SOCK
+environment variable.
+Otherwise if the specified value begins with a
+.Sq $
+character, then it will be treated as an environment variable containing
+the location of the socket.
+.Pp
+Arguments to
+.Cm ForwardIdentityAgent
+may use the tilde syntax to refer to a user's home directory
+or the tokens described in the
+.Sx TOKENS
+section.
+.Pp
+This option allow users to use a dedicated ssh-agent for agent forwarding.
 .It Cm ForwardX11
 Specifies whether X11 connections will be automatically redirected
 over the secure channel and

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -702,7 +702,10 @@ or the tokens described in the
 .Sx TOKENS
 section.
 .Pp
-This option allow users to use a dedicated ssh-agent for agent forwarding.
+This option is used to configure a dedicated ssh-agent for agent forwarding.
+Helpful in cases where a user needs to enable ForwardAgent (e.g. for
+SSH sudo authentication using a dedicated identity), but doesn't want to
+expose cached SSH login identities to remote hosts.
 .It Cm ForwardX11
 Specifies whether X11 connections will be automatically redirected
 over the secure channel and

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -676,7 +676,7 @@ can access the local agent through the forwarded connection.
 An attacker cannot obtain key material from the agent,
 however they can perform operations on the keys that enable them to
 authenticate using the identities loaded into the agent.
-.It ForwardIdentityAgent
+.It Cm ForwardIdentityAgent
 Specifies the
 .Ux Ns -domain
 socket used to communicate with the forwarded authentication agent.


### PR DESCRIPTION
# New Feature Request

## Problem Statement
We have a requirement to use `ForwardAgent` to enable SSH `sudo` authentication using identities cached in our local `ssh-agent`. However the agent forwarding has an unintended security consequence. With agent forwarding (active session) anyone with sufficient permissions (e.g. sudo users or an attacker who managed to compromised the host) on the remote host can potentially impersonate the user and connect to a 3rd host by performing authentication using login identities (keys) from your `ssh-agent` (lateral movement).

To mitigate this problem, one option is to use a separate identity for `sudo`, different from SSH login identity. But `openssh` client forwards the same authentication agent used for SSH login, exposing our login identities to remote hosts. 

As a workaround, it is technically possible to setup `RemoteForward` to local `ssh-agent` for sudo authentication, but that requires some hacks/less-ideal changes in the server side.

The proposed feature will allow us to separate login and ssh authentication identities by using two different `ssh-agent` in the workstation.

More info: see [here](https://medium.com/@prbinu/touch2sudo-enable-remote-sudo-two-factor-authentication-using-mac-touch-id-df638b7da594)

##  `ForwardIdentityAgent`

This option specifies the UNIX-domain socket used to communicate with the forwarded authentication agent. `ForwardIdentityAgent` can be used in conjunction with `ForwardAgent` to configure a separate `ssh-agent` for agent forwarding. This is similar to `IdentityAgent`, but for `ForwardAgent`.

This feature is helpful in cases where a user needs to enable `ForwardAgent` (e.g. for SSH `sudo` authentication using a dedicated identity), but doesn't want to expose **cached** SSH login identities (certificates) to remote hosts.

## Usage

```bash
# default ssh-agent that contains login identity key
$ env | grep SSH_AUTH
SSH_AUTH_SOCK=/tmp/ssh-z1Lsp0G9s6wh/agent.27887

# another ssh-agent instance that contains sudo authentication identity key
$ SUDO_SSH_AUTH_SOCK=/tmp/ssh-A5JsI9UpPWzg/agent.27955
$ ssh -o "ForwardIdentityAgent $SUDO_SSH_AUTH_SOCK" -A bob@172.31.2.67
...
bob@ip-172-31-2-67:~$ sudo whoami
root

```


