### PR TITLE
ssh-keygen.1 - State that the KDF algo is bcrypt

### DIFF
--- a/ssh-keygen.1
+++ b/ssh-keygen.1
@@ -277,7 +277,7 @@ When saving a private key, this option specifies the number of KDF
 (key derivation function) rounds used.
 Higher numbers result in slower passphrase verification and increased
 resistance to brute-force password cracking (should the keys be stolen).
-The default is 16 rounds.
+The default is 16 rounds. The KDF algorithm is bcrypt.
 .It Fl B
 Show the bubblebabble digest of specified private or public key file.
 .It Fl b Ar bits


### PR DESCRIPTION
The ssh-keygen.1 manpage now states that the default number of KDF rounds is 16, but it doesn't state what KDF algorithm is used. It's important to know the KDF algorithm when choosing the number of rounds. This isn't obvious (except perhaps to openbsd users?). This commit adds an explicit statement to the -a option section that the KDF function is bcrypt.