### PR TITLE
Fix error when DEBUG_SK is on and Unify variable names in sk part

### DIFF
--- a/sk-api.h
+++ b/sk-api.h
@@ -86,7 +86,7 @@ int sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
     struct sk_option **options, struct sk_enroll_response **enroll_response);
 
 /* Sign a challenge */
-int sk_sign(uint32_t alg, const uint8_t *message, size_t message_len,
+int sk_sign(uint32_t alg, const uint8_t *data, size_t data_len,
     const char *application, const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, const char *pin, struct sk_option **options,
     struct sk_sign_response **sign_response);

--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -118,7 +118,7 @@ int sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
     struct sk_option **options, struct sk_enroll_response **enroll_response);
 
 /* Sign a challenge */
-int sk_sign(uint32_t alg, const uint8_t *message, size_t message_len,
+int sk_sign(uint32_t alg, const uint8_t *data, size_t data_len,
     const char *application, const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, const char *pin, struct sk_option **options,
     struct sk_sign_response **sign_response);
@@ -990,6 +990,10 @@ sk_sign(uint32_t alg, const uint8_t *data, size_t datalen,
 		skdebug(__func__, "hash message failed");
 		goto out;
 	}
+#ifdef DEBUG_SK
+	fprintf(stderr, "%s: hashed message:\n", __func__);
+	sshbuf_dump_data(message, sizeof(message), stderr);
+#endif
 	if (device != NULL)
 		sk = sk_open(device);
 	else if (pin != NULL || (flags & SSH_SK_USER_VERIFICATION_REQD))

--- a/ssh-sk.c
+++ b/ssh-sk.c
@@ -59,7 +59,7 @@ struct sshsk_provider {
 	    struct sk_enroll_response **enroll_response);
 
 	/* Sign a challenge */
-	int (*sk_sign)(int alg, const uint8_t *message, size_t message_len,
+	int (*sk_sign)(int alg, const uint8_t *data, size_t data_len,
 	    const char *application,
 	    const uint8_t *key_handle, size_t key_handle_len,
 	    uint8_t flags, const char *pin, struct sk_option **opts,
@@ -75,7 +75,7 @@ int ssh_sk_enroll(int alg, const uint8_t *challenge,
     size_t challenge_len, const char *application, uint8_t flags,
     const char *pin, struct sk_option **opts,
     struct sk_enroll_response **enroll_response);
-int ssh_sk_sign(int alg, const uint8_t *message, size_t message_len,
+int ssh_sk_sign(int alg, const uint8_t *data, size_t data_len,
     const char *application,
     const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, const char *pin, struct sk_option **opts,
@@ -694,8 +694,6 @@ sshsk_sign(const char *provider_path, struct sshkey *key,
 #ifdef DEBUG_SK
 	fprintf(stderr, "%s: sig_flags = 0x%02x, sig_counter = %u\n",
 	    __func__, resp->flags, resp->counter);
-	fprintf(stderr, "%s: hashed message:\n", __func__);
-	sshbuf_dump_data(message, sizeof(message), stderr);
 	fprintf(stderr, "%s: sigbuf:\n", __func__);
 	sshbuf_dump(sig, stderr);
 #endif


### PR DESCRIPTION
## The error
```console
$ make CFLAGS="-DDEBUG_SK"
ranlib libssh.a
ssh-sk.c: In function ‘sshsk_sign’:
ssh-sk.c:698:19: error: ‘message’ undeclared (first use in this function)
  698 |  sshbuf_dump_data(message, sizeof(message), stderr);
      |                   ^~~~~~~
ssh-sk.c:698:19: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:195: ssh-sk.o] Error 1
```

This error is introduced by 59d2de956ed29aa5565ed5e5947a7abdb27ac013
In this commit, variable `message` is removed from func `sshsk_sign` into `sk_sign` in `sk-usbhid.c`
but its debug code is not removed.

## Variable names

Also, variable names in func argument was renamed in definition but not
in declaration, so in this commit their names are unified.