### PR TITLE
Correct typo in the sshd_config(5) manual page

### DIFF
--- a/sshd_config.5
+++ b/sshd_config.5
@@ -385,7 +385,7 @@ Specifies which algorithms are allowed for signing of certificates
 by certificate authorities (CAs).
 The default is:
 .Bd -literal -offset indent
-ecdsa-sha2-nistp256.ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
+ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
 ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
 .Ed
 .Pp


### PR DESCRIPTION
One comma in the listing of algorithms used by default for CASignatureAlgorithms was a dot.