### PR TITLE
ssh: pkcs11: pkcs11_del_provider was missing for ssh.

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -1690,6 +1690,10 @@ main(int ac, char **av)
 		options.certificate_files[i] = NULL;
 	}
 
+#ifdef ENABLE_PKCS11
+	(void)pkcs11_del_provider(options.pkcs11_provider);
+#endif
+
  skip_connect:
 	exit_status = ssh_session2(ssh, cinfo);
 	ssh_conn_info_free(cinfo);


### PR DESCRIPTION
C_Finalize API is needed to properly terminate a C_Initialize.
This can cause pkcs11 objects to be left exposed. This patch
does the required cleanup to keep the sanity of the HSM.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>