### PR TITLE
docs: Use more appropriate language when referring to the user

### DIFF
--- a/ssh.1
+++ b/ssh.1
@@ -88,7 +88,7 @@ or a URI of the form
 .No ssh:// Oo user @ Oc hostname Op : port .
 .Sm on
 The user must prove
-his/her identity to the remote machine using one of several methods
+their identity to the remote machine using one of several methods
 (see below).
 .Pp
 If a
@@ -908,7 +908,7 @@ or higher (e.g. by using the
 .Fl v
 flag).
 .Pp
-The user creates his/her key pair by running
+The user creates their key pair by running
 .Xr ssh-keygen 1 .
 This stores the private key in
 .Pa ~/.ssh/id_dsa
@@ -942,7 +942,7 @@ in the user's home directory.
 The user should then copy the public key
 to
 .Pa ~/.ssh/authorized_keys
-in his/her home directory on the remote machine.
+in their home directory on the remote machine.
 The
 .Pa authorized_keys
 file corresponds to the conventional

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1346,7 +1346,7 @@ check_host_key(char *hostname, const struct ssh_conn_info *cinfo,
 		 * XXX Should permit the user to change to use the new id.
 		 * This could be done by converting the host key to an
 		 * identifying sentence, tell that the host identifies itself
-		 * by that sentence, and ask the user if he/she wishes to
+		 * by that sentence, and ask the user if they wish to
 		 * accept the authentication.
 		 */
 		break;


### PR DESCRIPTION
This pull request changes the language used in the `ssh.1` manpage and `sshconnect.c` comments in order to be more modern and correct, when referring to the user. The [singular they](https://www.merriam-webster.com/words-at-play/singular-nonbinary-they) pronoun is more appropriate to use here, and is less awkward than saying `his/her`.