### PR TITLE
Remove redundant `attrib_clear` from SFTP client

### DIFF
--- a/sftp-client.c
+++ b/sftp-client.c
@@ -1853,7 +1853,6 @@ upload_dir_internal(struct sftp_conn *conn, const char *src, const char *dst,
 	if (print_flag)
 		mprintf("Entering %s\n", src);
 
-	attrib_clear(&a);
 	stat_to_attrib(&sb, &a);
 	a.flags &= ~SSH2_FILEXFER_ATTR_SIZE;
 	a.flags &= ~SSH2_FILEXFER_ATTR_UIDGID;


### PR DESCRIPTION
The `stat_to_attrib()` call just below the removed line calls `attrib_clear()` itself.

https://github.com/openssh/openssh-portable/blob/46f4a853c4681153ef45b08dfb87df6a6caebe5a/sftp-common.c#L67-L82