### PR TITLE
Remove duplicated declaration in fatal.c .

### DIFF
--- a/regress/misc/sk-dummy/fatal.c
+++ b/regress/misc/sk-dummy/fatal.c
@@ -9,9 +9,6 @@
 
 #include "log.h"
 
-void sshfatal(const char *file, const char *func, int line, int showfunc,
-    LogLevel level, const char *suffix, const char *fmt, ...);
-
 void
 sshfatal(const char *file, const char *func, int line, int showfunc,
     LogLevel level, const char *suffix, const char *fmt, ...)


### PR DESCRIPTION
Declaration of sshfatal has been included in log.h. So there is no need to declare it again. And also, I check the code in [openbsd](https://github.com/openbsd/src/blob/2d2e8ab08946096eec777725afff21569594ceef/usr.bin/ssh/fatal.c), there is no such declaration in fatal.c. So maybe it is duplicated?