### PR TITLE
Remove perm_ok argument from sshkey_load_private_type

### DIFF
--- a/authfile.c
+++ b/authfile.c
@@ -164,10 +164,9 @@ sshkey_perm_ok(int fd, const char *filename)
 	return 0;
 }
 
-/* XXX kill perm_ok now that we have SSH_ERR_KEY_BAD_PERMISSIONS? */
 int
 sshkey_load_private_type(int type, const char *filename, const char *passphrase,
-    struct sshkey **keyp, char **commentp, int *perm_ok)
+    struct sshkey **keyp, char **commentp)
 {
 	int fd, r;
 
@@ -176,19 +175,12 @@ sshkey_load_private_type(int type, const char *filename, const char *passphrase,
 	if (commentp != NULL)
 		*commentp = NULL;
 
-	if ((fd = open(filename, O_RDONLY)) == -1) {
-		if (perm_ok != NULL)
-			*perm_ok = 0;
+	if ((fd = open(filename, O_RDONLY)) == -1)
 		return SSH_ERR_SYSTEM_ERROR;
-	}
-	if (sshkey_perm_ok(fd, filename) != 0) {
-		if (perm_ok != NULL)
-			*perm_ok = 0;
-		r = SSH_ERR_KEY_BAD_PERMISSIONS;
+
+	r = sshkey_perm_ok(fd, filename);
+	if (r != 0)
 		goto out;
-	}
-	if (perm_ok != NULL)
-		*perm_ok = 1;
 
 	r = sshkey_load_private_type_fd(fd, type, passphrase, keyp, commentp);
 	if (r == 0 && keyp && *keyp)
@@ -387,7 +379,7 @@ sshkey_load_cert(const char *filename, struct sshkey **keyp)
 /* Load private key and certificate */
 int
 sshkey_load_private_cert(int type, const char *filename, const char *passphrase,
-    struct sshkey **keyp, int *perm_ok)
+    struct sshkey **keyp)
 {
 	struct sshkey *key = NULL, *cert = NULL;
 	int r;
@@ -410,7 +402,7 @@ sshkey_load_private_cert(int type, const char *filename, const char *passphrase,
 	}
 
 	if ((r = sshkey_load_private_type(type, filename,
-	    passphrase, &key, NULL, perm_ok)) != 0 ||
+	    passphrase, &key, NULL)) != 0 ||
 	    (r = sshkey_load_cert(filename, &cert)) != 0)
 		goto out;
 

--- a/authfile.h
+++ b/authfile.h
@@ -40,9 +40,9 @@ int sshkey_load_cert(const char *, struct sshkey **);
 int sshkey_load_public(const char *, struct sshkey **, char **);
 int sshkey_load_private(const char *, const char *, struct sshkey **, char **);
 int sshkey_load_private_cert(int, const char *, const char *,
-    struct sshkey **, int *);
+    struct sshkey **);
 int sshkey_load_private_type(int, const char *, const char *,
-    struct sshkey **, char **, int *);
+    struct sshkey **, char **);
 int sshkey_load_private_type_fd(int fd, int type, const char *passphrase,
     struct sshkey **keyp, char **commentp);
 int sshkey_perm_ok(int, const char *);

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1404,7 +1404,7 @@ load_identity_file(Identity *id)
 {
 	struct sshkey *private = NULL;
 	char prompt[300], *passphrase, *comment;
-	int r, perm_ok = 0, quit = 0, i;
+	int r, quit = 0, i;
 	struct stat st;
 
 	if (stat(id->filename, &st) == -1) {
@@ -1426,7 +1426,7 @@ load_identity_file(Identity *id)
 			}
 		}
 		switch ((r = sshkey_load_private_type(KEY_UNSPEC, id->filename,
-		    passphrase, &private, &comment, &perm_ok))) {
+		    passphrase, &private, &comment))) {
 		case 0:
 			break;
 		case SSH_ERR_KEY_WRONG_PASSPHRASE:


### PR DESCRIPTION
Remove perm_ok, which could potentially be used to check
for private identification file permissions.
But as sshkey_load_private_type would return
SSH_ERR_KEY_BAD_PERMISSIONS for bad permission.
Hence perm_ok seems redundant.