### PR TITLE
configure.ac: fix libfido2 back-compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3185,6 +3185,7 @@ if test "x$enable_sk" = "xyes" -a "x$enable_sk_internal" = "xyes" ; then
 	AC_CHECK_FUNCS([ \
 		fido_cred_prot \
 		fido_cred_set_prot \
+		fido_dev_get_touch_begin \
 		fido_dev_get_touch_status \
 		fido_dev_supports_cred_prot \
 	])

--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -43,7 +43,7 @@
 #include <fido/credman.h>
 
 /* backwards compat for libfido2 */
-#ifndef HAVE_FIDO_CRED_PROD
+#ifndef HAVE_FIDO_CRED_PROT
 #define fido_cred_prot(x) (0)
 #endif
 #ifndef HAVE_FIDO_CRED_SET_PROT


### PR DESCRIPTION
- HAVE_FIDO_CRED_PROD -> HAVE_FIDO_CRED_PROT;
- check for fido_dev_get_touch_begin(), so that HAVE_FIDO_DEV_GET_TOUCH_BEGIN gets defined.