### PR TITLE
seccomp: Allow clock_gettime64() in sandbox.

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -248,6 +248,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_clock_nanosleep_time64
 	SC_ALLOW(__NR_clock_nanosleep_time64),
 #endif
+#ifdef __NR_clock_gettime64
+	SC_ALLOW(__NR_clock_gettime64),
+#endif
 #ifdef __NR__newselect
 	SC_ALLOW(__NR__newselect),
 #endif


### PR DESCRIPTION
This helps sshd accept connections on mips platforms with
upcoming glibc ( 2.31 )