### PR TITLE
Ignoring comments at end of config file lines broke ProxyCommand.

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -2133,8 +2133,14 @@ read_config_file_depth(const char *filename, struct passwd *pw,
 		 * NB - preserve newlines, they are needed to reproduce
 		 * line numbers later for error messages.
 		 */
-		if ((cp = strchr(line, '#')) != NULL)
-			*cp = '\0';
+		for (cp = line; (cp - line) < linesize && *cp; cp++) {
+			if (!isspace(*cp)) {
+				if (*cp == '#') {
+					*cp = '\0';
+				}
+				break;
+			}
+		}
 		if (process_config_line_depth(options, pw, host, original_host,
 		    line, filename, linenum, activep, flags, want_final_pass,
 		    depth) != 0)


### PR DESCRIPTION
If all lines are negated from the hash-sign onwards, any existing
options with embedded hash-signs are truncated. e.g. If there are
bash parts that manipulate strings.

The value is too free form to keep a good tab on when the
hash-sign is meant to be in the value and when not.

Unfortunately as 8.5 is released, there probably already exist
config files that have comments at the end of options.

Changed the comment remover to ignore only lines having a
hash-sign as the first non-space character. This will break 8.5
configurations with hash-comments at the end of functional lines.