### PR TITLE
Fix building on MacOS without openssl

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -56,6 +56,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/ssh-ecdsa-sk.c
+++ b/ssh-ecdsa-sk.c
@@ -31,10 +31,12 @@
 
 #include <sys/types.h>
 
+#ifdef WITH_OPENSSL
 #include <openssl/bn.h>
 #include <openssl/ec.h>
 #include <openssl/ecdsa.h>
 #include <openssl/evp.h>
+#endif
 
 #include <string.h>
 #include <stdio.h> /* needed for DEBUG_SK only */


### PR DESCRIPTION
(cd openbsd-compat && /Library/Developer/CommandLineTools/usr/bin/make)
make[1]: Nothing to be done for `all'.
cc -g -O2 -pipe -Wunknown-warning-option -Qunused-arguments -Wall -Wpointer-arith -Wuninitialized -Wsign-compare -Wformat-security -Wsizeof-pointer-memaccess -Wno-pointer-sign -Wno-unused-result -Wimplicit-fallthrough -fno-strict-aliasing -mretpoline -D_FORTIFY_SOURCE=2 -ftrapv -fno-builtin-memset -fstack-protector-strong -fPIE   -I. -I.  -DSSHDIR=\"/usr/local/etc\" -D_PATH_SSH_PROGRAM=\"/usr/local/bin/ssh\" -D_PATH_SSH_ASKPASS_DEFAULT=\"/usr/local/libexec/ssh-askpass\" -D_PATH_SFTP_SERVER=\"/usr/local/libexec/sftp-server\" -D_PATH_SSH_KEY_SIGN=\"/usr/local/libexec/ssh-keysign\" -D_PATH_SSH_PKCS11_HELPER=\"/usr/local/libexec/ssh-pkcs11-helper\" -D_PATH_SSH_SK_HELPER=\"/usr/local/libexec/ssh-sk-helper\" -D_PATH_SSH_PIDDIR=\"/var/run\" -D_PATH_PRIVSEP_CHROOT_DIR=\"/var/empty\" -DHAVE_CONFIG_H -c ssh-ecdsa-sk.c -o ssh-ecdsa-sk.o
ssh-ecdsa-sk.c:34:10: fatal error: 'openssl/bn.h' file not found
         ^~~~~~~~~~~~~~
1 error generated.
make: *** [ssh-ecdsa-sk.o] Error 1