### PR TITLE
fix debug msg in client during publickey cert auth

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1373,8 +1373,8 @@ sign_and_send_pubkey(struct ssh *ssh, Identity *id)
 		}
 		if (sign_id != NULL) {
 			debug2_f("using private key \"%s\"%s for "
-			    "certificate", id->filename,
-			    id->agent_fd != -1 ? " from agent" : "");
+			    "certificate", sign_id->filename,
+			    sign_id->agent_fd != -1 ? " from agent" : "");
 		} else {
 			debug_f("no separate private key for certificate "
 			    "\"%s\"", id->filename);


### PR DESCRIPTION
the `sign_id->filename` should be shown when it's present during publickey
certificate based authentication exchange