### PR TITLE
Show key labels for PKCS#11 keys instead of library name

### DIFF
--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -613,7 +613,7 @@ process_add_smartcard_key(SocketEntry *e)
 			id = xcalloc(1, sizeof(Identity));
 			id->key = k;
 			id->provider = xstrdup(canonical_provider);
-			id->comment = xstrdup(canonical_provider); /* XXX */
+			id->comment = xstrdup(k->label ? k->label : canonical_provider);
 			id->death = death;
 			id->confirm = confirm;
 			TAILQ_INSERT_TAIL(&idtab->idlist, id, next);

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -790,14 +790,16 @@ do_download(struct passwd *pw)
 			    SSH_FP_RANDOMART);
 			if (fp == NULL || ra == NULL)
 				fatal("%s: sshkey_fingerprint fail", __func__);
-			printf("%u %s %s (PKCS11 key)\n", sshkey_size(keys[i]),
-			    fp, sshkey_type(keys[i]));
+			printf("%u %s %s (%s)\n", sshkey_size(keys[i]),
+			    fp, keys[i]->label ? keys[i]->label : "(PKCS11 key)", sshkey_type(keys[i]));
 			if (log_level_get() >= SYSLOG_LEVEL_VERBOSE)
 				printf("%s\n", ra);
 			free(ra);
 			free(fp);
 		} else {
 			(void) sshkey_write(keys[i], stdout); /* XXX check */
+			if (keys[i]->label)
+				fprintf(stdout, " %s", keys[i]->label);
 			fprintf(stdout, "\n");
 		}
 		sshkey_free(keys[i]);

--- a/ssh-pkcs11-helper.c
+++ b/ssh-pkcs11-helper.c
@@ -134,7 +134,7 @@ process_add(void)
 				continue;
 			}
 			if ((r = sshbuf_put_string(msg, blob, blen)) != 0 ||
-			    (r = sshbuf_put_cstring(msg, name)) != 0)
+			    (r = sshbuf_put_cstring(msg, keys[i]->label)) != 0)
 				fatal("%s: buffer error: %s",
 				    __func__, ssh_err(r));
 			free(blob);

--- a/sshkey.c
+++ b/sshkey.c
@@ -503,6 +503,7 @@ sshkey_new(int type)
 	k->ed25519_pk = NULL;
 	k->xmss_sk = NULL;
 	k->xmss_pk = NULL;
+	k->label = NULL;
 	switch (k->type) {
 #ifdef WITH_OPENSSL
 	case KEY_RSA:
@@ -602,6 +603,7 @@ sshkey_free(struct sshkey *k)
 	}
 	if (sshkey_is_cert(k))
 		cert_free(k->cert);
+	free(k->label);
 	freezero(k, sizeof(*k));
 }
 

--- a/sshkey.h
+++ b/sshkey.h
@@ -123,6 +123,7 @@ struct sshkey {
 	u_char	*xmss_sk;
 	u_char	*xmss_pk;
 	struct sshkey_cert *cert;
+	char	*label;
 };
 
 #define	ED25519_SK_SZ	crypto_sign_ed25519_SECRETKEYBYTES


### PR DESCRIPTION
This is useful e.g. for Yubikeys, which can have many RSA keys defined. It extends the sshkey struct to add a *label member, which is filled by pkcs11_add_provider, and ssh-agent and ssh-keygen use that field.