### PR TITLE
Deny (non-fatal) shmget/shmat/shmdt in preauth privsep child.

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -168,6 +168,15 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_stat64
 	SC_DENY(__NR_stat64, EACCES),
 #endif
+#ifdef __NR_shmget
+	SC_DENY(__NR_shmget, EACCES),
+#endif
+#ifdef __NR_shmat
+	SC_DENY(__NR_shmat, EACCES),
+#endif
+#ifdef __NR_shmdt
+	SC_DENY(__NR_shmdt, EACCES),
+#endif
 
 	/* Syscalls to permit */
 #ifdef __NR_brk


### PR DESCRIPTION
New `wait_random_seeded()` function on OpenSSL 1.1.1d uses `shmget`, `shmat`, and `shmdt`
in the preauth codepath, deny (non-fatal) in seccomp_filter sandbox.

Reference for OpenSSL `wait_random_seeded()` function:
https://github.com/openssl/openssl/blob/OpenSSL_1_1_1d/crypto/rand/rand_unix.c#L373

**Without this PR**, tested on x86_64 Linux 3.16.74, with no change in OpenSSH_8.0p1 and switching from OpenSSL 1.1.1c to OpenSSL 1.1.1d, built with the Linux default `--with-sandbox=seccomp_filter`, for `sshd` remote `ssh` connections exit with:
```
fatal: privsep_preauth: preauth child terminated by signal 31
```
A workaround is to build OpenSSH_8.0p1 with `--with-sandbox=rlimit`, the problem goes away.

**This PR** allows OpenSSH_8.0p1 built with `--with-sandbox=seccomp_filter` to work with OpenSSL 1.1.1d.

Sadly, for the x86_32 case, using `__i386__` the include `asm/unistd_32.h` does not support `__NR_shmget`, etc. . As such, at least for 32-bit Linux 3.16.x  `--with-sandbox=rlimit` is needed to work with the new `wait_random_seeded()` OpenSSL 1.1.1d feature.