### PR TITLE
configure.ac: fix ldns test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1533,8 +1533,6 @@ AC_ARG_WITH(ldns,
 	if test "x$withval" = "xyes" ; then
 		AC_PATH_TOOL([LDNSCONFIG], [ldns-config], [no])
 		if test "x$LDNSCONFIG" = "xno"; then
-			CPPFLAGS="$CPPFLAGS -I${withval}/include"
-			LDFLAGS="$LDFLAGS -L${withval}/lib"
 			LIBS="-lldns $LIBS"
 			ldns=yes
 		else


### PR DESCRIPTION
When running ./configure --with-ldns, if ldns-config cannot be found, we
add -Iyes/include to CPPFLAGS and -Lyes/lib to LDFLAGS. Fix that.