### PR TITLE
Improve sending struct passwd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4227,7 +4227,7 @@ AC_CHECK_MEMBERS([struct stat.st_blksize])
 AC_CHECK_MEMBERS([struct stat.st_mtim])
 AC_CHECK_MEMBERS([struct stat.st_mtime])
 AC_CHECK_MEMBERS([struct passwd.pw_gecos, struct passwd.pw_class,
-struct passwd.pw_change, struct passwd.pw_expire],
+struct passwd.pw_change, struct passwd.pw_expire, struct passwd.pw_fields],
 [], [], [[
 #include <sys/types.h>
 #include <pwd.h>

--- a/monitor.c
+++ b/monitor.c
@@ -744,17 +744,7 @@ mm_answer_pwnamallow(struct ssh *ssh, int sock, struct sshbuf *m)
 
 	/* XXX don't sent pwent to unpriv; send fake class/dir/shell too */
 	if ((r = sshbuf_put_u8(m, 1)) != 0 ||
-	    (r = sshbuf_put_string(m, pwent, sizeof(*pwent))) != 0 ||
-	    (r = sshbuf_put_cstring(m, pwent->pw_name)) != 0 ||
-	    (r = sshbuf_put_cstring(m, "*")) != 0 ||
-#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
-	    (r = sshbuf_put_cstring(m, pwent->pw_gecos)) != 0 ||
-#endif
-#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
-	    (r = sshbuf_put_cstring(m, pwent->pw_class)) != 0 ||
-#endif
-	    (r = sshbuf_put_cstring(m, pwent->pw_dir)) != 0 ||
-	    (r = sshbuf_put_cstring(m, pwent->pw_shell)) != 0)
+	    sshbuf_put_passwd(m, pwent))
 		fatal_fr(r, "assemble pw");
 
  out:

--- a/monitor_wrap.c
+++ b/monitor_wrap.c
@@ -277,24 +277,8 @@ mm_getpwnamallow(struct ssh *ssh, const char *username)
 		goto out;
 	}
 
-	/* XXX don't like passing struct passwd like this */
-	pw = xcalloc(sizeof(*pw), 1);
-	if ((r = sshbuf_get_string_direct(m, &p, &len)) != 0)
-		fatal_fr(r, "parse");
-	if (len != sizeof(*pw))
-		fatal_f("struct passwd size mismatch");
-	memcpy(pw, p, sizeof(*pw));
-
-	if ((r = sshbuf_get_cstring(m, &pw->pw_name, NULL)) != 0 ||
-	    (r = sshbuf_get_cstring(m, &pw->pw_passwd, NULL)) != 0 ||
-#ifdef HAVE_STRUCT_PASSWD_PW_GECOS
-	    (r = sshbuf_get_cstring(m, &pw->pw_gecos, NULL)) != 0 ||
-#endif
-#ifdef HAVE_STRUCT_PASSWD_PW_CLASS
-	    (r = sshbuf_get_cstring(m, &pw->pw_class, NULL)) != 0 ||
-#endif
-	    (r = sshbuf_get_cstring(m, &pw->pw_dir, NULL)) != 0 ||
-	    (r = sshbuf_get_cstring(m, &pw->pw_shell, NULL)) != 0)
+	pw = sshbuf_get_passwd(m);
+	if (pw == NULL)
 		fatal_fr(r, "parse pw");
 
 out:

--- a/sshbuf-getput-basic.c
+++ b/sshbuf-getput-basic.c
@@ -673,6 +673,9 @@ static inline int sshbuf_n_passwd_members() {
 #ifdef HAVE_STRUCT_PASSWD_PW_EXPIRE
 	n++;
 #endif
+#ifdef HAVE_STRUCT_PASSWD_PW_FIELDS
+	n++;
+#endif
 	return n;
 }
 
@@ -707,6 +710,9 @@ sshbuf_put_passwd(struct sshbuf *buf, const struct passwd *pwent)
 	    (r = sshbuf_put_cstring(buf, pwent->pw_shell)) != 0 ||
 #ifdef HAVE_STRUCT_PASSWD_PW_EXPIRE
 	    (r = sshbuf_put_time(buf, pwent->pw_expire)) != 0 ||
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_FIELDS
+	    (r = sshbuf_put_u32(buf, pwent->pw_fields)) != 0 ||
 #endif
 	    0) {
 		return r;
@@ -747,6 +753,9 @@ sshbuf_get_passwd(struct sshbuf *buf)
 	    sshbuf_get_cstring(buf, &pw->pw_shell, NULL) != 0 ||
 #ifdef HAVE_STRUCT_PASSWD_PW_EXPIRE
 	    sshbuf_get_time(buf, &pw->pw_expire) != 0 ||
+#endif
+#ifdef HAVE_STRUCT_PASSWD_PW_FIELDS
+	    sshbuf_get_u32(buf, &pw->pw_fields) != 0 ||
 #endif
 	    0) {
 		sshbuf_free_passwd(pw);

--- a/sshbuf.h
+++ b/sshbuf.h
@@ -309,6 +309,21 @@ int sshbuf_load_file(const char *, struct sshbuf **)
 int sshbuf_write_file(const char *path, struct sshbuf *buf)
     __attribute__((__nonnull__ (2)));
 
+/*
+ * store struct pwd
+ */
+int sshbuf_put_passwd(struct sshbuf *buf, const struct passwd *pwent);
+
+/*
+ * extract struct pwd
+ */
+struct passwd *sshbuf_get_passwd(struct sshbuf *buf);
+
+/*
+ * free struct passwd obtained from sshbuf_get_passwd.
+ */
+void sshbuf_free_passwd(struct passwd *pwent);
+
 /* Macros for decoding/encoding integers */
 #define PEEK_U64(p) \
 	(((u_int64_t)(((const u_char *)(p))[0]) << 56) | \


### PR DESCRIPTION
This pull request avoids sending pointer values in struct passwd.
It is possible to be a wild pointer in peer process, if a new pointer member is added.
And I believe that one ToDo comment will be finished.

Background:

I made a patch for FreeBSD's openssh. (c.f. [my FreeBSD patch](https://reviews.freebsd.org/D17128) to see what I fixed)
We discussed about pointer values should not be sent to another process.
It is necessary for openssh and I think the ToDo comment says as same as well.