### PR TITLE
correct ConnectTimeout man entry

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -484,9 +484,8 @@ This may be useful in scripts if the connection sometimes fails.
 The default is 1.
 .It Cm ConnectTimeout
 Specifies the timeout (in seconds) used when connecting to the
-SSH server, instead of using the default system TCP timeout.
-This value is used only when the target is down or really unreachable,
-not when it refuses the connection.
+SSH server. This value is used when the target is down, unreachable,
+or not timely finalizing the initial SSH-specific handshake.
 .It Cm ControlMaster
 Enables the sharing of multiple sessions over a single network connection.
 When set to


### PR DESCRIPTION
Since the ConnectTimeout ssh option was introduced in 2003 (see https://bugzilla.mindrot.org/show_bug.cgi?id=207), the value of this option was extended from the initial TCP connection to the full initial ssh protocol handshake. The initial documentation is now incorrect and  the attached patch proposal attempts to better reflect the current behavior.

Patch was also proposed on https://bugzilla.mindrot.org/show_bug.cgi?id=3035