### PR TITLE
fix control socket listener (didn't chdir /)

### DIFF
--- a/mux.c
+++ b/mux.c
@@ -1349,6 +1349,10 @@ muxserver_listen(struct ssh *ssh)
 	mux_listener_channel->mux_rcb = mux_master_read_cb;
 	debug3_f("mux listener channel %d fd %d",
 	    mux_listener_channel->self, mux_listener_channel->sock);
+
+	/* Now chdir / so as not to hamper umounts */
+	if (chdir("/") == -1)
+	    error("Control socket listener unable to chdir to path \"/\": %s", strerror(errno));
 }
 
 /* Callback on open confirmation in mux master for a mux client session. */


### PR DESCRIPTION
When a control socket is in use, the process inherits and retains the existing current working directory. This is a problem when it happens to be in the file system of a removeable storage device like a USB stick. Later, when the user tries to umount the removeable storage, it fails because an ssh process is still using it as a current working directory. The ssh process has to be identified and terminated before the removeable storage can be umounted. This patch adds chdir("/") at the end of muxserver_listen() in mux.c to solve this problem.