### PR TITLE
Let SSH check usernames by itself when possible

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -907,10 +907,6 @@ toremote(int argc, char **argv)
 			goto out;
 		}
 	}
-	if (tuser != NULL && !okname(tuser)) {
-		++errs;
-		goto out;
-	}
 
 	/* Parse source files */
 	for (i = 0; i < argc - 1; i++) {
@@ -925,10 +921,6 @@ toremote(int argc, char **argv)
 		}
 		if (r != 0) {
 			parse_user_host_path(argv[i], &suser, &host, &src);
-		}
-		if (suser != NULL && !okname(suser)) {
-			++errs;
-			continue;
 		}
 		if (host && throughlocal) {	/* extended remote to remote */
 			xasprintf(&bp, "%s -f %s%s", cmd,
@@ -945,6 +937,10 @@ toremote(int argc, char **argv)
 			(void) close(remout);
 			remin = remout = -1;
 		} else if (host) {	/* standard remote to remote */
+			if (tuser != NULL && !okname(tuser)) {
+				++errs;
+				break;
+			}
 			if (tport != -1 && tport != SSH_DEFAULT_PORT) {
 				/* This would require the remote support URIs */
 				fatal("target port not supported with two "
@@ -1023,10 +1019,6 @@ tolocal(int argc, char **argv)
 		}
 		if (r != 0)
 			parse_user_host_path(argv[i], &suser, &host, &src);
-		if (suser != NULL && !okname(suser)) {
-			++errs;
-			continue;
-		}
 		if (!host) {	/* Local to local. */
 			freeargs(&alist);
 			addargs(&alist, "%s", _PATH_CP);


### PR DESCRIPTION
This allows `scp file.txt Администратор@example.com`.
And even ``scp file.txt 'А`echo`Б'@example.com``.
It works for
* local to remote
* remote to local
* extended (-3) remote to remote

It doesn't work for simple remote to remote because command is passed as a string. I'm sure it can be fixed by escaping. But new PR is better probably. For now username is still limited for simple remote to remote case.