### PR TITLE
Deny (non-fatal) ipc in preauth privsep child.

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -177,6 +177,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_shmdt
 	SC_DENY(__NR_shmdt, EACCES),
 #endif
+#ifdef __NR_ipc
+	SC_DENY(__NR_ipc, EACCES),
+#endif
 
 	/* Syscalls to permit */
 #ifdef __NR_brk


### PR DESCRIPTION
As noted in openssh/openssh-portable#149, i386 does not have have
_NR_shmget etc.  Instead, it has a single ipc syscall (see man 2 ipc,
https://linux.die.net/man/2/ipc).  Add this syscall, if present, to the
list of syscalls that seccomp will deny non-fatally.