### PR TITLE
Fix the hostkeys protocol documentation

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -292,6 +292,7 @@ has completed.
 
 	byte		SSH_MSG_GLOBAL_REQUEST
 	string		"hostkeys-00@openssh.com"
+	char		0 /* want-reply */
 	string[]	hostkeys
 
 Upon receiving this message, a client should check which of the


### PR DESCRIPTION
The documentation was lacking the needed want-reply field in the initial global request. This was found implementing hostkeys support in another SSH implementation.

See https://gitlab.com/libssh/libssh-mirror/-/merge_requests/145 for where this is being added to libssh that lead to find this issue. 