### PR TITLE
openssl-devel is obsoleted by libssl-devel

### DIFF
--- a/contrib/cygwin/README
+++ b/contrib/cygwin/README
@@ -77,7 +77,7 @@ with the aforementioned cygport script:
 
   zlib
   crypt
-  openssl-devel
+  libssl-devel
   libedit-devel
   libkrb5-devel
 


### PR DESCRIPTION
openssl-devel is no longer installable via the cygwin setup and it's hidden by default, so you can't see the replacement very easy.