### PR TITLE
auth-pam.c: fix missing prototype

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -300,7 +300,7 @@ sshpam_chauthtok_ruid(pam_handle_t *pamh, int flags)
 # define pam_chauthtok(a,b)	(sshpam_chauthtok_ruid((a), (b)))
 #endif
 
-void
+static void
 sshpam_password_change_required(int reqd)
 {
 	extern struct sshauthopt *auth_opts;


### PR DESCRIPTION
The function is only used in this file, so make it static.
Fixes:
1 warning generated.
auth-pam.c:304:1: warning: no previous prototype for function 'sshpam_password_change_required' [-Wmissing-prototypes]
sshpam_password_change_required(int reqd)
^
1 warning generated.