### PR TITLE
Standardize the string functions

### DIFF
--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -95,7 +95,7 @@ int rresvport_af(int *alport, sa_family_t af);
 #endif
 
 #ifndef HAVE_STRLCPY
-size_t strlcpy(char * restrict dst, const char * restrict src, size_t siz);
+size_t strlcpy(char * __restrict dst, const char * __restrict src, size_t siz);
 #endif
 
 #ifndef HAVE_STRLCAT

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -95,7 +95,7 @@ int rresvport_af(int *alport, sa_family_t af);
 #endif
 
 #ifndef HAVE_STRLCPY
-size_t strlcpy(char *dst, const char *src, size_t siz);
+size_t strlcpy(char * restrict dst, const char * restrict src, size_t siz);
 #endif
 
 #ifndef HAVE_STRLCAT
@@ -119,7 +119,7 @@ int setenv(register const char *name, register const char *value, int rewrite);
 #endif
 
 #ifndef HAVE_STRMODE
-void strmode(int mode, char *p);
+void strmode(mode_t mode, char *p);
 #endif
 
 #ifndef HAVE_STRPTIME

--- a/openbsd-compat/strlcat.c
+++ b/openbsd-compat/strlcat.c
@@ -32,31 +32,31 @@
  * If retval >= siz, truncation occurred.
  */
 size_t
-strlcat(char *dst, const char *src, size_t siz)
+strlcat(char * __restrict dst, const char * __restrict src, size_t siz)
 {
-	char *d = dst;
-	const char *s = src;
-	size_t n = siz;
+	char * const d = dst;
+	const char * const s = src;
+	const size_t n = siz;
 	size_t dlen;
 
 	/* Find the end of dst and adjust bytes left but don't go past end */
-	while (n-- != 0 && *d != '\0')
-		d++;
-	dlen = d - dst;
-	n = siz - dlen;
+	while (siz-- != 0 && *dst != '\0')
+		dst++;
+	dlen = dst - d;
+	siz = n - dlen;
 
-	if (n == 0)
-		return(dlen + strlen(s));
-	while (*s != '\0') {
-		if (n != 1) {
-			*d++ = *s;
-			n--;
+	if (siz == 0)
+		return(dlen + strlen(src));
+	while (*src != '\0') {
+		if (siz != 1) {
+			*dst++ = *src;
+			siz--;
 		}
-		s++;
+		src++;
 	}
-	*d = '\0';
+	*dst = '\0';
 
-	return(dlen + (s - src));	/* count does not include NUL */
+	return(dlen + (src - s));	/* count does not include NUL */
 }
 
 #endif /* !HAVE_STRLCAT */

--- a/openbsd-compat/strlcpy.c
+++ b/openbsd-compat/strlcpy.c
@@ -30,7 +30,7 @@
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
 size_t
-strlcpy(char * restrict dst, const char * restrict src, size_t siz)
+strlcpy(char * __restrict dst, const char * __restrict src, size_t siz)
 {
 	const char * const s = src;
 	const size_t n = siz;

--- a/openbsd-compat/strlcpy.c
+++ b/openbsd-compat/strlcpy.c
@@ -30,29 +30,28 @@
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
 size_t
-strlcpy(char *dst, const char *src, size_t siz)
+strlcpy(char * restrict dst, const char * restrict src, size_t siz)
 {
-	char *d = dst;
-	const char *s = src;
-	size_t n = siz;
+	const char * const s = src;
+	const size_t n = siz;
 
 	/* Copy as many bytes as will fit */
-	if (n != 0) {
-		while (--n != 0) {
-			if ((*d++ = *s++) == '\0')
+	if (siz != 0) {
+		while (--siz != 0) {
+			if ((*dst++ = *src++) == '\0')
 				break;
 		}
 	}
 
 	/* Not enough room in dst, add NUL and traverse rest of src */
-	if (n == 0) {
-		if (siz != 0)
-			*d = '\0';		/* NUL-terminate dst */
-		while (*s++)
+	if (siz == 0) {
+		if (n != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
 			;
 	}
 
-	return(s - src - 1);	/* count does not include NUL */
+	return(src - s - 1);	/* count does not include NUL */
 }
 
 #endif /* !HAVE_STRLCPY */

--- a/openbsd-compat/strmode.c
+++ b/openbsd-compat/strmode.c
@@ -37,10 +37,8 @@
 #include <sys/stat.h>
 #include <string.h>
 
-/* XXX mode should be mode_t */
-
 void
-strmode(int mode, char *p)
+strmode(mode_t mode, char *p)
 {
 	 /* print type */
 	switch (mode & S_IFMT) {


### PR DESCRIPTION
Current standards say strlcpy and strlcat must have restrict qualifiers in their function definitions, also mode_t is now the type of the first argument in strmode.