### PR TITLE
Restore nonblock

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -398,9 +398,16 @@ channel_new(struct ssh *ssh, char *ctype, int type, int rfd, int wfd, int efd,
 	c->remote_name = xstrdup(remote_name);
 	c->ctl_chan = -1;
 	c->delayed = 1;		/* prevent call to channel_post handler */
+	c->nb_flags = 0;
 	TAILQ_INIT(&c->status_confirms);
 	debug("channel %d: new [%s]", found, remote_name);
 	return c;
+}
+
+void
+channel_set_nb_flags(Channel *c, int flags)
+{
+	c->nb_flags |= flags;
 }
 
 static void

--- a/channels.h
+++ b/channels.h
@@ -194,7 +194,9 @@ struct Channel {
 };
 
 /* Bit values for nb_flags */
-#define CHAN_UNSET_NB_OUT 		1
+#define CHAN_UNSET_NB_IN 		1
+#define CHAN_UNSET_NB_OUT 		2
+#define CHAN_UNSET_NB_ERR 		4
 
 #define CHAN_EXTENDED_IGNORE		0
 #define CHAN_EXTENDED_READ		1

--- a/channels.h
+++ b/channels.h
@@ -188,7 +188,13 @@ struct Channel {
 	void			*mux_ctx;
 	int			mux_pause;
 	int			mux_downstream_id;
+
+	/* nonblock should be restored */
+	int     		nb_flags;
 };
+
+/* Bit values for nb_flags */
+#define CHAN_UNSET_NB_OUT 		1
 
 #define CHAN_EXTENDED_IGNORE		0
 #define CHAN_EXTENDED_READ		1
@@ -268,6 +274,7 @@ void	 channel_register_status_confirm(struct ssh *, int,
 void	 channel_cancel_cleanup(struct ssh *, int);
 int	 channel_close_fd(struct ssh *, int *);
 void	 channel_send_window_changes(struct ssh *);
+void	 channel_set_nb_flags(Channel *c, int flags);
 
 /* mux proxy support */
 

--- a/clientloop.c
+++ b/clientloop.c
@@ -1403,14 +1403,6 @@ client_loop(struct ssh *ssh, int have_pty, int escape_char_arg,
 	if (have_pty)
 		leave_raw_mode(options.request_tty == REQUEST_TTY_FORCE);
 
-	/* restore blocking io */
-	if (!isatty(fileno(stdin)))
-		unset_nonblock(fileno(stdin));
-	if (!isatty(fileno(stdout)))
-		unset_nonblock(fileno(stdout));
-	if (!isatty(fileno(stderr)))
-		unset_nonblock(fileno(stderr));
-
 	/*
 	 * If there was no shell or command requested, there will be no remote
 	 * exit status to be returned.  In that case, clear error code if the

--- a/nchan.c
+++ b/nchan.c
@@ -40,6 +40,7 @@
 #include "channels.h"
 #include "compat.h"
 #include "log.h"
+#include "misc.h"
 
 /*
  * SSH Protocol 1.5 aka New Channel Protocol
@@ -384,6 +385,8 @@ chan_shutdown_write(struct ssh *ssh, Channel *c)
 			    c->istate, c->ostate, strerror(errno));
 		}
 	} else {
+		if (c->nb_flags & CHAN_UNSET_NB_OUT)
+			unset_nonblock(c->wfd);
 		if (channel_close_fd(ssh, &c->wfd) < 0) {
 			logit_f("channel %d: close() failed for "
 			    "fd %d [i%d o%d]: %.100s", c->self, c->wfd,

--- a/nchan.c
+++ b/nchan.c
@@ -415,6 +415,8 @@ chan_shutdown_read(struct ssh *ssh, Channel *c)
 			    c->istate, c->ostate, strerror(errno));
 		}
 	} else {
+		if (c->nb_flags & CHAN_UNSET_NB_IN)
+			unset_nonblock(c->rfd);
 		if (channel_close_fd(ssh, &c->rfd) < 0) {
 			logit_f("channel %d: close() failed for "
 			    "fd %d [i%d o%d]: %.100s", c->self, c->rfd,
@@ -434,6 +436,8 @@ chan_shutdown_extended_read(struct ssh *ssh, Channel *c)
 	debug_f("channel %d: (i%d o%d sock %d wfd %d efd %d [%s])",
 	    c->self, c->istate, c->ostate, c->sock, c->rfd, c->efd,
 	    channel_format_extended_usage(c));
+	if (c->nb_flags & CHAN_UNSET_NB_ERR)
+		unset_nonblock(c->efd);
 	if (channel_close_fd(ssh, &c->efd) < 0) {
 		logit_f("channel %d: close() failed for "
 		    "extended fd %d [i%d o%d]: %.100s", c->self, c->efd,

--- a/ssh.c
+++ b/ssh.c
@@ -2075,16 +2075,24 @@ ssh_session2_open(struct ssh *ssh)
 		fatal("dup() in/out/err failed");
 
 	/* enable nonblocking unless tty */
-	if (!isatty(in))
-		set_nonblock(in);
+	if (!isatty(in)) {
+		if ((fcntl(in, F_GETFL) & O_NONBLOCK) == 0) {
+			nb_flags |= CHAN_UNSET_NB_IN;
+			set_nonblock(in);
+		}
+	}
 	if (!isatty(out)) {
 		if ((fcntl(out, F_GETFL) & O_NONBLOCK) == 0) {
 			nb_flags |= CHAN_UNSET_NB_OUT;
 			set_nonblock(out);
 		}
 	}
-	if (!isatty(err))
-		set_nonblock(err);
+	if (!isatty(err)) {
+		if ((fcntl(err, F_GETFL) & O_NONBLOCK) == 0) {
+			nb_flags |= CHAN_UNSET_NB_ERR;
+			set_nonblock(err);
+		}
+	}
 
 	window = CHAN_SES_WINDOW_DEFAULT;
 	packetmax = CHAN_SES_PACKET_DEFAULT;


### PR DESCRIPTION
OpenSSH incorrectly restores the standard mode (blocking mode) on standard output upon exiting. This causes the next shell scripts commands to potentially fail in EAGAIN.
The reproducer is:
 
```
#!/bin/sh
(
ssh localhost true
cat /dev/zero
) | sleep 30
 
```
 
Restoring the blocking modes happens with the duped file descriptors and too late.
 
The changes causing this problem was introduced in https://github.com/openssh/openssh-portable/commit/4d5456c7de108e17603a0920c4d15bca87244921
 
We introduce storing the real blocking state of the file descriptors and restoring it on closing the fds.
We also remove the too late restoring of the blocking mode