### PR TITLE
Support Unix socket forwarding with -W

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -1517,12 +1517,18 @@ channel_decode_socks5(Channel *c, struct sshbuf *input, struct sshbuf *output)
 
 Channel *
 channel_connect_stdio_fwd(struct ssh *ssh,
-    const char *host_to_connect, u_short port_to_connect,
+    const char *host_to_connect, int port_to_connect,
     int in, int out, int nonblock)
 {
 	Channel *c;
+	char* rtype;
 
 	debug_f("%s:%d", host_to_connect, port_to_connect);
+
+	if (port_to_connect == PORT_STREAMLOCAL)
+		rtype = "direct-streamlocal@openssh.com";
+	else
+		rtype = "direct-tcpip";
 
 	c = channel_new(ssh, "stdio-forward", SSH_CHANNEL_OPENING, in, out,
 	    -1, CHAN_TCP_WINDOW_DEFAULT, CHAN_TCP_PACKET_DEFAULT,
@@ -1534,7 +1540,7 @@ channel_connect_stdio_fwd(struct ssh *ssh,
 	c->force_drain = 1;
 
 	channel_register_fds(ssh, c, in, out, -1, 0, 1, 0);
-	port_open_helper(ssh, c, "direct-tcpip");
+	port_open_helper(ssh, c, rtype);
 
 	return c;
 }

--- a/channels.h
+++ b/channels.h
@@ -324,7 +324,7 @@ Channel	*channel_connect_to_port(struct ssh *, const char *, u_short,
 	    char *, char *, int *, const char **);
 Channel *channel_connect_to_path(struct ssh *, const char *, char *, char *);
 Channel	*channel_connect_stdio_fwd(struct ssh *, const char*,
-	    u_short, int, int, int);
+	    int, int, int, int);
 Channel	*channel_connect_by_listen_address(struct ssh *, const char *,
 	    u_short, char *, char *);
 Channel	*channel_connect_by_listen_path(struct ssh *, const char *,

--- a/ssh.c
+++ b/ssh.c
@@ -909,7 +909,10 @@ main(int ac, char **av)
 			if (muxclient_command != 0)
 				fatal("Cannot specify stdio forward with -O");
 			if (parse_forward(&fwd, optarg, 1, 0)) {
-				options.stdio_forward_host = fwd.listen_host;
+				if (fwd.listen_port == PORT_STREAMLOCAL)
+					options.stdio_forward_host = fwd.listen_path;
+				else
+					options.stdio_forward_host = fwd.listen_host;
 				options.stdio_forward_port = fwd.listen_port;
 				free(fwd.connect_host);
 			} else {


### PR DESCRIPTION
Currently ssh -W will parse Unix socket arguments correctly, but will
then fail to set up a tunnel because parse_forward() sets listen_path
instead of listen_host.

Choose the correct value for stdio_forward_host and use the correct
rtype in channel_connect_stdio_fwd().