### PR TITLE
Print comment when converting from/to RFC4716. Bugzilla #2180

### DIFF
--- a/authfile.c
+++ b/authfile.c
@@ -224,9 +224,8 @@ sshkey_try_load_public(struct sshkey *k, const char *filename, char **commentp)
 		if (*cp) {
 			if ((r = sshkey_read(k, &cp)) == 0) {
 				cp[strcspn(cp, "\r\n")] = '\0';
-				if (commentp) {
-					*commentp = strdup(*cp ?
-					    cp : filename);
+				if (commentp && *cp) {
+					*commentp = strdup(cp);
 					if (*commentp == NULL)
 						r = SSH_ERR_ALLOC_FAIL;
 				}

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -150,7 +150,11 @@ t2:
 
 t3:
 	${TEST_SSH_SSHKEYGEN} -ef ${.CURDIR}/rsa_openssh.pub >$(OBJ)/t3.out
-	${TEST_SSH_SSHKEYGEN} -if $(OBJ)/t3.out | diff - ${.CURDIR}/rsa_openssh.pub
+	# rsa_openssh.pub does not contain a comment, so only check
+	# that algorithm and key match
+	${TEST_SSH_SSHKEYGEN} -if $(OBJ)/t3.out |\
+		awk 'BEGIN { FS="[ ]" } ; { print $$1 " " $$2 }' |\
+		diff - ${.CURDIR}/rsa_openssh.pub
 
 t4:
 	${TEST_SSH_SSHKEYGEN} -E md5 -lf ${.CURDIR}/rsa_openssh.pub |\
@@ -164,7 +168,22 @@ t6:
 	${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/dsa_ssh2.prv > $(OBJ)/t6.out1
 	${TEST_SSH_SSHKEYGEN} -if ${.CURDIR}/dsa_ssh2.pub > $(OBJ)/t6.out2
 	chmod 600 $(OBJ)/t6.out1
-	${TEST_SSH_SSHKEYGEN} -yf $(OBJ)/t6.out1 | diff - $(OBJ)/t6.out2
+	cat $(OBJ)/t6.out2 |\
+	grep "1024-bit dsa, Tue Jan 08 2002 22:00:23 +0100"
+	# dsa_ssh2.prv does not contain a comment, so only check
+	# that algorithm and key match
+	cat $(OBJ)/t6.out2 |\
+	awk 'BEGIN { FS="[ ]" } ; { print $$1 " " $$2 }' > $(OBJ)/t6.tmp
+	mv $(OBJ)/t6.tmp $(OBJ)/t6.out2
+	${TEST_SSH_SSHKEYGEN} -yf $(OBJ)/t6.out1 |\
+	diff - $(OBJ)/t6.out2
+	# check that the Comment field is preserved on conversion
+	# when it is not surrounded by double-quotes
+	cat ${.CURDIR}/dsa_ssh2.pub | sed 's/"//g' | tee $(OBJ)/t6.tmp
+	${TEST_SSH_SSHKEYGEN} -if $(OBJ)/t6.tmp > $(OBJ)/t6.out2
+	rm $(OBJ)/t6.tmp
+	cat $(OBJ)/t6.out2 |\
+	grep "1024-bit dsa, Tue Jan 08 2002 22:00:23 +0100"
 
 $(OBJ)/t7.out:
 	${TEST_SSH_SSHKEYGEN} -q -t rsa -N '' -f $@
@@ -207,6 +226,8 @@ $(OBJ)/t12.out:
 
 t12: $(OBJ)/t12.out
 	${TEST_SSH_SSHKEYGEN} -lf $(OBJ)/t12.out.pub | grep test-comment-1234 >/dev/null
+	${TEST_SSH_SSHKEYGEN} -f $(OBJ)/t12.out.pub -e -m RFC4716 |\
+	grep "Comment: \"test-comment-1234\""
 
 t-exec:	${LTESTS:=.sh}
 	@if [ "x$?" = "x" ]; then exit 0; fi; \

--- a/regress/keygen-convert.sh
+++ b/regress/keygen-convert.sh
@@ -33,6 +33,11 @@ for t in $types; do
 	    fail "$t import rfc4716 public"
 
 	cut -f1,2 -d " " $OBJ/$t-key.pub >$OBJ/$t-key-nocomment.pub
+	cat $OBJ/$t-rfc-imported |\
+	awk 'BEGIN { FS="[ ]" } ; { print $1 " " $2 }' > \
+	$OBJ/$t-rfc-imported.tmp
+	mv $OBJ/$t-rfc-imported.tmp $OBJ/$t-rfc-imported
+	cat $OBJ/$t-rfc-imported
 	cmp $OBJ/$t-key-nocomment.pub $OBJ/$t-rfc-imported || \
 	    fail "$t imported differs from original"
 

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -340,7 +340,7 @@ load_identity(const char *filename, char **commentp)
 
 #ifdef WITH_OPENSSL
 static void
-do_convert_to_ssh2(struct passwd *pw, struct sshkey *k)
+do_convert_to_ssh2(struct passwd *pw, struct sshkey *k, char *commentp)
 {
 	struct sshbuf *b;
 	char comment[61], *b64;
@@ -354,10 +354,14 @@ do_convert_to_ssh2(struct passwd *pw, struct sshkey *k)
 		fatal("%s: sshbuf_dtob64_string failed", __func__);
 
 	/* Comment + surrounds must fit into 72 chars (RFC 4716 sec 3.3) */
-	snprintf(comment, sizeof(comment),
-	    "%u-bit %s, converted by %s@%s from OpenSSH",
-	    sshkey_size(k), sshkey_type(k),
-	    pw->pw_name, hostname);
+	if (commentp != NULL) {
+		strlcpy(comment, commentp, 61);
+	} else {
+		snprintf(comment, sizeof(comment),
+		    "%u-bit %s, converted by %s@%s from OpenSSH",
+		    sshkey_size(k), sshkey_type(k),
+	 	   pw->pw_name, hostname);
+	}
 
 	sshkey_free(k);
 	sshbuf_free(b);
@@ -423,16 +427,17 @@ do_convert_to(struct passwd *pw)
 	struct sshkey *k;
 	struct stat st;
 	int r;
+	char *comment = NULL;
 
 	if (!have_identity)
 		ask_filename(pw, "Enter file in which the key is");
 	if (stat(identity_file, &st) == -1)
 		fatal("%s: %s: %s", __progname, identity_file, strerror(errno));
-	if ((r = sshkey_load_public(identity_file, &k, NULL)) != 0)
+	if ((r = sshkey_load_public(identity_file, &k, &comment)) != 0)
 		k = load_identity(identity_file, NULL);
 	switch (convert_format) {
 	case FMT_RFC4716:
-		do_convert_to_ssh2(pw, k);
+		do_convert_to_ssh2(pw, k, comment);
 		break;
 	case FMT_PKCS8:
 		do_convert_to_pkcs8(k);
@@ -627,13 +632,14 @@ get_line(FILE *fp, char *line, size_t len)
 }
 
 static void
-do_convert_from_ssh2(struct passwd *pw, struct sshkey **k, int *private)
+do_convert_from_ssh2(struct passwd *pw, struct sshkey **k, char **comment, int *private)
 {
 	int r, blen, escaped = 0;
 	u_int len;
 	char line[1024];
 	struct sshbuf *buf;
 	char encoded[8096];
+	char *com_start, *com_end;
 	FILE *fp;
 
 	if ((buf = sshbuf_new()) == NULL)
@@ -650,6 +656,18 @@ do_convert_from_ssh2(struct passwd *pw, struct sshkey **k, int *private)
 				*private = 1;
 			if (strstr(line, " END ") != NULL) {
 				break;
+			}
+			if (strncmp(line, "Comment: ", 9) == 0 && blen > 9) {
+				com_start = line + 9;
+				if (*com_start == '\"') {
+					com_start++;
+				}
+				com_end = strchr(com_start, '\"');
+				if (com_end != NULL) {
+					*comment = strndup(com_start, com_end - com_start);
+				} else {
+					*comment = xstrdup(com_start);
+				}
 			}
 			/* fprintf(stderr, "ignore: %s", line); */
 			continue;
@@ -745,6 +763,7 @@ do_convert_from(struct passwd *pw)
 	struct sshkey *k = NULL;
 	int r, private = 0, ok = 0;
 	struct stat st;
+	char *comment = NULL;
 
 	if (!have_identity)
 		ask_filename(pw, "Enter file in which the key is");
@@ -753,7 +772,7 @@ do_convert_from(struct passwd *pw)
 
 	switch (convert_format) {
 	case FMT_RFC4716:
-		do_convert_from_ssh2(pw, &k, &private);
+		do_convert_from_ssh2(pw, &k, &comment, &private);
 		break;
 	case FMT_PKCS8:
 		do_convert_from_pkcs8(&k, &private);
@@ -768,8 +787,13 @@ do_convert_from(struct passwd *pw)
 	if (!private) {
 		if ((r = sshkey_write(k, stdout)) == 0)
 			ok = 1;
-		if (ok)
+		if (ok) {
+			if (comment != NULL) {
+				fprintf(stdout, " %s", comment);
+				free(comment);
+			}
 			fprintf(stdout, "\n");
+		}
 	} else {
 		switch (k->type) {
 		case KEY_DSA:


### PR DESCRIPTION
As reported in Bugzilla #2180, preserve the comment field when converting public keys from and to RFC4716 format, On export to RFC4716, this change will preserve a comment if one exists or if not, keep the standard user@host comment. On import, it will keep a comment if one exists.

RFC4716 sec 3 does allow multi-line comments indicated by a '\', however as supporting that would require a larger code change I haven't included support for it here. If multi-line comments are desirable I'm happy to implement them next.

Some existing unit tests have been change to only check the algorithm and key, as the user@host comment will change per machine. New unit tests are added to test the new comment features.