### PR TITLE
Warn on system with secure verification requested

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -221,6 +221,7 @@ verify_host_key_dns(const char *hostname, struct sockaddr *address,
 	u_int8_t dnskey_digest_type;
 	u_char *dnskey_digest;
 	size_t dnskey_digest_len;
+	int verify_hosts = *flags;
 
 	*flags = 0;
 
@@ -247,6 +248,10 @@ verify_host_key_dns(const char *hostname, struct sockaddr *address,
 	} else {
 		debug("found %d insecure fingerprints in DNS",
 		    fingerprints->rri_nrdatas);
+		if (verify_hosts == 1 &&
+		    (fingerprints->rri_flags & RRSET_SECURE_UNSUPPORTED))
+			error("System does not support secure DNS, "
+			      "try options edns0 in resolv.conf");
 	}
 
 	/* Initialize default host key parameters */

--- a/openbsd-compat/getrrsetbyname.c
+++ b/openbsd-compat/getrrsetbyname.c
@@ -195,6 +195,7 @@ getrrsetbyname(const char *hostname, unsigned int rdclass,
 	struct rdatainfo *rdata;
 	int length;
 	unsigned int index_ans, index_sig;
+	int rri_flags = 0;
 	u_char answer[ANSWER_BUFFER_SIZE];
 
 	/* check for invalid class and type */
@@ -229,6 +230,8 @@ getrrsetbyname(const char *hostname, unsigned int rdclass,
 	/* turn on DNSSEC if EDNS0 is configured */
 	if (_resp->options & RES_USE_EDNS0)
 		_resp->options |= RES_USE_DNSSEC;
+	else
+		rri_flags |= RRSET_SECURE_UNSUPPORTED;
 #endif /* RES_USE_DNSEC */
 
 	/* make query */
@@ -270,11 +273,14 @@ getrrsetbyname(const char *hostname, unsigned int rdclass,
 	rrset->rri_rdtype = response->query->type;
 	rrset->rri_ttl = response->answer->ttl;
 	rrset->rri_nrdatas = response->header.ancount;
+	rrset->rri_flags = rri_flags;
 
 #ifdef HAVE_HEADER_AD
 	/* check for authenticated data */
 	if (response->header.ad == 1)
 		rrset->rri_flags |= RRSET_VALIDATED;
+#else
+	rrset->rri_flags |= RRSET_SECURE_UNSUPPORTED;
 #endif
 
 	/* copy name from answer section */

--- a/openbsd-compat/getrrsetbyname.h
+++ b/openbsd-compat/getrrsetbyname.h
@@ -72,6 +72,8 @@
 #ifndef RRSET_VALIDATED
 # define RRSET_VALIDATED	1
 #endif
+/* Indicate secure validation cannot occur */
+# define RRSET_SECURE_UNSUPPORTED 8
 
 /*
  * Return codes for getrrsetbyname()
@@ -83,6 +85,7 @@
 # define ERRSET_INVAL		3
 # define ERRSET_NONAME		4
 # define ERRSET_NODATA		5
+# define ERRSET_NOSUPPORT	6
 #endif
 
 struct rdatainfo {

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1243,6 +1243,7 @@ verify_host_key(char *host, struct sockaddr *hostaddr, struct sshkey *host_key)
 		 * XXX certs are not yet supported for DNS, so downgrade
 		 * them and try the plain key.
 		 */
+		flags = options.verify_host_key_dns;
 		if ((r = sshkey_from_private(host_key, &plain)) != 0)
 			goto out;
 		if (sshkey_is_cert(plain))


### PR DESCRIPTION
If system is unable to provide secure validation and it was requested by
SSH configuration, warn user it cannot occur. It may need tweak in
resolv.conf.

Signed-off-by: Petr Mensik <pemensik@redhat.com>