### PR TITLE
Remove unnecessary unlink

### DIFF
--- a/clientloop.c
+++ b/clientloop.c
@@ -338,7 +338,6 @@ client_x11_get_proto(struct ssh *ssh, const char *display,
 			    "%s/xauthfile", xauthdir)) < 0 ||
 			    (size_t)r >= sizeof(xauthfile)) {
 				error("%s: xauthfile path too long", __func__);
-				unlink(xauthfile);
 				rmdir(xauthdir);
 				return -1;
 			}


### PR DESCRIPTION
Remove unnecessary

    unlink(xauthfile);

Just before that line writing to the string _xauthfile_ failed.

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>