### PR TITLE
OpenSSH's ssh-keygen can't parse encrypted PKCS#8 private keys being …

### DIFF
--- a/sshkey.c
+++ b/sshkey.c
@@ -4504,6 +4504,16 @@ translate_libcrypto_error(unsigned long pem_err)
 		default:
 			return SSH_ERR_INVALID_FORMAT;
 		}
+#ifdef ERR_R_INTERRUPTED_OR_CANCELLED
+	case ERR_LIB_CRYPTO:
+		switch (pem_reason) {
+		case ERR_R_INTERRUPTED_OR_CANCELLED:
+			return SSH_ERR_KEY_WRONG_PASSPHRASE;
+		default:
+			return SSH_ERR_INVALID_FORMAT;
+		}
+#endif
+
 	case ERR_LIB_EVP:
 		switch (pem_reason) {
 		case EVP_R_BAD_DECRYPT:


### PR DESCRIPTION
…built against openssl 3.0

See bz#3330