### PR TITLE
parse_user_host_path, empty path should be allowed

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -681,6 +681,8 @@ colon(char *cp)
 			flag = 1;
 		if (*cp == ']' && *(cp+1) == ':' && flag)
 			return (cp+1);
+		if (*cp == ']' && *(cp+1) == '\0' && flag)
+			return (cp+1);
 		if (*cp == ':' && !flag)
 			return (cp);
 		if (*cp == '/')
@@ -719,7 +721,8 @@ parse_user_host_path(const char *s, char **userp, char **hostp, char **pathp)
 		goto out;
 
 	/* Extract optional path */
-	*tmp++ = '\0';
+	if (*tmp != '\0')
+		*tmp++ = '\0';
 	if (*tmp == '\0')
 		tmp = ".";
 	path = xstrdup(tmp);


### PR DESCRIPTION
when parse_user_host_path, empty path should be allowed

when using "sftp root@[2001::16%eth0]", the error output:
ssh: Could not resolve hostname [2001::16%eth0]: Name
or service not known
Connection closed.
Connection closed

fix sftp ipv6 login failed accidental like this:
File "/root/!" not found.