### PR TITLE
Allow overriding TERM with SetEnv directives in ssh_config

### DIFF
--- a/mux.c
+++ b/mux.c
@@ -1896,7 +1896,7 @@ mux_client_request_session(int fd)
 	if (stdin_null_flag && stdfd_devnull(1, 0, 0) == -1)
 		fatal_f("stdfd_devnull failed");
 
-	if ((term = getenv("TERM")) == NULL)
+	if ((term = get_term(&options)) == NULL)
 		term = "";
 	echar = 0xffffffff;
 	if (options.escape_char != SSH_ESCAPECHAR_NONE)

--- a/readconf.c
+++ b/readconf.c
@@ -509,6 +509,22 @@ default_ssh_port(void)
 }
 
 /*
+ * Gets the value of the TERM environment variable as set in the options,
+ * defaulting to using that of the calling environment.
+ */
+const char *
+get_term(const Options *options) {
+    const char *term = NULL;
+    for (int idx = 0; idx < options->num_setenv; idx++) {
+        if (!strncmp("TERM=", options->setenv[idx], 5)) {
+            // skip the =
+            term = options->setenv[idx] + 5;
+        }
+    }
+    return term ? term : getenv("TERM");
+}
+
+/*
  * Execute a command in a shell.
  * Return its exit status or -1 on abnormal exit.
  */

--- a/readconf.h
+++ b/readconf.h
@@ -226,4 +226,6 @@ void	 add_remote_forward(Options *, const struct Forward *);
 void	 add_identity_file(Options *, const char *, const char *, int);
 void	 add_certificate_file(Options *, const char *, int);
 
+const char *get_term(const Options *options);
+
 #endif				/* READCONF_H */

--- a/ssh.c
+++ b/ssh.c
@@ -2000,7 +2000,7 @@ ssh_session2_setup(struct ssh *ssh, int id, int success, void *arg)
 	ssh_packet_set_interactive(ssh, interactive,
 	    options.ip_qos_interactive, options.ip_qos_bulk);
 
-	client_session2_setup(ssh, id, tty_flag, subsystem_flag, getenv("TERM"),
+	client_session2_setup(ssh, id, tty_flag, subsystem_flag, get_term(&options),
 	    NULL, fileno(stdin), command, environ);
 }
 

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1559,6 +1559,13 @@ Note that the
 .Ev TERM
 environment variable is always sent whenever a
 pseudo-terminal is requested as it is required by the protocol.
+The value of
+.Ev TERM
+sent to the server can be overridden using the
+.Cm SetEnv
+directive, replacing the value found in the environment of
+.Xr ssh 1
+with the value specified.
 Refer to
 .Cm AcceptEnv
 in


### PR DESCRIPTION
This removes the necessity to change profile files that are potentially
immutable or unsupported while using terminals that are not in the remote
server's termcap.

My personal use for this is that I use `alacritty` which is `xterm` compatible, but I often have to log into old systems that don't have `alacritty` in termcap, so I want to override `TERM` to be `xterm`. The alternative to this change is writing a wrapper script which would have to parse the host specification and other details, which is not ideal.

Let me know if this is the right avenue to submit this change.

Related threads: https://lists.mindrot.org/pipermail/openssh-unix-dev/2018-November/037361.html; https://serverfault.com/q/986847/322245