### PR TITLE
skip ensure_minimum_time_since if use pam

### DIFF
--- a/auth2.c
+++ b/auth2.c
@@ -336,7 +336,7 @@ input_userauth_request(int type, u_int32_t seq, struct ssh *ssh)
 		debug2("input_userauth_request: try method %s", method);
 		authenticated =	m->userauth(ssh);
 	}
-	if (!authctxt->authenticated)
+	if (!authctxt->authenticated && !options.use_pam)
 		ensure_minimum_time_since(tstart,
 		    user_specific_delay(authctxt->user));
 	userauth_finish(ssh, authenticated, method, NULL);


### PR DESCRIPTION
some pam modules will set fail delay, e.g. ,pam_tally*, pam_faillock.
When ensure_minimum_time_since is invoked, these delays are not
guaranteed to be correct.