### PR TITLE
Bug #3030: window change events not passed when using session multipl…

### DIFF
--- a/openbsd-compat/port-solaris.c
+++ b/openbsd-compat/port-solaris.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006 Chad Mynhier.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -348,8 +349,7 @@ solaris_drop_privs_root_pinfo_net_exec(void)
 	    priv_delset(pset, PRIV_NET_ACCESS) != 0 ||
 #endif
 	    priv_delset(pset, PRIV_PROC_EXEC) != 0 ||
-	    priv_delset(pset, PRIV_PROC_INFO) != 0 ||
-	    priv_delset(pset, PRIV_PROC_SESSION) != 0)
+	    priv_delset(pset, PRIV_PROC_INFO) != 0)
 		fatal("priv_delset: %s", strerror(errno));
 
 	if (setppriv(PRIV_SET, PRIV_PERMITTED, pset) != 0 ||


### PR DESCRIPTION
When the ssh client code calls platform_pledge_mux() on Solaris it will call solaris_drop_privs_root_pinfo_net_exec().  This function drops too many privileges.

It is supposed to be equivalent to pledge("stdio proc tty", ...)

Note "proc" is kept because of the need to call kill(2).  The Solaris implementation of this is currently dropping PRIV_PROC_SESSION which is needed to be able to send signals to processes the user owns but are outside of the current session.