### PR TITLE
Clarify docs on ssh command behaviour

### DIFF
--- a/ssh.1
+++ b/ssh.1
@@ -94,7 +94,8 @@ his/her identity to the remote machine using one of several methods
 If a
 .Ar command
 is specified,
-it is executed on the remote host instead of a login shell.
+it is executed on the remote host via the users shell
+(using the -c shell argument).
 .Pp
 The options are as follows:
 .Pp


### PR DESCRIPTION
From what I can tell empirically, and looking at the source, all user commands are executed via a shell. Update the docs to match the behaviour. 

https://github.com/openssh/openssh-portable/blob/7349149da1074d82b71722338e05b6a282f126cc/ssh.1#L97

https://github.com/openssh/openssh-portable/blob/4d28fa78abce2890e136281950633fae2066cc29/session.c#L1704

