### PR TITLE
Correct and clarify no-touch-required option for CAs and certificates.

### DIFF
--- a/PROTOCOL.certkeys
+++ b/PROTOCOL.certkeys
@@ -280,12 +280,15 @@ their data fields are:
 
 Name                    Format        Description
 -----------------------------------------------------------------------------
-no-presence-required    empty         Flag indicating that signatures made
+no-touch-required       empty         Flag indicating that signatures made
                                       with this certificate need not assert
                                       user presence. This option only make
                                       sense for the U2F/FIDO security key
                                       types that support this feature in
-                                      their signature formats.
+                                      their signature formats. Note that the
+                                      CA must also have been marked with the
+                                      no-touch-required option for this to
+                                      be respected.
 
 permit-X11-forwarding   empty         Flag indicating that X11 forwarding
                                       should be permitted. X11 forwarding will


### PR DESCRIPTION
Based on [source](https://github.com/openssh/openssh-portable/blob/master/auth-options.c#L98) and testing, this certificate extension should be "no-touch-required". Also based on some testing, the certificate also has to have been loaded (in an authorized_keys files) with the no-touch-required option for this extension to be respected (otherwise all signatures will still require touch even if this extension is included in the certificate).