### PR TITLE
Update default CASignatureAlgorithms in ssh_config.5/sshd_config.5

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -364,7 +364,8 @@ by certificate authorities (CAs).
 The default is:
 .Bd -literal -offset indent
 ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
-ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+sk-ecdsa-sha2-nistp256@openssh.com,ssh-ed25519,
+sk-ssh-ed25519@openssh.com,rsa-sha2-512,rsa-sha2-256
 .Ed
 .Pp
 .Xr ssh 1

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -380,7 +380,8 @@ by certificate authorities (CAs).
 The default is:
 .Bd -literal -offset indent
 ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
-ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
+sk-ecdsa-sha2-nistp256@openssh.com,ssh-ed25519,
+sk-ssh-ed25519@openssh.com,rsa-sha2-512,rsa-sha2-256
 .Ed
 .Pp
 Certificates signed using other algorithms will not be accepted for


### PR DESCRIPTION
Update doc references to `CASignatureAlgorithms` to match `SSH_ALLOWED_CA_SIGALGS` changes in c3368a5d5ec368ef6bdf9971d6330ca0e3bdca06