### PR TITLE
Use more accurate "unresponsive" instead of "inactive"

### DIFF
--- a/sshd_config.5
+++ b/sshd_config.5
@@ -514,7 +514,7 @@ The TCP keepalive option enabled by
 .Cm TCPKeepAlive
 is spoofable.
 The client alive mechanism is valuable when the client or
-server depend on knowing when a connection has become inactive.
+server depend on knowing when a connection has become unresponsive.
 .Pp
 The default value is 3.
 If


### PR DESCRIPTION
The ClientAliveInterval setting is grossly misunderstood by administrators to be some sort of "idle session timeout" tunable. I think a good deal of this confusion comes from the usage of the overloaded word "inactive" in this man page when "unresponsive" is meant.