### PR TITLE
Allow shmget/shmat/shmdt in preauth privsep child.

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -230,6 +230,15 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_munmap
 	SC_ALLOW(__NR_munmap),
 #endif
+#ifdef __NR_shmget
+	SC_ALLOW(__NR_shmget),
+#endif
+#ifdef __NR_shmat
+	SC_ALLOW(__NR_shmat),
+#endif
+#ifdef __NR_shmdt
+	SC_ALLOW(__NR_shmdt),
+#endif
 #ifdef __NR_nanosleep
 	SC_ALLOW(__NR_nanosleep),
 #endif


### PR DESCRIPTION
New `wait_random_seeded()` function on OpenSSL 1.1.1d uses `shmget`, `shmat`, and `shmdt`
in the preauth codepath, allow in seccomp_filter sandbox.

Reference for OpenSSL `wait_random_seeded()` function:
https://github.com/openssl/openssl/blob/OpenSSL_1_1_1d/crypto/rand/rand_unix.c#L373

**Without this PR**, tested on x86_64 Linux 3.16.74, with no change in OpenSSH_8.0p1 and switching from OpenSSL 1.1.1c to OpenSSL 1.1.1d, built with the Linux default `--with-sandbox=seccomp_filter`, for `sshd` remote `ssh` connections exit with:
```
fatal: privsep_preauth: preauth child terminated by signal 31
```
A workaround is to build OpenSSH_8.0p1 with `--with-sandbox=rlimit`, the problem goes away.

**This PR** allows OpenSSH_8.0p1 built with `--with-sandbox=seccomp_filter` to work with OpenSSL 1.1.1d.