### PR TITLE
Initial (pre-alpha) implementation of SSH w/lz4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1260,6 +1260,47 @@ AC_CHECK_FUNC([getspnam], ,
 AC_SEARCH_LIBS([basename], [gen], [AC_DEFINE([HAVE_BASENAME], [1],
 	[Define if you have the basename function.])])
 
+# Check whether user wants to use lz4
+LZ4_MSG="no"
+AC_ARG_WITH(lz4,
+	[  --with-lz4[[=PATH]]      Use lz4 for -C compression (optionally in PATH)],
+	[
+    if test "x$withval" != "xyes" -a "x$withval" != "xno"; then
+        if test -d "$withval/lib"; then
+            if test -n "${rpath_opt}"; then
+                LDFLAGS="-L${withval}/lib ${rpath_opt}${withval}/lib ${LDFLAGS}"
+            else
+                LDFLAGS="-L${withval}/lib ${LDFLAGS}"
+            fi
+        else
+            if test -n "${rpath_opt}"; then
+                LDFLAGS="-L${withval} ${rpath_opt}${withval} ${LDFLAGS}"
+            else
+                LDFLAGS="-L${withval} ${LDFLAGS}"
+            fi
+        fi
+        if test -d "$withval/include"; then
+            CPPFLAGS="-I${withval}/include ${CPPFLAGS}"
+        else
+            CPPFLAGS="-I${withval} ${CPPFLAGS}"
+        fi
+    fi
+    if test "x$withval" != "xno"; then
+        LZ4_MSG="yes"
+		AC_CHECK_HEADER([lz4.h], ,[AC_MSG_ERROR([*** lz4.h missing - please install first or check config.log ***])])
+		AC_CHECK_LIB([lz4], [LZ4_compress_fast_continue], ,
+			[
+				LIBS="$LIBS -llz4"
+				AC_TRY_LINK_FUNC([LZ4_compress], [AC_DEFINE([HAVE_LIBLZ4])],
+					[
+						AC_MSG_ERROR([*** liblz4 missing - please install first or check config.log ***])
+					]
+				)
+			]
+		)
+    fi
+])
+
 dnl zlib is required
 AC_ARG_WITH([zlib],
 	[  --with-zlib=PATH        Use zlib in PATH],
@@ -5221,6 +5262,7 @@ echo "                   SELinux support: $SELINUX_MSG"
 echo "              MD5 password support: $MD5_MSG"
 echo "                   libedit support: $LIBEDIT_MSG"
 echo "                   libldns support: $LDNS_MSG"
+echo "                    liblz4 support: $LZ4_MSG"
 echo "  Solaris process contract support: $SPC_MSG"
 echo "           Solaris project support: $SP_MSG"
 echo "         Solaris privilege support: $SPP_MSG"

--- a/kex.c
+++ b/kex.c
@@ -798,6 +798,11 @@ choose_comp(struct sshcomp *comp, char *client, char *server)
 		return SSH_ERR_NO_COMPRESS_ALG_MATCH;
 	if (strcmp(name, "zlib@openssh.com") == 0) {
 		comp->type = COMP_DELAYED;
+#ifdef COMP_LZ4_DELAYED
+#warning EXPERIMENTAL LZ4 SUPPORT
+	} else if (strcmp(name, "lz4@openssh.com") == 0) {
+		comp->type = COMP_LZ4_DELAYED;
+#endif
 	} else if (strcmp(name, "zlib") == 0) {
 		comp->type = COMP_ZLIB;
 	} else if (strcmp(name, "none") == 0) {

--- a/kex.h
+++ b/kex.h
@@ -68,6 +68,9 @@
 /* pre-auth compression (COMP_ZLIB) is only supported in the client */
 #define COMP_ZLIB	1
 #define COMP_DELAYED	2
+#if HAVE_LIBLZ4
+#define COMP_LZ4_DELAYED	3
+#endif
 
 #define CURVE25519_SIZE 32
 

--- a/myproposal.h
+++ b/myproposal.h
@@ -173,7 +173,13 @@
 
 #endif /* WITH_OPENSSL */
 
-#define	KEX_DEFAULT_COMP	"none,zlib@openssh.com"
+#if HAVE_LIBLZ4
+#define LZ4S "lz4@openssh.com,"
+#else
+#define LZ4S ""
+#endif
+
+#define	KEX_DEFAULT_COMP	"none," LZ4S "zlib@openssh.com"
 #define	KEX_DEFAULT_LANG	""
 
 #define KEX_CLIENT \

--- a/packet.c
+++ b/packet.c
@@ -130,11 +130,8 @@ struct packet {
 };
 
 #if HAVE_LIBLZ4
-// ! Send small packets without compression
-#define LZ4_THRESH 16
-// !!We use negative sizes for uncompressed small packets
-#define LZ4_MSGMAX (32 * 1024 - 1)
-#define LZ4_RINGSIZE (96 * 1024)
+#define LZ4_MSGMAX (32 * 1024)
+#define LZ4_RINGSIZE (64 * 1024)
 struct LZ4_state {
 	uint32_t c_off;
 	uint32_t d_off;
@@ -821,9 +818,8 @@ compress_buffer(struct ssh *ssh, struct sshbuf *in, struct sshbuf *out)
 
 	int r, status;
 #if HAVE_LIBLZ4
-	u_int comptype;
-	int16_t nsize;
-	int isize, osize;
+	u_int comptype, isize;
+	uint16_t osize;
 	struct LZ4_state *z4s;
 	char *buf_out;
 #endif
@@ -876,21 +872,13 @@ compress_buffer(struct ssh *ssh, struct sshbuf *in, struct sshbuf *out)
 		do {
 			isize = MIN(ssh->state->compression_out_stream.avail_in,
 			            LZ4_MSGMAX);
-			if (isize > LZ4_THRESH) {
-				buf_out = z4s->c_buf + z4s->c_off;
-				memcpy(buf_out,
-				       ssh->state->compression_out_stream.next_in,
-				       ssh->state->compression_out_stream.avail_in);
-				z4s->c_off += ssh->state->compression_out_stream.avail_in;
-				osize = LZ4_compress_fast_continue(&z4s->lz4Stream,
-				  buf_out, z4buf, isize, sizeof(z4buf), 1);
-				nsize = osize;
-				buf_out = z4buf;
-			} else {
-				buf_out = ssh->state->compression_out_stream.next_in;
-				osize = isize;
-				nsize = -isize;
-			}
+			buf_out = z4s->c_buf + z4s->c_off;
+			memcpy(buf_out,
+			       ssh->state->compression_out_stream.next_in,
+			       ssh->state->compression_out_stream.avail_in);
+			z4s->c_off += ssh->state->compression_out_stream.avail_in;
+			osize = LZ4_compress_fast_continue(&z4s->lz4Stream,
+			  buf_out, z4buf, isize, sizeof(z4buf), 1);
 			/* TODO: Error check */
 			ssh->state->compression_out_stream.avail_in -= isize;
 			ssh->state->compression_out_stream.next_in += isize;
@@ -898,15 +886,14 @@ compress_buffer(struct ssh *ssh, struct sshbuf *in, struct sshbuf *out)
 			ssh->state->compression_out_stream.total_out += osize
 			    + SIZEOF_SHORT_INT;
 			// We have to do framing here; LZ4 packet out: [uint16 len][data]
-			nsize = htons(nsize);
-			if (sshbuf_put(out, &nsize, sizeof(nsize)) != 0)
+			osize = htons(osize);
+			if (sshbuf_put(out, &osize, sizeof(osize)) != 0)
 				return SSH_ERR_ALLOC_FAIL;
-			if ((r = sshbuf_put(out, buf_out, osize)) != 0)
+			osize = ntohs(osize);
+			if ((r = sshbuf_put(out, z4buf, osize)) != 0)
 				return r;
 			if (z4s->c_off > (LZ4_RINGSIZE - LZ4_MSGMAX))
 				z4s->c_off = 0;
-			if (ssh->state->compression_out_stream.avail_in)
-				debug("More than one packet...");
 		} while (ssh->state->compression_out_stream.avail_in > 0);
 		break;
 	}
@@ -920,10 +907,8 @@ uncompress_buffer(struct ssh *ssh, struct sshbuf *in, struct sshbuf *out)
 	u_char buf[4096];
 	int r, status;
 #if HAVE_LIBLZ4
-	u_int comptype;
-	int16_t nsize;
-	int osize;
-	u_int isize;
+	uint16_t comptype, isize;
+	uint16_t osize;
 	struct LZ4_state *z4s;
 	char *buf_dec;
 #endif
@@ -981,13 +966,9 @@ uncompress_buffer(struct ssh *ssh, struct sshbuf *in, struct sshbuf *out)
 			if (ssh->state->compression_in_stream.avail_in < SIZEOF_SHORT_INT)
 				return 0;
 			// No guarantees on alignment of next_in; access as bytes.
-			nsize = get16(ssh->state->compression_in_stream.next_in);
-			nsize = ntohs(nsize);
-			
-			if (nsize < 0)
-				isize = -nsize;
-			else
-				isize = nsize;
+			isize = get16(ssh->state->compression_in_stream.next_in);
+			isize = ntohs(isize);
+
 			if (ssh->state->compression_in_stream.avail_in < 
 			    SIZEOF_SHORT_INT + isize)
 				return 0;
@@ -995,20 +976,16 @@ uncompress_buffer(struct ssh *ssh, struct sshbuf *in, struct sshbuf *out)
 			ssh->state->compression_in_stream.next_in += SIZEOF_SHORT_INT;
 			ssh->state->compression_in_stream.avail_in -= SIZEOF_SHORT_INT;
 
-			if (nsize > 0) {
-				buf_dec = z4s->d_buf + z4s->d_off;
-				osize = LZ4_decompress_safe_continue(&z4s->lz4Decode,
-				  ssh->state->compression_in_stream.next_in,
-				  buf_dec, isize, LZ4_MSGMAX);
-				/* TODO: Error check */
-				
-				z4s->d_off += osize;
-				if (z4s->d_off > (LZ4_RINGSIZE - LZ4_MSGMAX))
-					z4s->d_off = 0;
-			} else {
-				buf_dec = ssh->state->compression_in_stream.next_in;
-				osize = isize;
-			}
+			buf_dec = z4s->d_buf + z4s->d_off;
+
+			osize = LZ4_decompress_safe_continue(&z4s->lz4Decode,
+			  ssh->state->compression_in_stream.next_in,
+			  buf_dec, isize, LZ4_MSGMAX);
+			/* TODO: Error check */
+			
+			z4s->d_off += osize;
+			if (z4s->d_off > (LZ4_RINGSIZE - LZ4_MSGMAX))
+				z4s->d_off = 0;
 
 			ssh->state->compression_in_stream.next_in += isize;
 			ssh->state->compression_in_stream.avail_in -= isize;

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -173,7 +173,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port)
 	    compat_cipher_proposal(options.ciphers);
 	myproposal[PROPOSAL_COMP_ALGS_CTOS] =
 	    myproposal[PROPOSAL_COMP_ALGS_STOC] = options.compression ?
-	    "zlib@openssh.com,zlib,none" : "none,zlib@openssh.com,zlib";
+	    LZ4S "zlib@openssh.com,zlib,none" : "none," LZ4S "zlib@openssh.com,zlib";
 	myproposal[PROPOSAL_MAC_ALGS_CTOS] =
 	    myproposal[PROPOSAL_MAC_ALGS_STOC] = options.macs;
 	if (options.hostkeyalgorithms != NULL) {


### PR DESCRIPTION
This is not ready to be merged, but just thought I would put it out there to gauge interest.

Replaces zlib with lz4 as the compression used if available on both sides; otherwise backwards compatible.

Needs more work, just posting this up in case someone else is interested in helping out / has more experience with openssh internals.

Seems to function at this point. Textual input actually grows due to lots of tiny packets, and lz4 streaming properties. Need to consider what to do about this (send tiny packets uncompressed with just a size header? May not be worth the extra complexity since these very small packets will be dominated by other (network latency) timings anyway...

But this has very low (CPU) overhead compared to zlib for many reasonable compression on many streams. A quick test on my 2.3 GHz i5 is 4x faster when CPU bound.