### PR TITLE
bz3259：Fix log deadlock occurs during sshd running

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -339,9 +339,7 @@ main_sigchld_handler(int sig)
 	int save_errno = errno;
 	pid_t pid;
 	int status;
-
-	debug("main_sigchld_handler: %s", strsignal(sig));
-
+	
 	while ((pid = waitpid(-1, &status, WNOHANG)) > 0 ||
 	    (pid == -1 && errno == EINTR))
 		;


### PR DESCRIPTION
We recommend removing the debug printing function in main_sigchld_handler to avoid possible deadlocks.

https://bugzilla.mindrot.org/show_bug.cgi?id=3259