### PR TITLE
StrictHostKeyChecking man page arg formatting fixes

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1707,14 +1707,14 @@ This option forces the user to manually
 add all new hosts.
 .Pp
 If this flag is set to
-.Dq accept-new
+.Cm accept-new ,
 then ssh will automatically add new host keys to the user
 known hosts files, but will not permit connections to hosts with
 changed host keys.
 If this flag is set to
-.Dq no
+.Cm no
 or
-.Dq off ,
+.Cm off ,
 ssh will automatically add new host keys to the user known hosts files
 and allow connections to hosts with changed hostkeys to proceed,
 subject to some restrictions.


### PR DESCRIPTION
Format StrictHostKeyChecking args consistently with others, use `.Cm`
instead of `.Dq`.

While at it, add a missing comma after `accept-new`.