### PR TITLE
Fix `EOF: command not found` error in ssh-copy-id

### DIFF
--- a/contrib/ssh-copy-id
+++ b/contrib/ssh-copy-id
@@ -247,7 +247,7 @@ installkeys_sh() {
   #    the -z `tail ...` checks for a trailing newline. The echo adds one if was missing
   #    the cat adds the keys we're getting via STDIN
   #    and if available restorecon is used to restore the SELinux context
-  INSTALLKEYS_SH=$(tr '\t\n' ' ' <<-EOF)
+  INSTALLKEYS_SH=$(tr '\t\n' ' ' <<-EOF
 	cd;
 	umask 077;
 	mkdir -p $(dirname "${AUTH_KEY_FILE}") &&
@@ -258,6 +258,7 @@ installkeys_sh() {
 	  restorecon -F .ssh ${AUTH_KEY_FILE};
 	fi
 EOF
+  )
 
   # to defend against quirky remote shells: use 'exec sh -c' to get POSIX;
   printf "exec sh -c '%s'" "${INSTALLKEYS_SH}"


### PR DESCRIPTION
At the moment, the ssh-copy-id utility is not working properly.

```sh
$ ssh-copy-id user@hostname
/usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
/usr/bin/ssh-copy-id: INFO: 2 key(s) remain to be installed -- if you are prompted now it is to install the new keys
/usr/bin/ssh-copy-id: line 251: warning: here-document at line 251 delimited by end-of-file (wanted `EOF')
/usr/bin/ssh-copy-id: line 250: warning: here-document at line 250 delimited by end-of-file (wanted `EOF')
/usr/bin/ssh-copy-id: line 254: /dev/null`: Permission denied
/usr/bin/ssh-copy-id: line 260: EOF: command not found
```

OpenSSH 8.4/8.4p1 (2020-09-27).