### PR TITLE
Remove stray "i" from CASignatureAlgorithms man page listings

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -373,7 +373,7 @@ by certificate authorities (CAs).
 The default is:
 .Bd -literal -offset indent
 ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
-sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,i
+sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,
 rsa-sha2-512,rsa-sha2-256
 .Ed
 .Pp

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -378,7 +378,7 @@ by certificate authorities (CAs).
 The default is:
 .Bd -literal -offset indent
 ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,
-sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,i
+sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,
 rsa-sha2-512,rsa-sha2-256
 .Ed
 .Pp


### PR DESCRIPTION
It wasn't there in the #174 original, maybe cropped up in the merge.