### PR TITLE
agent: support receiving multiple messages in a single recv()

### DIFF
--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -822,7 +822,7 @@ process_message(u_int socknum)
 			/* send a fail message for all other request types */
 			send_status(e, 0);
 		}
-		return 0;
+		return 1;
 	}
 
 	switch (type) {
@@ -866,7 +866,7 @@ process_message(u_int socknum)
 		send_status(e, 0);
 		break;
 	}
-	return 0;
+	return 1;
 }
 
 static void
@@ -957,7 +957,7 @@ handle_conn_read(u_int socknum)
 	if ((r = sshbuf_put(sockets[socknum].input, buf, len)) != 0)
 		fatal("%s: buffer error: %s", __func__, ssh_err(r));
 	explicit_bzero(buf, sizeof(buf));
-	process_message(socknum);
+	while(process_message(socknum) > 0);
 	return 0;
 }
 


### PR DESCRIPTION
The agent support receiving partial messages, but when it receives multiple messages in a single recv() call, the remaining messages are buffered instead of responded to.

This is probably best demonstrated with the following simple python program which sends 2 packets in one send() and waits for responses.  Without this patch, only one response ever arrives.

```
import socket
import struct
import os

s = socket.socket(socket.AF_UNIX)
s.connect(os.environ['SSH_AUTH_SOCK'])
msg = struct.pack('!Ib', 1, 11)
s.send(msg + msg)

for i in range(2):
	p = s.recv(4)
	l = struct.unpack('!I', p)[0]
	m = s.recv(l)
	t = struct.unpack('b', m[0])[0]
	print("Received a message of type %d and length %d" % (t, l))4

$ SSH_AUTH_SOCK=/path/to/original/agent python sshtest.py
Received a message of type 12 and length 317
[ ... hangs until ^C is hit ]

$ SSH_AUTH_SOCK=/path/to/patched/agent python sshtest.py
Received a message of type 12 and length 317
Received a message of type 12 and length 317
```

The above is more of a toy example of course. The actual thing that triggered this is a parallel ssh client that I'm writing. Profiling told me that talking to the ssh agent in the conventional way of serially writing a request and reading a response was very slow, especially when talking to a forwarded agent. When changing this to simply blasting signing requests to the socket from many threads, and using another thread to receive and dispatch responses, I ran into this issue. strace told me that ssh-agent was receiving data in 1024-byte chunks, each containing multiple signing requests. But it was only sending 1 response for each received chunk. With this patch applied, talking to the ssh agent in this fashion works properly and is very fast.