### PR TITLE
[ssh-copy-id] Do not treat Dropbear special

### DIFF
--- a/contrib/ssh-copy-id
+++ b/contrib/ssh-copy-id
@@ -332,13 +332,6 @@ case "$REMOTE_VERSION" in
       exit 1
     fi
     ;;
-  dropbear*)
-    populate_new_ids 0
-    [ "$DRY_RUN" ] || printf '%s\n' "$NEW_IDS" | \
-      $SSH "$@" "$(installkeys_sh /etc/dropbear/authorized_keys)" \
-      || exit 1
-    ADDED=$(printf '%s\n' "$NEW_IDS" | wc -l)
-    ;;
   *)
     # Assuming that the remote host treats ~/.ssh/authorized_keys as one might expect
     populate_new_ids 0


### PR DESCRIPTION
`ssh-copy-id` currently copies authorized keys to `/etc/dropbear/authorized_keys` when Dropbear is detected as SSH server. This is wrong as Dropbear by default looks for authorized keys in `~/.ssh/authorized_keys`, like OpenSSH does. Presumably `/etc/dropbear/authorized_keys` made its way into this script as OpenWRT uses a non-default Dropbear build, using this location instead. But this is special to OpenWRT, being a single user single purpose router distribution.

Official Dropbear manpage: https://github.com/mkj/dropbear/blob/846d38fe4319c517683ac3df1796b3bc0180be14/dropbear.8#L108

OpenWRT patch to override the authorized keys location: https://github.com/openwrt/openwrt/blob/ec6293febc244d187e71a6e54f44920be679cde4/package/network/services/dropbear/patches/100-pubkey_path.patch