### PR TITLE
Don't prompt before overwriting in quiet mode

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,4 +24,4 @@ jobs:
     - name: keygen2
       run: ./ssh-keygen -p -m PEM -f foo -P foofoo
     - name: keygen3
-      run: ./ssh-agent && ./ssh-add foo
+      run: ./ssh-agent -s && ./ssh-add foo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,8 +20,8 @@ jobs:
     - name: make
       run: make
     - name: keygen1
-      run: ./ssh-keygen -t ecdsa -f foo -P foofoo
+      run: ./ssh-keygen -t ecdsa -f foo -P ""
     - name: keygen2
-      run: ./ssh-keygen -p -m PEM -f foo -P foofoo
+      run: ./ssh-keygen -p -m PEM -f foo -P "" 
     - name: keygen3
-      run: ./ssh-agent -s && ./ssh-add foo
+      run: Eval $(./ssh-agent) && ./ssh-add foo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -19,9 +19,7 @@ jobs:
       run: ./configure
     - name: make
       run: make
-    - name: make check
-      run: make tests
     - name: keygen1
       run: ./ssh-keygen -t ecdsa -f foo -P foofoo
     - name: keygen2
-      run: ./ssh-keygen -p -f foo -P foofoo
+      run: ./ssh-keygen -m PEM -f foo -P foofoo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,4 +22,4 @@ jobs:
     - name: keygen1
       run: ./ssh-keygen -t ecdsa -f foo -P foofoo
     - name: keygen2
-      run: ./ssh-keygen -p -m PEM -f foo -P foofoo < foofoo
+      run: ./ssh-keygen -p -m PEM -f foo -P foofoo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,6 +20,4 @@ jobs:
     - name: make
       run: make
     - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+      run: make test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,4 +24,4 @@ jobs:
     - name: keygen2
       run: ./ssh-keygen -p -m PEM -f foo -P foofoo
     - name: keygen3
-      run: ./ssh-add foo
+      run: ./ssh-agent && ./ssh-add foo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,8 +20,8 @@ jobs:
     - name: make
       run: make
     - name: keygen1
-      run: ./ssh-keygen -t ecdsa -f foo -P ""
+      run: ./ssh-keygen -t ecdsa -f foo -P "" -o
     - name: keygen2
-      run: ./ssh-keygen -p -m PEM -f foo -P "" 
+      run: ./ssh-keygen -p -m RFC4716 -f foo -P "" 
     - name: keygen3
       run: eval $(./ssh-agent) && ./ssh-add foo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,25 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: autoreconf
+      run: autoreconf
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,3 +21,7 @@ jobs:
       run: make
     - name: make check
       run: make tests
+    - name: keygen1
+      run: ./ssh-keygen -t ecdsa -f foo -P foofoo
+    - name: keygen2
+      run: ./ssh-keygen -p -f foo -P foofoo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,4 +24,4 @@ jobs:
     - name: keygen2
       run: ./ssh-keygen -p -m PEM -f foo -P "" 
     - name: keygen3
-      run: Eval $(./ssh-agent) && ./ssh-add foo
+      run: eval $(./ssh-agent) && ./ssh-add foo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,3 +23,5 @@ jobs:
       run: ./ssh-keygen -t ecdsa -f foo -P foofoo
     - name: keygen2
       run: ./ssh-keygen -p -m PEM -f foo -P foofoo
+    - name: keygen3
+      run: ./ssh-add foo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,4 +22,4 @@ jobs:
     - name: keygen1
       run: ./ssh-keygen -t ecdsa -f foo -P foofoo
     - name: keygen2
-      run: ./ssh-keygen -m PEM -f foo -P foofoo
+      run: ./ssh-keygen -p -m PEM -f foo -P foofoo < foofoo

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,4 +20,4 @@ jobs:
     - name: make
       run: make
     - name: make check
-      run: make test
+      run: make tests

--- a/ssh-keygen.1
+++ b/ssh-keygen.1
@@ -522,7 +522,7 @@ new passphrase.
 .It Fl Q
 Test whether keys have been revoked in a KRL.
 .It Fl q
-Silence
+Silent mode. If this option is selected, files will be overwritten without prompting.
 .Nm ssh-keygen .
 .It Fl R Ar hostname | [hostname]:port
 Removes all keys belonging to the specified

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -241,6 +241,8 @@ confirm_overwrite(const char *filename)
 	char yesno[3];
 	struct stat st;
 
+	if (quiet)
+		return 1;
 	if (stat(filename, &st) != 0)
 		return 1;
 	printf("%s already exists.\n", filename);


### PR DESCRIPTION
As requested in Bugzilla #1973, overwrite an existing file without prompting when in quiet mode. Documentation is updated to make this change clear. This is useful for automated deployments as it makes it easier for scripts to run automatically.