### PR TITLE
Fix memory leak bug

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -886,6 +886,7 @@ sshpam_query(void *ctx, char **name, char **info,
 		case PAM_AUTH_ERR:
 			debug3("PAM: %s", pam_strerror(sshpam_handle, type));
 			if (**prompts != NULL && strlen(**prompts) != 0) {
+			    free(*info);
 				*info = **prompts;
 				**prompts = NULL;
 				*num = 0;


### PR DESCRIPTION
the pointer to the allocated memory is overwritten and lost on line 889