### PR TITLE
Add PermitListen support for port 0

### DIFF
--- a/auth-options.c
+++ b/auth-options.c
@@ -361,7 +361,7 @@ handle_permit(const char **optsp, int listen,
 	 * permitlisten is allowed on port 0.
 	 */
 	if (cp == NULL ||
-	    (strcmp(cp, "*") != 0 && ((port = (a2port(cp) < 0)) || (!listen && port == 0)))) {
+	    (strcmp(cp, "*") != 0 && !(((port = a2port(cp)) >= 0) && (listen || (port != 0))))) {
 		free(tmp);
 		free(opt);
 		*errstrp = "invalid permission port";

--- a/auth-options.c
+++ b/auth-options.c
@@ -314,11 +314,12 @@ sshauthopt_new_with_keys_defaults(void)
  * Return 0 on success. Return -1 on failure and sets *errstrp to error reason.
  */
 static int
-handle_permit(const char **optsp, int allow_bare_port,
+handle_permit(const char **optsp, int listen,
     char ***permitsp, size_t *npermitsp, const char **errstrp)
 {
 	char *opt, *tmp, *cp, *host, **permits = *permitsp;
 	size_t npermits = *npermitsp;
+	int port;
 	const char *errstr = "unknown error";
 
 	if (npermits > SSH_AUTHOPT_PERMIT_MAX) {
@@ -328,7 +329,7 @@ handle_permit(const char **optsp, int allow_bare_port,
 	if ((opt = opt_dequote(optsp, &errstr)) == NULL) {
 		return -1;
 	}
-	if (allow_bare_port && strchr(opt, ':') == NULL) {
+	if (listen && strchr(opt, ':') == NULL) {
 		/*
 		 * Allow a bare port number in permitlisten to indicate a
 		 * listen_host wildcard.
@@ -357,9 +358,10 @@ handle_permit(const char **optsp, int allow_bare_port,
 	/*
 	 * don't want to use permitopen_port to avoid
 	 * dependency on channels.[ch] here.
+	 * permitlisten is allowed on port 0.
 	 */
 	if (cp == NULL ||
-	    (strcmp(cp, "*") != 0 && a2port(cp) <= 0)) {
+	    (strcmp(cp, "*") != 0 && ((port = (a2port(cp) < 0)) || (!listen && port == 0)))) {
 		free(tmp);
 		free(opt);
 		*errstrp = "invalid permission port";

--- a/channels.c
+++ b/channels.c
@@ -4179,7 +4179,7 @@ permitopen_port(const char *p, int where)
 	
 	port = a2port(p);
 	// FORWARD_REMOTE can be permitted on port 0
-	if ((port > 0) && ((where == FORWARD_LOCAL) && (port != 0))
+	if ((port >= 0) && ((where == FORWARD_REMOTE) || (port != 0)))
 		return port;
 	return -1;
 }

--- a/channels.c
+++ b/channels.c
@@ -4165,15 +4165,21 @@ channel_update_permission(struct ssh *ssh, int idx, int newport)
 	}
 }
 
-/* returns port number, FWD_PERMIT_ANY_PORT or -1 on error */
+/* 
+ * returns port number, FWD_PERMIT_ANY_PORT or -1 on error.
+ * permitopen allows ports bigger than 0, permitlisten allows ports bigger or equal to 0
+ */
 int
-permitopen_port(const char *p)
+permitopen_port(const char *p, int where)
 {
 	int port;
 
 	if (strcmp(p, "*") == 0)
 		return FWD_PERMIT_ANY_PORT;
-	if ((port = a2port(p)) > 0)
+	
+	port = a2port(p);
+	// FORWARD_REMOTE can be permitted on port 0
+	if ((port > 0) && ((where == FORWARD_LOCAL) && (port != 0))
 		return port;
 	return -1;
 }

--- a/channels.h
+++ b/channels.h
@@ -316,7 +316,7 @@ int	 channel_setup_remote_fwd_listener(struct ssh *, struct Forward *,
 int	 channel_cancel_rport_listener(struct ssh *, struct Forward *);
 int	 channel_cancel_lport_listener(struct ssh *, struct Forward *,
 	    int, struct ForwardOptions *);
-int	 permitopen_port(const char *);
+int	 permitopen_port(const char *, int);
 
 /* x11 forwarding */
 

--- a/servconf.c
+++ b/servconf.c
@@ -1957,7 +1957,7 @@ process_server_config_line(ServerOptions *options, char *line,
 				p = cleanhostname(p);
 			}
 			if (arg == NULL ||
-			    ((port = permitopen_port(arg, opcode == sPermitListen ? FORWARD_LOCAL : FORWARD_REMOTE)) < 0)) {
+			    ((port = permitopen_port(arg, opcode == sPermitListen ? FORWARD_REMOTE : FORWARD_LOCAL)) < 0)) {
 				fatal("%s line %d: bad port number in %s",
 				    filename, linenum,
 				    lookup_opcode_name(opcode));

--- a/servconf.c
+++ b/servconf.c
@@ -900,7 +900,7 @@ process_permitopen_list(struct ssh *ssh, ServerOpCodes opcode,
 		if (host == NULL || ch == '/')
 			fatal("%s: missing host in %s", __func__, what);
 		host = cleanhostname(host);
-		if (arg == NULL || ((port = permitopen_port(arg)) < 0))
+		if (arg == NULL || ((port = permitopen_port(arg, where)) < 0))
 			fatal("%s: bad port number in %s", __func__, what);
 		/* Send it to channels layer */
 		channel_add_permission(ssh, FORWARD_ADM,
@@ -1957,7 +1957,7 @@ process_server_config_line(ServerOptions *options, char *line,
 				p = cleanhostname(p);
 			}
 			if (arg == NULL ||
-			    ((port = permitopen_port(arg)) < 0)) {
+			    ((port = permitopen_port(arg, opcode == sPermitListen ? FORWARD_LOCAL : FORWARD_REMOTE)) < 0)) {
 				fatal("%s line %d: bad port number in %s",
 				    filename, linenum,
 				    lookup_opcode_name(opcode));

--- a/session.c
+++ b/session.c
@@ -307,7 +307,7 @@ set_fwdpermit_from_authopts(struct ssh *ssh, const struct sshauthopt *opts)
 			if ((host = hpdelim(&cp)) == NULL)
 				fatal("%s: internal error: hpdelim", __func__);
 			host = cleanhostname(host);
-			if (cp == NULL || (port = permitopen_port(cp)) < 0)
+			if (cp == NULL || (port = permitopen_port(cp, FORWARD_LOCAL)) < 0)
 				fatal("%s: internal error: permitopen port",
 				    __func__);
 			channel_add_permission(ssh,
@@ -323,7 +323,7 @@ set_fwdpermit_from_authopts(struct ssh *ssh, const struct sshauthopt *opts)
 			if ((host = hpdelim(&cp)) == NULL)
 				fatal("%s: internal error: hpdelim", __func__);
 			host = cleanhostname(host);
-			if (cp == NULL || (port = permitopen_port(cp)) < 0)
+			if (cp == NULL || (port = permitopen_port(cp, FORWARD_REMOTE)) < 0)
 				fatal("%s: internal error: permitlisten port",
 				    __func__);
 			channel_add_permission(ssh,


### PR DESCRIPTION
As part of a project I'm working on I want to limit an SSH user to only be able to create remote forwards with a randomly binded port (0).
Current implementation doesn't let the user permit port=0 on remote forwards, even though it's a valid input in remote forwards (not in local forwards).
With this PR the context of what flow is being passed into the port validation, taking it into account.