### PR TITLE
bz2217: connect via SRV record

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -281,6 +281,8 @@ clean:	regressclean
 	rm -f regress/unittests/bitmap/test_bitmap$(EXEEXT)
 	rm -f regress/unittests/conversion/*.o
 	rm -f regress/unittests/conversion/test_conversion$(EXEEXT)
+	rm -f regress/unittests/dns/*.o
+	rm -f regress/unittests/dns/test_dns$(EXEEXT)
 	rm -f regress/unittests/hostkeys/*.o
 	rm -f regress/unittests/hostkeys/test_hostkeys$(EXEEXT)
 	rm -f regress/unittests/kex/*.o
@@ -316,6 +318,8 @@ distclean:	regressclean
 	rm -f regress/unittests/bitmap/test_bitmap
 	rm -f regress/unittests/conversion/*.o
 	rm -f regress/unittests/conversion/test_conversion
+	rm -f regress/unittests/dns/*.o
+	rm -f regress/unittests/dns/test_dns
 	rm -f regress/unittests/hostkeys/*.o
 	rm -f regress/unittests/hostkeys/test_hostkeys
 	rm -f regress/unittests/kex/*.o
@@ -493,6 +497,7 @@ regress-prep:
 	$(MKDIR_P) `pwd`/regress/unittests/sshsig
 	$(MKDIR_P) `pwd`/regress/unittests/bitmap
 	$(MKDIR_P) `pwd`/regress/unittests/conversion
+	$(MKDIR_P) `pwd`/regress/unittests/dns
 	$(MKDIR_P) `pwd`/regress/unittests/hostkeys
 	$(MKDIR_P) `pwd`/regress/unittests/kex
 	$(MKDIR_P) `pwd`/regress/unittests/match
@@ -592,6 +597,17 @@ regress/unittests/conversion/test_conversion$(EXEEXT): \
 	    regress/unittests/test_helper/libtest_helper.a \
 	    -lssh -lopenbsd-compat -lssh -lopenbsd-compat $(LIBS)
 
+UNITTESTS_TEST_DNS_OBJS=\
+	regress/unittests/dns/tests.o \
+	$(SKOBJS)
+
+regress/unittests/dns/test_dns$(EXEEXT): \
+    ${UNITTESTS_TEST_DNS_OBJS} \
+    regress/unittests/test_helper/libtest_helper.a libssh.a
+	$(LD) -o $@ $(LDFLAGS) $(UNITTESTS_TEST_DNS_OBJS) \
+	    regress/unittests/test_helper/libtest_helper.a \
+	    -lssh -lopenbsd-compat -lssh -lopenbsd-compat $(LIBS)
+
 UNITTESTS_TEST_KEX_OBJS=\
 	regress/unittests/kex/tests.o \
 	regress/unittests/kex/test_kex.o \
@@ -672,6 +688,7 @@ regress-unit-binaries: regress-prep $(REGRESSLIBS) \
 	regress/unittests/sshsig/test_sshsig$(EXEEXT) \
 	regress/unittests/bitmap/test_bitmap$(EXEEXT) \
 	regress/unittests/conversion/test_conversion$(EXEEXT) \
+	regress/unittests/dns/test_dns$(EXEEXT) \
 	regress/unittests/hostkeys/test_hostkeys$(EXEEXT) \
 	regress/unittests/kex/test_kex$(EXEEXT) \
 	regress/unittests/match/test_match$(EXEEXT) \

--- a/dns.c
+++ b/dns.c
@@ -352,3 +352,46 @@ export_dns_rr(const char *hostname, struct sshkey *key, FILE *f, int generic)
 
 	return success;
 }
+
+/*
+ * Decoded a DNS wire-format name to the commonly
+ * used, dot-separated format of labels.
+ * Returns a dynamically allocated string on success
+ * and NULL on error.
+ */
+char*
+dns_decode_name(const char* data, size_t len) {
+    size_t      index  = 0;
+
+    char*  decoded = NULL;
+    size_t size    = 0;
+
+    uint8_t next_label_len;
+    do {
+        next_label_len = data[index];
+
+        char* old_decoded = decoded;
+
+        if(old_decoded) {
+            decoded = malloc(size + next_label_len + 2);
+            memcpy(decoded, old_decoded, size);
+            decoded[size] = '.';
+            memcpy(decoded + size + 1, data + index + 1, next_label_len);
+            decoded[size + next_label_len + 1] = 0;
+
+            size += 1;
+
+            free(old_decoded);
+        }
+        else {
+            decoded = malloc(next_label_len + 1);
+            memcpy(decoded, data + index + 1, next_label_len);
+            decoded[next_label_len] = 0;
+        }
+
+        size  += next_label_len;
+        index += next_label_len + 1;
+    } while(next_label_len > 0 && index + next_label_len <= len);
+
+    return decoded;
+}

