### PR TITLE
U2f mnemonic

### DIFF
--- a/ssh-keygen.1
+++ b/ssh-keygen.1
@@ -51,7 +51,7 @@
 .Op Fl t Cm dsa | ecdsa | ecdsa-sk | ed25519 | rsa
 .Op Fl N Ar new_passphrase
 .Op Fl w Ar provider
-.Op Fl x Ar flags
+.Op Fl x Cm no_up
 .Nm ssh-keygen
 .Fl p
 .Op Fl f Ar keyfile
@@ -666,9 +666,10 @@ Specify desired generator when testing candidate moduli for DH-GEX.
 Specifies a path to a security key provider library that will be used when
 creating any security key-hosted keys, overriding the default of the
 internal support for USB HID keys.
-.It Fl x Ar flags
+.It Fl x Cm no_up
 Specifies the security key flags to use when enrolling a security key-hosted
-key.
+key. Currently only "no_up" is supported, which disables the user-presence
+requirement to use the key.
 .It Fl y
 This option will read a private
 OpenSSH format file and print an OpenSSH public key to stdout.

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -2793,7 +2793,7 @@ main(int argc, char **argv)
 	int gen_all_hostkeys = 0, gen_krl = 0, update_krl = 0, check_krl = 0;
 	int prefer_agent = 0, convert_to = 0, convert_from = 0;
 	int print_public = 0, print_generic = 0, cert_serial_autoinc = 0;
-	unsigned long long ull, cert_serial = 0;
+	unsigned long long cert_serial = 0;
 	char *identity_comment = NULL, *ca_key_path = NULL;
 	u_int32_t bits = 0;
 	FILE *f;

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -3000,14 +3000,12 @@ main(int argc, char **argv)
 		case 'x':
 			if (*optarg == '\0')
 				fatal("Missing security key flags");
-			ull = strtoull(optarg, &ep, 0);
-			if (*ep != '\0')
-				fatal("Security key flags \"%s\" is not a "
-				    "number", optarg);
-			if (ull > 0xff)
-				fatal("Invalid security key flags 0x%llx", ull);
 #ifdef ENABLE_SK
-			sk_flags = (uint8_t)ull;
+			if (strcasecmp(optarg, "no_up") == 0){
+				sk_flags = sk_flags & ~SSH_SK_USER_PRESENCE_REQD;
+			}else{
+				fatal("Unsupported U2F option \"%s\"", optarg);
+			}
 #endif
 			break;
 		case 'z':


### PR DESCRIPTION
Update the U2F `-x` option to use a string argument instead of raw flag numbers. Also fixes an issue with "x" being defined twice in ```getopt```. The flag is named `no_up` to disable the user-presence requirement when signing.