### PR TITLE
Fix serverside SetEnv inside Match blocks

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -1945,12 +1945,11 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		break;
 
 	case sSetEnv:
-		uvalue = options->num_setenv;
 		while ((arg = strdelimw(&cp)) && *arg != '\0') {
 			if (strchr(arg, '=') == NULL)
 				fatal("%s line %d: Invalid environment.",
 				    filename, linenum);
-			if (!*activep || uvalue != 0)
+			if (!*activep)
 				continue;
 			array_append(filename, linenum, "SetEnv",
 			    &options->setenv, &options->num_setenv, arg);

--- a/servconf.h
+++ b/servconf.h
@@ -277,6 +277,7 @@ TAILQ_HEAD(include_list, include_item);
 		M_CP_STRARRAYOPT(allow_groups, num_allow_groups); \
 		M_CP_STRARRAYOPT(deny_groups, num_deny_groups); \
 		M_CP_STRARRAYOPT(accept_env, num_accept_env); \
+		M_CP_STRARRAYOPT(setenv, num_setenv); \
 		M_CP_STRARRAYOPT(auth_methods, num_auth_methods); \
 		M_CP_STRARRAYOPT(permitted_opens, num_permitted_opens); \
 		M_CP_STRARRAYOPT(permitted_listens, num_permitted_listens); \


### PR DESCRIPTION
I noticed that serverside `SetEnv` keywords inside `Match` blocks isn't working. Looking at the commit history (28013759f09ed3ebf7e8335e83a62936bd7a7f47) it looks like adding the array to copy macro simply has been forgotten.

Further more it seems multiple statements inside the same context are not supported for no apparent reason. So I removed that as well.