### PR TITLE
sandbox-seccomp-filter: allow mprotect syscall

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -202,6 +202,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_mmap2
 	SC_ALLOW(__NR_mmap2),
 #endif
+#ifdef __NR_mprotect
+	SC_ALLOW(__NR_mprotect),
+#endif
 #ifdef __NR_mremap
 	SC_ALLOW(__NR_mremap),
 #endif


### PR DESCRIPTION
This allows to use portable OpenSSH with OpenBSD malloc and GrapheneOS hardened_malloc.

See:
- https://github.com/openbsd/src/blob/df69c215c7c66baf660f3f65414fd34796c96152/lib/libc/stdlib/malloc.c#L489
- https://github.com/GrapheneOS/hardened_malloc/blob/a32e26b8e9987177ef7573594b2aab2104ca9d3f/memory.c#L51
- GrapheneOS/hardened_malloc#97