### PR TITLE
change type of nid to int

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -184,7 +184,7 @@ type_bits_valid(int type, const char *name, u_int32_t *bitsp)
 		fatal("unknown key type %s", key_type_name);
 	if (*bitsp == 0) {
 #ifdef WITH_OPENSSL
-		u_int nid;
+		int nid;
 
 		switch(type) {
 		case KEY_DSA:


### PR DESCRIPTION
This is in line with the return type of sshkey_ecdsa_nid_from_name()
and the argument type of sshkey_curve_nid_to_bits(int nid).

When casting to u_int, the possible -1 error return value of
sshkey_ecdsa_nid_from_name() will go unchecked.