### PR TITLE
Add ssh_config equivalents of -N, -s, -n and -f

### DIFF
--- a/clientloop.c
+++ b/clientloop.c
@@ -115,9 +115,6 @@
 /* import options */
 extern Options options;
 
-/* Flag indicating that stdin should be redirected from /dev/null. */
-extern int stdin_null_flag;
-
 /* Flag indicating that ssh should daemonise after authentication is complete */
 extern int fork_after_authentication_flag;
 

--- a/clientloop.c
+++ b/clientloop.c
@@ -118,9 +118,6 @@ extern Options options;
 /* Flag indicating that stdin should be redirected from /dev/null. */
 extern int stdin_null_flag;
 
-/* Flag indicating that no shell has been requested */
-extern int no_shell_flag;
-
 /* Flag indicating that ssh should daemonise after authentication is complete */
 extern int fork_after_authentication_flag;
 
@@ -1410,7 +1407,7 @@ client_loop(struct ssh *ssh, int have_pty, int escape_char_arg,
 	 * exit status to be returned.  In that case, clear error code if the
 	 * connection was deliberately terminated at this end.
 	 */
-	if (no_shell_flag && received_signal == SIGTERM) {
+	if (options.session_type == SESSION_TYPE_NONE && received_signal == SIGTERM) {
 		received_signal = 0;
 		exit_status = 0;
 	}
@@ -2585,7 +2582,7 @@ client_stop_mux(void)
 	 * If we are in persist mode, or don't have a shell, signal that we
 	 * should close when all active channels are closed.
 	 */
-	if (options.control_persist || no_shell_flag) {
+	if (options.control_persist || options.session_type == SESSION_TYPE_NONE) {
 		session_closed = 1;
 		setproctitle("[stopped mux]");
 	}

--- a/clientloop.c
+++ b/clientloop.c
@@ -115,9 +115,6 @@
 /* import options */
 extern Options options;
 
-/* Flag indicating that ssh should daemonise after authentication is complete */
-extern int fork_after_authentication_flag;
-
 /* Control socket */
 extern int muxserver_sock; /* XXX use mux_client_cleanup() instead */
 
@@ -1240,7 +1237,7 @@ client_loop(struct ssh *ssh, int have_pty, int escape_char_arg,
 			fatal_f("pledge(): %s", strerror(errno));
 
 	} else if (!option_clear_or_none(options.proxy_command) ||
-	    fork_after_authentication_flag) {
+	    options.fork_after_authentication) {
 		debug("pledge: proc");
 		if (pledge("stdio cpath unix inet dns proc tty", NULL) == -1)
 			fatal_f("pledge(): %s", strerror(errno));

--- a/mux.c
+++ b/mux.c
@@ -73,7 +73,6 @@ extern int tty_flag;
 extern Options options;
 extern int stdin_null_flag;
 extern char *host;
-extern int subsystem_flag;
 extern struct sshbuf *command;
 extern volatile sig_atomic_t quit_pending;
 
@@ -1899,7 +1898,7 @@ mux_client_request_session(int fd)
 	    (r = sshbuf_put_u32(m, tty_flag)) != 0 ||
 	    (r = sshbuf_put_u32(m, options.forward_x11)) != 0 ||
 	    (r = sshbuf_put_u32(m, options.forward_agent)) != 0 ||
-	    (r = sshbuf_put_u32(m, subsystem_flag)) != 0 ||
+	    (r = sshbuf_put_u32(m, options.session_type == SESSION_TYPE_SUBSYSTEM)) != 0 ||
 	    (r = sshbuf_put_u32(m, echar)) != 0 ||
 	    (r = sshbuf_put_cstring(m, term == NULL ? "" : term)) != 0 ||
 	    (r = sshbuf_put_stringb(m, command)) != 0)

--- a/mux.c
+++ b/mux.c
@@ -71,7 +71,6 @@
 /* from ssh.c */
 extern int tty_flag;
 extern Options options;
-extern int stdin_null_flag;
 extern char *host;
 extern struct sshbuf *command;
 extern volatile sig_atomic_t quit_pending;
@@ -1879,7 +1878,7 @@ mux_client_request_session(int fd)
 
 	ssh_signal(SIGPIPE, SIG_IGN);
 
-	if (stdin_null_flag && stdfd_devnull(1, 0, 0) == -1)
+	if (options.stdin_null && stdfd_devnull(1, 0, 0) == -1)
 		fatal_f("stdfd_devnull failed");
 
 	if ((term = lookup_env_in_list("TERM", options.setenv,
@@ -2102,7 +2101,7 @@ mux_client_request_stdio_fwd(int fd)
 
 	ssh_signal(SIGPIPE, SIG_IGN);
 
-	if (stdin_null_flag && stdfd_devnull(1, 0, 0) == -1)
+	if (options.stdin_null && stdfd_devnull(1, 0, 0) == -1)
 		fatal_f("stdfd_devnull failed");
 
 	if ((m = sshbuf_new()) == NULL)

--- a/readconf.c
+++ b/readconf.c
@@ -168,7 +168,7 @@ typedef enum {
 	oLocalCommand, oPermitLocalCommand, oRemoteCommand,
 	oVisualHostKey,
 	oKexAlgorithms, oIPQoS, oRequestTTY, oSessionType, oStdinNull,
-	oIgnoreUnknown, oProxyUseFdpass,
+	oForkAfterAuthentication, oIgnoreUnknown, oProxyUseFdpass,
 	oCanonicalDomains, oCanonicalizeHostname, oCanonicalizeMaxDots,
 	oCanonicalizeFallbackLocal, oCanonicalizePermittedCNAMEs,
 	oStreamLocalBindMask, oStreamLocalBindUnlink, oRevokedHostKeys,
@@ -300,6 +300,7 @@ static struct {
 	{ "requesttty", oRequestTTY },
 	{ "sessiontype", oSessionType },
 	{ "stdinnull", oStdinNull },
+	{ "forkafterauthentication", oForkAfterAuthentication },
 	{ "proxyusefdpass", oProxyUseFdpass },
 	{ "canonicaldomains", oCanonicalDomains },
 	{ "canonicalizefallbacklocal", oCanonicalizeFallbackLocal },
@@ -1959,6 +1960,10 @@ parse_pubkey_algos:
 		intptr = &options->stdin_null;
 		goto parse_flag;
 
+	case oForkAfterAuthentication:
+		intptr = &options->fork_after_authentication;
+		goto parse_flag;
+
 	case oIgnoreUnknown:
 		charptr = &options->ignored_unknown;
 		goto parse_string;
@@ -2383,6 +2388,7 @@ initialize_options(Options * options)
 	options->request_tty = -1;
 	options->session_type = -1;
 	options->stdin_null = -1;
+	options->fork_after_authentication = -1;
 	options->proxy_use_fdpass = -1;
 	options->ignored_unknown = NULL;
 	options->num_canonical_domains = 0;
@@ -2573,6 +2579,8 @@ fill_default_options(Options * options)
 		options->session_type = SESSION_TYPE_DEFAULT;
 	if (options->stdin_null == -1)
 		options->stdin_null = 0;
+	if (options->fork_after_authentication == -1)
+		options->fork_after_authentication = 0;
 	if (options->proxy_use_fdpass == -1)
 		options->proxy_use_fdpass = 0;
 	if (options->canonicalize_max_dots == -1)
@@ -3252,6 +3260,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oRequestTTY, o->request_tty);
 	dump_cfg_fmtint(oSessionType, o->session_type);
 	dump_cfg_fmtint(oStdinNull, o->stdin_null);
+	dump_cfg_fmtint(oForkAfterAuthentication, o->fork_after_authentication);
 	dump_cfg_fmtint(oStreamLocalBindUnlink, o->fwd_opts.streamlocal_bind_unlink);
 	dump_cfg_fmtint(oStrictHostKeyChecking, o->strict_host_key_checking);
 	dump_cfg_fmtint(oTCPKeepAlive, o->tcp_keep_alive);

--- a/readconf.c
+++ b/readconf.c
@@ -167,7 +167,8 @@ typedef enum {
 	oTunnel, oTunnelDevice,
 	oLocalCommand, oPermitLocalCommand, oRemoteCommand,
 	oVisualHostKey,
-	oKexAlgorithms, oIPQoS, oRequestTTY, oIgnoreUnknown, oProxyUseFdpass,
+	oKexAlgorithms, oIPQoS, oRequestTTY, oSessionType,
+	oIgnoreUnknown, oProxyUseFdpass,
 	oCanonicalDomains, oCanonicalizeHostname, oCanonicalizeMaxDots,
 	oCanonicalizeFallbackLocal, oCanonicalizePermittedCNAMEs,
 	oStreamLocalBindMask, oStreamLocalBindUnlink, oRevokedHostKeys,
@@ -297,6 +298,7 @@ static struct {
 	{ "kexalgorithms", oKexAlgorithms },
 	{ "ipqos", oIPQoS },
 	{ "requesttty", oRequestTTY },
+	{ "sessiontype", oSessionType },
 	{ "proxyusefdpass", oProxyUseFdpass },
 	{ "canonicaldomains", oCanonicalDomains },
 	{ "canonicalizefallbacklocal", oCanonicalizeFallbackLocal },
@@ -870,6 +872,12 @@ static const struct multistate multistate_requesttty[] = {
 	{ "no",				REQUEST_TTY_NO },
 	{ "force",			REQUEST_TTY_FORCE },
 	{ "auto",			REQUEST_TTY_AUTO },
+	{ NULL, -1 }
+};
+static const struct multistate multistate_sessiontype[] = {
+	{ "none",			SESSION_TYPE_NONE },
+	{ "subsystem",			SESSION_TYPE_SUBSYSTEM },
+	{ "default",			SESSION_TYPE_DEFAULT },
 	{ NULL, -1 }
 };
 static const struct multistate multistate_canonicalizehostname[] = {
@@ -1941,6 +1949,11 @@ parse_pubkey_algos:
 		multistate_ptr = multistate_requesttty;
 		goto parse_multistate;
 
+	case oSessionType:
+		intptr = &options->session_type;
+		multistate_ptr = multistate_sessiontype;
+		goto parse_multistate;
+
 	case oIgnoreUnknown:
 		charptr = &options->ignored_unknown;
 		goto parse_string;
@@ -2363,6 +2376,7 @@ initialize_options(Options * options)
 	options->ip_qos_interactive = -1;
 	options->ip_qos_bulk = -1;
 	options->request_tty = -1;
+	options->session_type = -1;
 	options->proxy_use_fdpass = -1;
 	options->ignored_unknown = NULL;
 	options->num_canonical_domains = 0;
@@ -2549,6 +2563,8 @@ fill_default_options(Options * options)
 		options->ip_qos_bulk = IPTOS_DSCP_CS1;
 	if (options->request_tty == -1)
 		options->request_tty = REQUEST_TTY_AUTO;
+	if (options->session_type == -1)
+		options->session_type = SESSION_TYPE_DEFAULT;
 	if (options->proxy_use_fdpass == -1)
 		options->proxy_use_fdpass = 0;
 	if (options->canonicalize_max_dots == -1)
@@ -3063,6 +3079,8 @@ fmt_intarg(OpCodes code, int val)
 		return fmt_multistate_int(val, multistate_tunnel);
 	case oRequestTTY:
 		return fmt_multistate_int(val, multistate_requesttty);
+	case oSessionType:
+		return fmt_multistate_int(val, multistate_sessiontype);
 	case oCanonicalizeHostname:
 		return fmt_multistate_int(val, multistate_canonicalizehostname);
 	case oAddKeysToAgent:
@@ -3224,6 +3242,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oProxyUseFdpass, o->proxy_use_fdpass);
 	dump_cfg_fmtint(oPubkeyAuthentication, o->pubkey_authentication);
 	dump_cfg_fmtint(oRequestTTY, o->request_tty);
+	dump_cfg_fmtint(oSessionType, o->session_type);
 	dump_cfg_fmtint(oStreamLocalBindUnlink, o->fwd_opts.streamlocal_bind_unlink);
 	dump_cfg_fmtint(oStrictHostKeyChecking, o->strict_host_key_checking);
 	dump_cfg_fmtint(oTCPKeepAlive, o->tcp_keep_alive);

--- a/readconf.c
+++ b/readconf.c
@@ -167,7 +167,7 @@ typedef enum {
 	oTunnel, oTunnelDevice,
 	oLocalCommand, oPermitLocalCommand, oRemoteCommand,
 	oVisualHostKey,
-	oKexAlgorithms, oIPQoS, oRequestTTY, oSessionType,
+	oKexAlgorithms, oIPQoS, oRequestTTY, oSessionType, oStdinNull,
 	oIgnoreUnknown, oProxyUseFdpass,
 	oCanonicalDomains, oCanonicalizeHostname, oCanonicalizeMaxDots,
 	oCanonicalizeFallbackLocal, oCanonicalizePermittedCNAMEs,
@@ -299,6 +299,7 @@ static struct {
 	{ "ipqos", oIPQoS },
 	{ "requesttty", oRequestTTY },
 	{ "sessiontype", oSessionType },
+	{ "stdinnull", oStdinNull },
 	{ "proxyusefdpass", oProxyUseFdpass },
 	{ "canonicaldomains", oCanonicalDomains },
 	{ "canonicalizefallbacklocal", oCanonicalizeFallbackLocal },
@@ -1954,6 +1955,10 @@ parse_pubkey_algos:
 		multistate_ptr = multistate_sessiontype;
 		goto parse_multistate;
 
+	case oStdinNull:
+		intptr = &options->stdin_null;
+		goto parse_flag;
+
 	case oIgnoreUnknown:
 		charptr = &options->ignored_unknown;
 		goto parse_string;
@@ -2377,6 +2382,7 @@ initialize_options(Options * options)
 	options->ip_qos_bulk = -1;
 	options->request_tty = -1;
 	options->session_type = -1;
+	options->stdin_null = -1;
 	options->proxy_use_fdpass = -1;
 	options->ignored_unknown = NULL;
 	options->num_canonical_domains = 0;
@@ -2565,6 +2571,8 @@ fill_default_options(Options * options)
 		options->request_tty = REQUEST_TTY_AUTO;
 	if (options->session_type == -1)
 		options->session_type = SESSION_TYPE_DEFAULT;
+	if (options->stdin_null == -1)
+		options->stdin_null = 0;
 	if (options->proxy_use_fdpass == -1)
 		options->proxy_use_fdpass = 0;
 	if (options->canonicalize_max_dots == -1)
@@ -3243,6 +3251,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oPubkeyAuthentication, o->pubkey_authentication);
 	dump_cfg_fmtint(oRequestTTY, o->request_tty);
 	dump_cfg_fmtint(oSessionType, o->session_type);
+	dump_cfg_fmtint(oStdinNull, o->stdin_null);
 	dump_cfg_fmtint(oStreamLocalBindUnlink, o->fwd_opts.streamlocal_bind_unlink);
 	dump_cfg_fmtint(oStrictHostKeyChecking, o->strict_host_key_checking);
 	dump_cfg_fmtint(oTCPKeepAlive, o->tcp_keep_alive);

--- a/readconf.h
+++ b/readconf.h
@@ -147,6 +147,7 @@ typedef struct {
 
 	int	request_tty;
 	int	session_type;
+	int	stdin_null;
 
 	int	proxy_use_fdpass;
 

--- a/readconf.h
+++ b/readconf.h
@@ -148,6 +148,7 @@ typedef struct {
 	int	request_tty;
 	int	session_type;
 	int	stdin_null;
+	int	fork_after_authentication;
 
 	int	proxy_use_fdpass;
 

--- a/readconf.h
+++ b/readconf.h
@@ -146,6 +146,7 @@ typedef struct {
 	int	visual_host_key;
 
 	int	request_tty;
+	int	session_type;
 
 	int	proxy_use_fdpass;
 
@@ -190,6 +191,10 @@ typedef struct {
 #define REQUEST_TTY_NO		1
 #define REQUEST_TTY_YES		2
 #define REQUEST_TTY_FORCE	3
+
+#define SESSION_TYPE_NONE	0
+#define SESSION_TYPE_SUBSYSTEM	1
+#define SESSION_TYPE_DEFAULT	2
 
 #define SSHCONF_CHECKPERM	1  /* check permissions on config file */
 #define SSHCONF_USERCONF	2  /* user provided config file not system */

--- a/ssh.1
+++ b/ssh.1
@@ -425,6 +425,11 @@ keyword for more information.
 .It Fl N
 Do not execute a remote command.
 This is useful for just forwarding ports.
+Refer to the description of
+.Cm SessionType
+in
+.Xr ssh_config 5
+for details.
 .Pp
 .It Fl n
 Redirects stdin from
@@ -546,6 +551,7 @@ For full details of the options listed below, and their possible values, see
 .It SendEnv
 .It ServerAliveInterval
 .It ServerAliveCountMax
+.It SessionType
 .It SetEnv
 .It StreamLocalBindMask
 .It StreamLocalBindUnlink
@@ -703,6 +709,11 @@ Subsystems facilitate the use of SSH
 as a secure transport for other applications (e.g.\&
 .Xr sftp 1 ) .
 The subsystem is specified as the remote command.
+Refer to the description of
+.Cm SessionType
+in
+.Xr ssh_config 5
+for details.
 .Pp
 .It Fl T
 Disable pseudo-terminal allocation.

--- a/ssh.1
+++ b/ssh.1
@@ -451,6 +451,11 @@ program will be put in the background.
 needs to ask for a password or passphrase; see also the
 .Fl f
 option.)
+Refer to the description of
+.Cm StdinNull
+in
+.Xr ssh_config 5
+for details.
 .Pp
 .It Fl O Ar ctl_cmd
 Control an active connection multiplexing master process.
@@ -553,6 +558,7 @@ For full details of the options listed below, and their possible values, see
 .It ServerAliveCountMax
 .It SessionType
 .It SetEnv
+.It StdinNull
 .It StreamLocalBindMask
 .It StreamLocalBindUnlink
 .It StrictHostKeyChecking

--- a/ssh.1
+++ b/ssh.1
@@ -259,6 +259,11 @@ then a client started with
 .Fl f
 will wait for all remote port forwards to be successfully established
 before placing itself in the background.
+Refer to the description of
+.Cm ForkAfterAuthentication
+in
+.Xr ssh_config 5
+for details.
 .Pp
 .It Fl G
 Causes
@@ -508,6 +513,7 @@ For full details of the options listed below, and their possible values, see
 .It EscapeChar
 .It ExitOnForwardFailure
 .It FingerprintHash
+.It ForkAfterAuthentication
 .It ForwardAgent
 .It ForwardX11
 .It ForwardX11Timeout

--- a/ssh.c
+++ b/ssh.c
@@ -126,9 +126,6 @@ int debug_flag = 0;
 /* Flag indicating whether a tty should be requested */
 int tty_flag = 0;
 
-/* don't exec a shell */
-int no_shell_flag = 0;
-
 /*
  * Flag indicating that nothing should be read from stdin.  This can be set
  * on the command line.
@@ -142,7 +139,7 @@ int stdin_null_flag = 0;
 int need_controlpersist_detach = 0;
 
 /* Copies of flags for ControlPersist foreground mux-client */
-int ostdin_null_flag, ono_shell_flag, otty_flag, orequest_tty;
+int ostdin_null_flag, osession_type, otty_flag, orequest_tty;
 
 /*
  * Flag indicating that ssh should fork after authentication.  This is useful
@@ -181,9 +178,6 @@ Sensitive sensitive_data;
 
 /* command to be executed */
 struct sshbuf *command;
-
-/* Should we execute a command or invoke a subsystem? */
-int subsystem_flag = 0;
 
 /* # of replies received for global requests */
 static int forward_confirms_pending = -1;
@@ -921,7 +915,7 @@ main(int ac, char **av)
 				exit(255);
 			}
 			options.request_tty = REQUEST_TTY_NO;
-			no_shell_flag = 1;
+			options.session_type = SESSION_TYPE_NONE;
 			break;
 		case 'q':
 			options.log_level = SYSLOG_LEVEL_QUIET;
@@ -1024,7 +1018,7 @@ main(int ac, char **av)
 #endif
 			break;
 		case 'N':
-			no_shell_flag = 1;
+			options.session_type = SESSION_TYPE_NONE;
 			options.request_tty = REQUEST_TTY_NO;
 			break;
 		case 'T':
@@ -1039,7 +1033,7 @@ main(int ac, char **av)
 			free(line);
 			break;
 		case 's':
-			subsystem_flag = 1;
+			options.session_type = SESSION_TYPE_SUBSYSTEM;
 			break;
 		case 'S':
 			free(options.control_path);
@@ -1122,7 +1116,7 @@ main(int ac, char **av)
 	 */
 	if (!ac) {
 		/* No command specified - execute shell on a tty. */
-		if (subsystem_flag) {
+		if (options.session_type == SESSION_TYPE_SUBSYSTEM) {
 			fprintf(stderr,
 			    "You must specify a subsystem to invoke.\n");
 			usage();
@@ -1331,7 +1325,7 @@ main(int ac, char **av)
 
 	/* Cannot fork to background if no command. */
 	if (fork_after_authentication_flag && sshbuf_len(command) == 0 &&
-	    options.remote_command == NULL && !no_shell_flag)
+	    options.remote_command == NULL && options.session_type != SESSION_TYPE_NONE)
 		fatal("Cannot fork into background without a command "
 		    "to execute.");
 
@@ -2061,7 +2055,7 @@ ssh_session2_setup(struct ssh *ssh, int id, int success, void *arg)
 	if ((term = lookup_env_in_list("TERM", options.setenv,
 	    options.num_setenv)) == NULL || *term == '\0')
 		term = getenv("TERM");
-	client_session2_setup(ssh, id, tty_flag, subsystem_flag, term,
+	client_session2_setup(ssh, id, tty_flag, options.session_type == SESSION_TYPE_SUBSYSTEM, term,
 	    NULL, fileno(stdin), command, environ);
 }
 
@@ -2097,7 +2091,7 @@ ssh_session2_open(struct ssh *ssh)
 	debug3_f("channel_new: %d", c->self);
 
 	channel_send_open(ssh, c->self);
-	if (!no_shell_flag)
+	if (options.session_type != SESSION_TYPE_NONE)
 		channel_register_open_confirm(ssh, c->self,
 		    ssh_session2_setup, NULL);
 
@@ -2142,14 +2136,14 @@ ssh_session2(struct ssh *ssh, const struct ssh_conn_info *cinfo)
 	 */
 	if (options.control_persist && muxserver_sock != -1) {
 		ostdin_null_flag = stdin_null_flag;
-		ono_shell_flag = no_shell_flag;
+		osession_type = options.session_type;
 		orequest_tty = options.request_tty;
 		otty_flag = tty_flag;
 		stdin_null_flag = 1;
-		no_shell_flag = 1;
+		options.session_type = SESSION_TYPE_NONE;
 		tty_flag = 0;
 		if (!fork_after_authentication_flag &&
-		    (!ono_shell_flag || options.stdio_forward_host != NULL))
+		    (osession_type != SESSION_TYPE_NONE || options.stdio_forward_host != NULL))
 			need_controlpersist_detach = 1;
 		fork_after_authentication_flag = 1;
 	}
@@ -2160,7 +2154,7 @@ ssh_session2(struct ssh *ssh, const struct ssh_conn_info *cinfo)
 	if (options.control_persist && muxserver_sock == -1)
 		ssh_init_stdio_forwarding(ssh);
 
-	if (!no_shell_flag)
+	if (options.session_type != SESSION_TYPE_NONE)
 		id = ssh_session2_open(ssh);
 	else {
 		ssh_packet_set_interactive(ssh,

--- a/ssh.c
+++ b/ssh.c
@@ -136,13 +136,6 @@ int need_controlpersist_detach = 0;
 int ostdin_null_flag, osession_type, otty_flag, orequest_tty;
 
 /*
- * Flag indicating that ssh should fork after authentication.  This is useful
- * so that the passphrase can be entered manually, and then ssh goes to the
- * background.
- */
-int fork_after_authentication_flag = 0;
-
-/*
  * General data structure for command line options and options configurable
  * in configuration files.  See readconf.h.
  */
@@ -720,7 +713,7 @@ main(int ac, char **av)
 			options.stdin_null = 1;
 			break;
 		case 'f':
-			fork_after_authentication_flag = 1;
+			options.fork_after_authentication = 1;
 			options.stdin_null = 1;
 			break;
 		case 'x':
@@ -1318,7 +1311,7 @@ main(int ac, char **av)
 		fatal("Cannot execute command-line and remote command.");
 
 	/* Cannot fork to background if no command. */
-	if (fork_after_authentication_flag && sshbuf_len(command) == 0 &&
+	if (options.fork_after_authentication && sshbuf_len(command) == 0 &&
 	    options.remote_command == NULL && options.session_type != SESSION_TYPE_NONE)
 		fatal("Cannot fork into background without a command "
 		    "to execute.");
@@ -1744,7 +1737,7 @@ fork_postauth(void)
 	if (need_controlpersist_detach)
 		control_persist_detach();
 	debug("forking to background");
-	fork_after_authentication_flag = 0;
+	options.fork_after_authentication = 0;
 	if (daemon(1, 1) == -1)
 		fatal("daemon() failed: %.200s", strerror(errno));
 	if (stdfd_devnull(1, 1, !(log_is_on_stderr() && debug_flag)) == -1)
@@ -1758,7 +1751,7 @@ forwarding_success(void)
 		return;
 	if (--forward_confirms_pending == 0) {
 		debug_f("all expected forwarding replies received");
-		if (fork_after_authentication_flag)
+		if (options.fork_after_authentication)
 			fork_postauth();
 	} else {
 		debug2_f("%d expected forwarding replies remaining",
@@ -2136,10 +2129,10 @@ ssh_session2(struct ssh *ssh, const struct ssh_conn_info *cinfo)
 		options.stdin_null = 1;
 		options.session_type = SESSION_TYPE_NONE;
 		tty_flag = 0;
-		if (!fork_after_authentication_flag &&
+		if (!options.fork_after_authentication &&
 		    (osession_type != SESSION_TYPE_NONE || options.stdio_forward_host != NULL))
 			need_controlpersist_detach = 1;
-		fork_after_authentication_flag = 1;
+		options.fork_after_authentication = 1;
 	}
 	/*
 	 * ControlPersist mux listen socket setup failed, attempt the
@@ -2186,7 +2179,7 @@ ssh_session2(struct ssh *ssh, const struct ssh_conn_info *cinfo)
 	 * If requested and we are not interested in replies to remote
 	 * forwarding requests, then let ssh continue in the background.
 	 */
-	if (fork_after_authentication_flag) {
+	if (options.fork_after_authentication) {
 		if (options.exit_on_forward_failure &&
 		    options.num_remote_forwards > 0) {
 			debug("deferring postauth fork until remote forward "

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1675,6 +1675,22 @@ Similarly to
 with the exception of the
 .Ev TERM
 variable, the server must be prepared to accept the environment variable.
+.It Cm StdinNull
+Redirects stdin from
+.Pa /dev/null
+(actually, prevents reading from stdin).
+Either this or the equivalent
+.Fl n
+option must be used when
+.Nm ssh
+is run in the background.
+The argument to this keyword must be
+.Cm yes
+(same as the
+.Fl n
+option) or
+.Cm no
+(the default).
 .It Cm StreamLocalBindMask
 Sets the octal file creation mode mask
 .Pq umask

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -676,6 +676,45 @@ Valid options are:
 and
 .Cm sha256
 (the default).
+.It Cm ForkAfterAuthentication
+Requests
+.Nm ssh
+to go to background just before command execution.
+This is useful if
+.Nm ssh
+is going to ask for passwords or passphrases, but the user
+wants it in the background.
+This implies the
+.Cm StdinNull
+configuration option being set to
+.Dq yes .
+The recommended way to start X11 programs at a remote site is with
+something like
+.Ic ssh -f host xterm ,
+which is the same as
+.Ic ssh host xterm
+if the
+.Cm ForkAfterAuthentication
+configuration option is set to
+.Dq yes .
+.Pp
+If the
+.Cm ExitOnForwardFailure
+configuration option is set to
+.Dq yes ,
+then a client started with the
+.Cm ForkAfterAuthentication
+configuration option being set to
+.Dq yes
+will wait for all remote port forwards to be successfully established
+before placing itself in the background.
+The argument to this keyword must be
+.Cm yes
+(same as the
+.Fl f
+option) or
+.Cm no
+(the default).
 .It Cm ForwardAgent
 Specifies whether the connection to the authentication agent (if any)
 will be forwarded to the remote machine.

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1263,6 +1263,21 @@ The argument to this keyword must be
 or
 .Cm no
 (the default).
+.It Cm SessionType
+May be used to either request invocation of a subsystem on the remote system,
+or to prevent the execution of a remote command at all.
+The latter is useful for just forwarding ports.
+The argument to this keyword must be
+.Cm none
+(same as the
+.Fl N
+option),
+.Cm subsystem
+(same as the
+.Fl s
+option) or
+.Cm default
+(the default).
 .It Cm NumberOfPasswordPrompts
 Specifies the number of password prompts before giving up.
 The argument to this keyword must be an integer.


### PR DESCRIPTION
Dear OpenSSH developers,

I kindly ask you to review the attached set of patches which introduce `ssh_config` equivalents of the flags `-N`, `-s`, `-n` and `-f` in a straight forward way:

* <del>`NoShell` for `-N`</del>
* `SessionType` for `-N` and `-s`
* `StdinNull` for `-n`
* `ForkAfterAuthentication` for `-f`

The `ssh_config` names are corresponding directly to the internal flag names. The man pages `ssh(1)` and `ssh_config(5)` are adjusted accordingly.

<del>As a final remark, I noticed that the variable `ono_shell_flag` (not to be confused with `no_shell_flag`) is only assigned once and never used. So I assume this is dead code and I'm proposing a patch to remove it.</del>
(Update: `ono_shell_flag` was actually meant to be used, see 5953c143008259d87342fb5155bd0b8835ba88e5)

Related mailing list threads:
* [[PATCH] Add ssh_config option ExecRemoteCommand which is equivalent to -N](https://marc.info/?l=openssh-unix-dev&m=147248154926769) (original proposal from 2016)
* [Option equivalent to -n in client?](https://marc.info/?l=openssh-unix-dev&m=161301825023655) (another user asking for a similar improvement in 2021)
* [[PATCH] Add ssh_config equivalents of -N, -n and -f](https://marc.info/?l=openssh-unix-dev&m=161387765919633) (new proposed patches in 2021)

Best regards,
Volker