--- a/dns.c
+++ b/dns.c
@@ -52,7 +52,7 @@ static const char *errset_text[] = {
 	"data does not exist",	/* 5 ERRSET_NODATA */
 };
 
-static const char *
+const char *
 dns_result_totext(unsigned int res)
 {
 	switch (res) {

--- a/dns.h
+++ b/dns.h
@@ -58,4 +58,6 @@ int	export_dns_rr(const char *, struct sshkey *, FILE *, int);
 
 const char* dns_result_totext(unsigned int res);
 
+char* dns_decode_name(const char* data, size_t len);
+
 #endif /* DNS_H */

--- a/dns.h
+++ b/dns.h
@@ -46,6 +46,7 @@ enum sshfp_hashes {
 
 #define DNS_RDATACLASS_IN	1
 #define DNS_RDATATYPE_SSHFP	44
+#define DNS_RDATATYPE_SRV	33
 
 #define DNS_VERIFY_FOUND	0x00000001
 #define DNS_VERIFY_MATCH	0x00000002
@@ -54,5 +55,7 @@ enum sshfp_hashes {
 int	verify_host_key_dns(const char *, struct sockaddr *,
     struct sshkey *, int *);
 int	export_dns_rr(const char *, struct sshkey *, FILE *, int);
+
+const char* dns_result_totext(unsigned int res);
 
 #endif /* DNS_H */

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -256,6 +256,7 @@ unit:
 			-d ${.CURDIR}/unittests/sshsig/testdata ; \
 		$$V ${.OBJDIR}/unittests/bitmap/test_bitmap ; \
 		$$V ${.OBJDIR}/unittests/conversion/test_conversion ; \
+		$$V ${.OBJDIR}/unittests/dns/test_dns ; \
 		$$V ${.OBJDIR}/unittests/kex/test_kex ; \
 		$$V ${.OBJDIR}/unittests/hostkeys/test_hostkeys \
 			-d ${.CURDIR}/unittests/hostkeys/testdata ; \

--- a/regress/unittests/Makefile
+++ b/regress/unittests/Makefile
@@ -1,7 +1,7 @@
 #	$OpenBSD: Makefile,v 1.12 2020/06/19 04:34:21 djm Exp $
 
 REGRESS_FAIL_EARLY?=	yes
-SUBDIR=	test_helper sshbuf sshkey bitmap kex hostkeys utf8 match conversion
+SUBDIR=	test_helper sshbuf sshkey bitmap kex hostkeys utf8 match conversion dns
 SUBDIR+=authopt misc sshsig
 
 .include <bsd.subdir.mk>

--- a/regress/unittests/dns/tests.c
+++ b/regress/unittests/dns/tests.c
@@ -1,0 +1,48 @@
+/* 	$OpenBSD: tests.c,v 1.3 2021/01/18 11:43:34 dtucker Exp $ */
+/*
+ * Regress test for dns utility functions
+ *
+ * Placed in the public domain
+ */
+
+#include "includes.h"
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <stdio.h>
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#include <stdlib.h>
+#include <string.h>
+
+#include "../test_helper/test_helper.h"
+
+#include "sshkey.h"
+#include "dns.h"
+
+void
+tests(void)
+{
+    TEST_START("dns_decode_name");
+
+    // no data at all
+	ASSERT_PTR_EQ(dns_decode_name(0, 0), NULL);
+
+    // some data, but truncated a lot
+	ASSERT_PTR_EQ(dns_decode_name("\04example", 4), NULL);
+
+    // some data, but truncated (trailing zero length label missing)
+	ASSERT_PTR_EQ(dns_decode_name("\07example", 8), NULL);
+
+    // single label, correct data
+	ASSERT_STRING_EQ(dns_decode_name("\07example", 9), "example");
+
+    // two labels, correct data
+	ASSERT_STRING_EQ(dns_decode_name("\07example\03com", 13), "example.com");
+
+    // three labels, correct data
+	ASSERT_STRING_EQ(dns_decode_name("\03www\07example\03com", 17), "www.example.com");
+
+	TEST_DONE();
+}


### PR DESCRIPTION
Crude implementation of connection via SRV record. Currently only connects to the lowest-prio, highest-weight server, but this is still useful for non-standard ports.

SRV lookup is only done when a port is not manually given on either command line (`-p`) or config.