### PR TITLE
Allow import Edwards keys from OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2890,6 +2890,7 @@ if test "x$openssl" = "xyes" ; then
 		EVP_MD_CTX_new \
 		EVP_MD_CTX_free \
 		EVP_chacha20 \
+		EVP_PKEY_get_raw_public_key \
 	])
 
 	if test "x$openssl_engine" = "xyes" ; then

--- a/sshkey.c
+++ b/sshkey.c
@@ -4661,6 +4661,42 @@ sshkey_parse_private_pem_fileblob(struct sshbuf *blob, int type,
 			sshkey_dump_ec_key(prv->ecdsa);
 # endif
 #endif /* OPENSSL_HAS_ECC */
+#ifdef HAVE_EVP_PKEY_GET_RAW_PUBLIC_KEY
+	} else if (EVP_PKEY_base_id(pk) == EVP_PKEY_ED25519 &&
+	    (type == KEY_UNSPEC || type == KEY_ED25519)) {
+		u_char *privkey, *pubkey;
+		size_t privlen = crypto_sign_ed25519_PUBLICKEYBYTES, publen = crypto_sign_ed25519_PUBLICKEYBYTES;
+
+		if ((prv = sshkey_new(KEY_UNSPEC)) == NULL) {
+			r = SSH_ERR_ALLOC_FAIL;
+			goto out;
+		}
+
+		if ((privkey = malloc(privlen)) == NULL) {
+			r = SSH_ERR_ALLOC_FAIL;
+			goto out;
+		}
+
+		if(EVP_PKEY_get_raw_private_key(pk, privkey, &privlen) <= 0) {
+			r = SSH_ERR_INVALID_FORMAT;
+			goto out;
+		}
+
+		if ((pubkey = malloc(publen)) == NULL) {
+			freezero(privkey, privlen);
+			r = SSH_ERR_ALLOC_FAIL;
+			goto out;
+		}
+
+		if(EVP_PKEY_get_raw_public_key(pk, pubkey, &publen) <= 0) {
+			r = SSH_ERR_INVALID_FORMAT;
+			goto out;
+		}
+
+		prv->type = KEY_ED25519;
+		prv->ed25519_sk = privkey;
+		prv->ed25519_pk = pubkey;
+#endif /* HAVE_EVP_PKEY_GET_RAW_PUBLIC_KEY */
 	} else {
 		r = SSH_ERR_INVALID_FORMAT;
 		goto out;


### PR DESCRIPTION
Modern OpenSSL versions support ed25519 keys. These patches add the detection of the necessary functions and uses them for import of ed25519 keys to OpenSSH