### PR TITLE
fix control socket listener (didn't chdir /)

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -1736,7 +1736,7 @@ control_persist_detach(void)
 	}
 	if (stdfd_devnull(1, 1, !(log_is_on_stderr() && debug_flag)) == -1)
 		error_f("stdfd_devnull failed");
-	daemon(1, 1);
+	daemon(0, 1);
 	setproctitle("%s [mux]", options.control_path);
 }
 


### PR DESCRIPTION
When a control socket is in use, the process inherits and retains the existing current working directory. This is a problem when it happens to be in the file system of a removeable storage device like a USB stick. Later, when the user tries to umount the removeable storage, it fails because an ssh process is still using it as a current working directory. The ssh process has to be identified and terminated before the removeable storage can be umounted. This patch changes daemon(1, 1) in the control_persist_detach() function to daemon(0, 1) so that daemon() will chdir /.