### PR TITLE
Fix missing prototype warning

### DIFF
--- a/session.c
+++ b/session.c
@@ -974,11 +974,13 @@ copy_environment_blacklist(char **source, char ***env, u_int *envsize,
 	}
 }
 
-void
+#ifdef HAVE_CYGWIN
+static void
 copy_environment(char **source, char ***env, u_int *envsize)
 {
 	copy_environment_blacklist(source, env, envsize, NULL);
 }
+#endif
 
 static char **
 do_setup_env(struct ssh *ssh, Session *s, const char *shell)


### PR DESCRIPTION
This function is only used in this file, and only on Cygwin,
so make it static and hide it behind HAVE_CYGWIN

Fixes:
session.c:978:1: warning: no previous prototype for function 'copy_environment' [-Wmissing-prototypes]
copy_environment(char **source, char ***env, u_int *envsize)