### PR TITLE
kex: avoid NULL deref upon kex_assemble_names misuse

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -223,7 +223,9 @@ kex_assemble_names(char **listp, const char *def, const char *all)
 	char *list = NULL, *ret = NULL, *matching = NULL, *opatterns = NULL;
 	int r = SSH_ERR_INTERNAL_ERROR;
 
-	if (listp == NULL || *listp == NULL || **listp == '\0') {
+	if (listp == NULL)
+		return SSH_ERR_INTERNAL_ERROR;
+	if (*listp == NULL || **listp == '\0') {
 		if ((*listp = strdup(def)) == NULL)
 			return SSH_ERR_ALLOC_FAIL;
 		return 0;


### PR DESCRIPTION
No functional change, kex_assemble_names is never called with NULL
listp.

Reported by Coverity against FreeBSD, CID 1395656