### PR TITLE
allow s390 specific ioctl for ecc hardware support

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -250,6 +250,7 @@ static const struct sock_filter preauth_insns[] = {
 	SC_ALLOW_ARG(__NR_ioctl, 1, Z90STAT_STATUS_MASK),
 	SC_ALLOW_ARG(__NR_ioctl, 1, ICARSAMODEXPO),
 	SC_ALLOW_ARG(__NR_ioctl, 1, ICARSACRT),
+	SC_ALLOW_ARG(__NR_ioctl, 1, ZSECSENDCPRB),
 #endif
 #if defined(__x86_64__) && defined(__ILP32__) && defined(__X32_SYSCALL_BIT)
 	/*


### PR DESCRIPTION
Adding another s390 specific ioctl to be able to support ECC hardware acceleration
to the sandbox seccomp filter rules.

Now the ibmca openssl engine provides elliptic curve cryptography support with the
help of libica and CCA crypto cards. This is done via jet another ioctl call to the zcrypt
device driver and so there is a need to enable this on the openssl sandbox.

Code is s390 specific and has been tested, verified and reviewed.

Please note that I am also the originator of the previous changes in that area.
I posted these changes to Eduardo and he forwarded the patches to the openssl
community.

Signed-off-by: Harald Freudenberger <freude@linux.ibm.com>
Reviewed-by: Joerg Schmidbauer <jschmidb@de.ibm.com>