### PR TITLE
Deny (non-fatal) statx in preauth privsep child.

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -181,6 +181,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_ipc
 	SC_DENY(__NR_ipc, EACCES),
 #endif
+#ifdef __NR_statx
+	SC_DENY(__NR_statx, EACCES),
+#endif
 
 	/* Syscalls to permit */
 #ifdef __NR_brk


### PR DESCRIPTION
Hi, this PR is similar to #149 which was made in response to https://github.com/openssl/openssl/issues/9984 .

I haven't tracked down where the statx syscall is made exactly but this patch fixes ssh with openssl 1.1.1h on armv7 with a v3.4.x kernel with musl libc.

Please advise whether this an appropriate solution or if changes need to be made to either patch content or description.

