### PR TITLE
Don't prompt before overwriting in quiet mode

### DIFF
--- a/ssh-keygen.1
+++ b/ssh-keygen.1
@@ -522,7 +522,7 @@ new passphrase.
 .It Fl Q
 Test whether keys have been revoked in a KRL.
 .It Fl q
-Silence
+Silent mode. If this option is selected, files will be overwritten without prompting.
 .Nm ssh-keygen .
 .It Fl R Ar hostname | [hostname]:port
 Removes all keys belonging to the specified

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -241,6 +241,8 @@ confirm_overwrite(const char *filename)
 	char yesno[3];
 	struct stat st;
 
+	if (quiet)
+		return 1;
 	if (stat(filename, &st) != 0)
 		return 1;
 	printf("%s already exists.\n", filename);


### PR DESCRIPTION
As requested in Bugzilla #1973, overwrite an existing file without prompting when in quiet mode. Documentation is updated to make this change clear. This is useful for automated deployments as it makes it easier for scripts to run automatically.