### PR TITLE
Portability: use `uname -n` instead of `hostname`.

### DIFF
--- a/regress/percent.sh
+++ b/regress/percent.sh
@@ -10,8 +10,8 @@ fi
 
 USER=`id -u -n`
 USERID=`id -u`
-HOST=`hostname | cut -f1 -d.`
-HOSTNAME=`hostname`
+HOST=`uname -n | cut -f1 -d.`
+HOSTNAME=`uname -n`
 
 # Localcommand is evaluated after connection because %T is not available
 # until then.  Because of this we use a different method of exercising it,


### PR DESCRIPTION
hostname is not defined by POSIX and not present by default on some modern Linux distro's, eg. Arch or Fedora.