### PR TITLE
sandbox-darwin.c: fix missing prototypes

### DIFF
--- a/sandbox-darwin.c
+++ b/sandbox-darwin.c
@@ -30,7 +30,7 @@
 #include <unistd.h>
 
 #include "log.h"
-#include "sandbox.h"
+#include "ssh-sandbox.h"
 #include "monitor.h"
 #include "xmalloc.h"
 


### PR DESCRIPTION
Include the right header just like the other sandbox files.

Fixes:
cc -g -O2 -pipe -Wunknown-warning-option -Qunused-arguments -Wall -Wpointer-arith -Wuninitialized -Wsign-compare -Wformat-security -Wsizeof-pointer-memaccess -Wno-pointer-sign -Wno-unused-result -Wimplicit-fallthrough -fno-strict-aliasing -Wno-deprecated-declarations -Wmissing-prototypes -mretpoline -D_FORTIFY_SOURCE=2 -ftrapv -fno-builtin-memset   -I. -I. -I/usr/local/opt/openssl@1.1/include    -DSSHDIR=\"/usr/local/etc\" -D_PATH_SSH_PROGRAM=\"/usr/local/bin/ssh\" -D_PATH_SSH_ASKPASS_DEFAULT=\"/usr/local/libexec/ssh-askpass\" -D_PATH_SFTP_SERVER=\"/usr/local/libexec/sftp-server\" -D_PATH_SSH_KEY_SIGN=\"/usr/local/libexec/ssh-keysign\" -D_PATH_SSH_PKCS11_HELPER=\"/usr/local/libexec/ssh-pkcs11-helper\" -D_PATH_SSH_SK_HELPER=\"/usr/local/libexec/ssh-sk-helper\" -D_PATH_SSH_PIDDIR=\"/var/run\" -D_PATH_PRIVSEP_CHROOT_DIR=\"/var/empty\" -DHAVE_CONFIG_H -c sandbox-darwin.c -o sandbox-darwin.o
sandbox-darwin.c:44:1: warning: no previous prototype for function 'ssh_sandbox_init' [-Wmissing-prototypes]
ssh_sandbox_init(struct monitor *monitor)
^
sandbox-darwin.c:60:1: warning: no previous prototype for function 'ssh_sandbox_child' [-Wmissing-prototypes]
ssh_sandbox_child(struct ssh_sandbox *box)
^
sandbox-darwin.c:87:1: warning: no previous prototype for function 'ssh_sandbox_parent_finish' [-Wmissing-prototypes]
ssh_sandbox_parent_finish(struct ssh_sandbox *box)
^
sandbox-darwin.c:94:1: warning: no previous prototype for function 'ssh_sandbox_parent_preauth' [-Wmissing-prototypes]
ssh_sandbox_parent_preauth(struct ssh_sandbox *box, pid_t child_pid)
^
4 warnings generated.