### PR TITLE
Using explicit_memset for the explicit_bzero compatibility layer.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1795,6 +1795,7 @@ AC_CHECK_FUNCS([ \
 	err \
 	errx \
 	explicit_bzero \
+	explicit_memset \
 	fchmod \
 	fchmodat \
 	fchown \

--- a/openbsd-compat/explicit_bzero.c
+++ b/openbsd-compat/explicit_bzero.c
@@ -15,7 +15,15 @@
 
 #ifndef HAVE_EXPLICIT_BZERO
 
-#ifdef HAVE_MEMSET_S
+#ifdef HAVE_EXPLICIT_MEMSET
+
+void
+explicit_bzero(void *p, size_t n)
+{
+	(void)explicit_memset(p, 0, n);
+}
+
+#elif defined(HAVE_MEMSET_S)
 
 void
 explicit_bzero(void *p, size_t n)


### PR DESCRIPTION
Favoriting the native implementation in this case.