### PR TITLE
CVE-2016-20012 - Publickey Information leak - Only allow SSH_MSG_USERAUTH_REQUEST with signature

### DIFF
--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -264,9 +264,10 @@ userauth_pubkey(struct ssh *ssh)
 		 * if a user is not allowed to login. is this an
 		 * issue? -markus
 		 */
-		debug_f("options.pubkey_disable_pk_check %d", options.pubkey_disable_pk_check);
-		if (options.pubkey_disable_pk_check)
+		if (options.pubkey_disable_pk_check) {
+			debug_f("SSH_MSG_USERAUTH_REQUEST without signature are forbidden");
 			goto done;
+		}
 		if (PRIVSEP(user_key_allowed(ssh, pw, key, 0, NULL))) {
 			if ((r = sshpkt_start(ssh, SSH2_MSG_USERAUTH_PK_OK))
 			    != 0 ||

--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -264,6 +264,9 @@ userauth_pubkey(struct ssh *ssh)
 		 * if a user is not allowed to login. is this an
 		 * issue? -markus
 		 */
+		debug_f("options.pubkey_disable_pk_check %d", options.pubkey_disable_pk_check);
+		if (options.pubkey_disable_pk_check)
+			goto done;
 		if (PRIVSEP(user_key_allowed(ssh, pw, key, 0, NULL))) {
 			if ((r = sshpkt_start(ssh, SSH2_MSG_USERAUTH_PK_OK))
 			    != 0 ||

--- a/readconf.c
+++ b/readconf.c
@@ -154,7 +154,7 @@ typedef enum {
 	oBatchMode, oCheckHostIP, oStrictHostKeyChecking, oCompression,
 	oTCPKeepAlive, oNumberOfPasswordPrompts,
 	oLogFacility, oLogLevel, oLogVerbose, oCiphers, oMacs,
-	oPubkeyAuthentication,
+	oPubkeyAuthentication, oPubkeyDisablePKCheck,
 	oKbdInteractiveAuthentication, oKbdInteractiveDevices, oHostKeyAlias,
 	oDynamicForward, oPreferredAuthentications, oHostbasedAuthentication,
 	oHostKeyAlgorithms, oBindAddress, oBindInterface, oPKCS11Provider,
@@ -233,6 +233,7 @@ static struct {
 	{ "skeyauthentication", oKbdInteractiveAuthentication }, /* alias */
 	{ "tisauthentication", oKbdInteractiveAuthentication },  /* alias */
 	{ "pubkeyauthentication", oPubkeyAuthentication },
+	{ "pubkeydisablepkcheck", oPubkeyDisablePKCheck},
 	{ "dsaauthentication", oPubkeyAuthentication },		    /* alias */
 	{ "hostbasedauthentication", oHostbasedAuthentication },
 	{ "identityfile", oIdentityFile },
@@ -1103,6 +1104,10 @@ parse_time:
 
 	case oPubkeyAuthentication:
 		intptr = &options->pubkey_authentication;
+		goto parse_flag;
+
+	case oPubkeyDisablePKCheck:
+		intptr = &options->pubkey_disable_pk_check;
 		goto parse_flag;
 
 	case oHostbasedAuthentication:
@@ -2332,6 +2337,7 @@ initialize_options(Options * options)
 	options->fwd_opts.streamlocal_bind_mask = (mode_t)-1;
 	options->fwd_opts.streamlocal_bind_unlink = -1;
 	options->pubkey_authentication = -1;
+	options->pubkey_disable_pk_check = -1;
 	options->gss_authentication = -1;
 	options->gss_deleg_creds = -1;
 	options->password_authentication = -1;
@@ -2488,6 +2494,8 @@ fill_default_options(Options * options)
 		options->fwd_opts.streamlocal_bind_unlink = 0;
 	if (options->pubkey_authentication == -1)
 		options->pubkey_authentication = 1;
+	if (options->pubkey_disable_pk_check == -1)
+		options->pubkey_disable_pk_check = 0;
 	if (options->gss_authentication == -1)
 		options->gss_authentication = 0;
 	if (options->gss_deleg_creds == -1)
@@ -3285,7 +3293,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oGssDelegateCreds, o->gss_deleg_creds);
 #endif /* GSSAPI */
 	dump_cfg_fmtint(oHashKnownHosts, o->hash_known_hosts);
-	dump_cfg_fmtint(oHostbasedAuthentication, o->hostbased_authentication);
+	dump_cfg_fmtint(oHostbasedAuthentication, o->pubkey_disable_pk_check);
 	dump_cfg_fmtint(oIdentitiesOnly, o->identities_only);
 	dump_cfg_fmtint(oKbdInteractiveAuthentication, o->kbd_interactive_authentication);
 	dump_cfg_fmtint(oNoHostAuthenticationForLocalhost, o->no_host_authentication_for_localhost);
@@ -3293,6 +3301,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oPermitLocalCommand, o->permit_local_command);
 	dump_cfg_fmtint(oProxyUseFdpass, o->proxy_use_fdpass);
 	dump_cfg_fmtint(oPubkeyAuthentication, o->pubkey_authentication);
+	dump_cfg_fmtint(oPubkeyDisablePKCheck, o->pubkey_disable_pk_check);
 	dump_cfg_fmtint(oRequestTTY, o->request_tty);
 	dump_cfg_fmtint(oSessionType, o->session_type);
 	dump_cfg_fmtint(oStdinNull, o->stdin_null);

--- a/readconf.c
+++ b/readconf.c
@@ -3293,7 +3293,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oGssDelegateCreds, o->gss_deleg_creds);
 #endif /* GSSAPI */
 	dump_cfg_fmtint(oHashKnownHosts, o->hash_known_hosts);
-	dump_cfg_fmtint(oHostbasedAuthentication, o->pubkey_disable_pk_check);
+	dump_cfg_fmtint(oHostbasedAuthentication, o->hostbased_authentication);
 	dump_cfg_fmtint(oIdentitiesOnly, o->identities_only);
 	dump_cfg_fmtint(oKbdInteractiveAuthentication, o->kbd_interactive_authentication);
 	dump_cfg_fmtint(oNoHostAuthenticationForLocalhost, o->no_host_authentication_for_localhost);

--- a/readconf.h
+++ b/readconf.h
@@ -37,6 +37,7 @@ typedef struct {
 	char   *xauth_location;	/* Location for xauth program */
 	struct ForwardOptions fwd_opts;	/* forwarding options */
 	int     pubkey_authentication;	/* Try ssh2 pubkey authentication. */
+	int		pubkey_disable_pk_check; /* If true, disables ssh2 pubkey check. */
 	int     hostbased_authentication;	/* ssh2's rhosts_rsa */
 	int     gss_authentication;	/* Try GSS authentication */
 	int     gss_deleg_creds;	/* Delegate GSS credentials */

--- a/scp.1
+++ b/scp.1
@@ -211,6 +211,7 @@ For full details of the options listed below, and their possible values, see
 .It ProxyJump
 .It PubkeyAcceptedAlgorithms
 .It PubkeyAuthentication
+.It PubkeyDisablePKCheck
 .It RekeyLimit
 .It SendEnv
 .It ServerAliveInterval

--- a/servconf.c
+++ b/servconf.c
@@ -129,6 +129,7 @@ initialize_server_options(ServerOptions *options)
 	options->hostbased_accepted_algos = NULL;
 	options->hostkeyalgorithms = NULL;
 	options->pubkey_authentication = -1;
+	options->pubkey_disable_pk_check = -1;
 	options->pubkey_auth_options = -1;
 	options->pubkey_accepted_algos = NULL;
 	options->kerberos_authentication = -1;
@@ -344,6 +345,8 @@ fill_default_server_options(ServerOptions *options)
 		options->hostbased_uses_name_from_packet_only = 0;
 	if (options->pubkey_authentication == -1)
 		options->pubkey_authentication = 1;
+	if(options->pubkey_disable_pk_check == -1)
+		options->pubkey_disable_pk_check = 1;
 	if (options->pubkey_auth_options == -1)
 		options->pubkey_auth_options = 0;
 	if (options->kerberos_authentication == -1)
@@ -498,7 +501,7 @@ typedef enum {
 	sPermitUserEnvironment, sAllowTcpForwarding, sCompression,
 	sRekeyLimit, sAllowUsers, sDenyUsers, sAllowGroups, sDenyGroups,
 	sIgnoreUserKnownHosts, sCiphers, sMacs, sPidFile, sModuliFile,
-	sGatewayPorts, sPubkeyAuthentication, sPubkeyAcceptedAlgorithms,
+	sGatewayPorts, sPubkeyAuthentication, sPubkeyDisablePKCheck, sPubkeyAcceptedAlgorithms,
 	sXAuthLocation, sSubsystem, sMaxStartups, sMaxAuthTries, sMaxSessions,
 	sBanner, sUseDNS, sHostbasedAuthentication,
 	sHostbasedUsesNameFromPacketOnly, sHostbasedAcceptedAlgorithms,
@@ -562,6 +565,7 @@ static struct {
 	{ "hostkeyalgorithms", sHostKeyAlgorithms, SSHCFG_GLOBAL },
 	{ "rsaauthentication", sDeprecated, SSHCFG_ALL },
 	{ "pubkeyauthentication", sPubkeyAuthentication, SSHCFG_ALL },
+	{ "pubkeydisablepkcheck", sPubkeyDisablePKCheck, SSHCFG_ALL },
 	{ "pubkeyacceptedalgorithms", sPubkeyAcceptedAlgorithms, SSHCFG_ALL },
 	{ "pubkeyacceptedkeytypes", sPubkeyAcceptedAlgorithms, SSHCFG_ALL }, /* obsolete */
 	{ "pubkeyauthoptions", sPubkeyAuthOptions, SSHCFG_ALL },
@@ -1529,6 +1533,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 
 	case sPubkeyAuthentication:
 		intptr = &options->pubkey_authentication;
+		goto parse_flag;
+
+	case sPubkeyDisablePKCheck:
+		intptr = &options->pubkey_disable_pk_check;
 		goto parse_flag;
 
 	case sPubkeyAcceptedAlgorithms:
@@ -2576,6 +2584,7 @@ copy_set_server_options(ServerOptions *dst, ServerOptions *src, int preauth)
 	M_CP_INTOPT(password_authentication);
 	M_CP_INTOPT(gss_authentication);
 	M_CP_INTOPT(pubkey_authentication);
+	M_CP_INTOPT(pubkey_disable_pk_check);
 	M_CP_INTOPT(pubkey_auth_options);
 	M_CP_INTOPT(kerberos_authentication);
 	M_CP_INTOPT(hostbased_authentication);
@@ -2880,6 +2889,7 @@ dump_config(ServerOptions *o)
 	dump_cfg_fmtint(sHostbasedUsesNameFromPacketOnly,
 	    o->hostbased_uses_name_from_packet_only);
 	dump_cfg_fmtint(sPubkeyAuthentication, o->pubkey_authentication);
+	dump_cfg_fmtint(sPubkeyDisablePKCheck, o->pubkey_disable_pk_check);
 #ifdef KRB5
 	dump_cfg_fmtint(sKerberosAuthentication, o->kerberos_authentication);
 	dump_cfg_fmtint(sKerberosOrLocalPasswd, o->kerberos_or_local_passwd);

--- a/servconf.c
+++ b/servconf.c
@@ -346,7 +346,7 @@ fill_default_server_options(ServerOptions *options)
 	if (options->pubkey_authentication == -1)
 		options->pubkey_authentication = 1;
 	if(options->pubkey_disable_pk_check == -1)
-		options->pubkey_disable_pk_check = 1;
+		options->pubkey_disable_pk_check = 0;
 	if (options->pubkey_auth_options == -1)
 		options->pubkey_auth_options = 0;
 	if (options->kerberos_authentication == -1)

--- a/servconf.h
+++ b/servconf.h
@@ -127,7 +127,7 @@ typedef struct {
 	char   *hostkeyalgorithms;	/* SSH2 server key types */
 	char   *ca_sign_algorithms;	/* Allowed CA signature algorithms */
 	int     pubkey_authentication;	/* If true, permit ssh2 pubkey authentication. */
-	int		pubkey_disable_pk_check;	/* If true, permit ssh2 pubkey check. */
+	int		pubkey_disable_pk_check;	/* If true, disable ssh2 pubkey check. */
 	char   *pubkey_accepted_algos;	/* Signature algos allowed for pubkey */
 	int	pubkey_auth_options;	/* -1 or mask of PUBKEYAUTH_* flags */
 	int     kerberos_authentication;	/* If true, permit Kerberos

--- a/servconf.h
+++ b/servconf.h
@@ -127,6 +127,7 @@ typedef struct {
 	char   *hostkeyalgorithms;	/* SSH2 server key types */
 	char   *ca_sign_algorithms;	/* Allowed CA signature algorithms */
 	int     pubkey_authentication;	/* If true, permit ssh2 pubkey authentication. */
+	int		pubkey_disable_pk_check;	/* If true, permit ssh2 pubkey check. */
 	char   *pubkey_accepted_algos;	/* Signature algos allowed for pubkey */
 	int	pubkey_auth_options;	/* -1 or mask of PUBKEYAUTH_* flags */
 	int     kerberos_authentication;	/* If true, permit Kerberos

--- a/sftp.1
+++ b/sftp.1
@@ -270,6 +270,7 @@ For full details of the options listed below, and their possible values, see
 .It ProxyJump
 .It PubkeyAcceptedAlgorithms
 .It PubkeyAuthentication
+.It PubkeyDisablePKCheck
 .It RekeyLimit
 .It SendEnv
 .It ServerAliveInterval

--- a/ssh.1
+++ b/ssh.1
@@ -564,6 +564,7 @@ For full details of the options listed below, and their possible values, see
 .It ProxyUseFdpass
 .It PubkeyAcceptedAlgorithms
 .It PubkeyAuthentication
+.It PubkeyDisablePKCheck
 .It RekeyLimit
 .It RemoteCommand
 .It RemoteForward

--- a/ssh_config
+++ b/ssh_config
@@ -24,6 +24,7 @@
 #   HostbasedAuthentication no
 #   GSSAPIAuthentication no
 #   GSSAPIDelegateCredentials no
+#   PubkeyDisablePKCheck no
 #   BatchMode no
 #   CheckHostIP yes
 #   AddressFamily any

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1526,6 +1526,13 @@ The argument to this keyword must be
 (the default)
 or
 .Cm no .
+.It Cm PubkeyDisablePKCheck
+Specifies whether to disable public key lookup on the remote server.
+The argument to this keyword must be
+.Cm no
+(the default)
+or
+.Cm yes .
 .It Cm RekeyLimit
 Specifies the maximum amount of data that may be transmitted before the
 session key is renegotiated, optionally followed by a maximum amount of

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1849,7 +1849,7 @@ userauth_pubkey(struct ssh *ssh)
 		 * encrypted keys we cannot do this and have to load the
 		 * private key instead
 		 */
-		if (id->key != NULL && !options.identities_only) {
+		if (id->key != NULL && !(options.pubkey_disable_pk_check && options.identities_only)) {
 			if (try_identity(ssh, id)) {
 				ident = format_identity(id);
 				debug("Offering public key: %s", ident);

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1849,7 +1849,7 @@ userauth_pubkey(struct ssh *ssh)
 		 * encrypted keys we cannot do this and have to load the
 		 * private key instead
 		 */
-		if (id->key != NULL) {
+		if (id->key != NULL && !options.identities_only) {
 			if (try_identity(ssh, id)) {
 				ident = format_identity(id);
 				debug("Offering public key: %s", ident);

--- a/sshd_config
+++ b/sshd_config
@@ -35,6 +35,7 @@
 #MaxSessions 10
 
 #PubkeyAuthentication yes
+#PubkeyDisablePKCheck no
 
 # The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
 # but this is overridden so installations will only check .ssh/authorized_keys

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1220,6 +1220,7 @@ Available keywords are
 .Cm PermitUserRC ,
 .Cm PubkeyAcceptedAlgorithms ,
 .Cm PubkeyAuthentication ,
+.Cm PubkeyDisablePKCheck ,
 .Cm RekeyLimit ,
 .Cm RevokedKeys ,
 .Cm RDomain ,
@@ -1570,6 +1571,10 @@ options have any effect for other, non-FIDO, public key types.
 Specifies whether public key authentication is allowed.
 The default is
 .Cm yes .
+.It Cm PubkeyDisablePKCheck
+Disables publickey lookups during publickey authentication. Only recommended for high security environments.
+The default is
+.CM no .
 .It Cm RekeyLimit
 Specifies the maximum amount of data that may be transmitted before the
 session key is renegotiated, optionally followed by a maximum amount of


### PR DESCRIPTION
CVE: https://nvd.nist.gov/vuln/detail/CVE-2016-20012

This pull request adds a new configuration option to the server to disable user enumeration when using publickey authentication.

The user enumeration was first mentioned on 6. june 2002:
https://github.com/openssh/openssh-portable/blob/d0fffc88c8fe90c1815c6f4097bc8cbcabc0f3dd/auth2-pubkey.c#L261-L265


### Publickey authentication:

Publickey authentication is defined in [RFC-4252](https://datatracker.ietf.org/doc/html/rfc4252#page-8) (released January 2006)

A client is allowed to ask the server, if a specific public key is known by the server. This allows the client to generate a signature only if it's necessary. If the publickey is not known, no signature must be created.

> Private keys are often stored in an encrypted form at the client
   host, and the user must supply a passphrase before the signature can
   be generated.  Even if they are not, the signing operation involves
   some expensive computation.  To avoid unnecessary processing and user
   interaction, the following message is provided for querying whether
   authentication using the "publickey" method would be acceptable.
>
>      byte      SSH_MSG_USERAUTH_REQUEST

**This behavior allows an attacker to check if a user is allowed to login.**

RFC-4252 also defines, that it's allowed to send a `SSH_MSG_USERAUTH_REQUEST` with a signature directly:

>   To perform actual authentication, the client MAY then send a
   signature generated using the private key.  The client MAY send the
   signature directly without first verifying whether the key is
   acceptable.  The signature is sent using the following packet:
>
>      byte      SSH_MSG_USERAUTH_REQUEST

### The patch

This patch adds a new configuration option to the OpenSSH server: `PubkeyDisablePKCheck no`

If this configuration option is enbabled, the client is not able to send a `SSH_MSG_USERAUTH_REQUEST` without signature. In cases, when a client asks the server if a publickey is known, the server denies the login.

A patch was also applied to the client, because the client allways asks the server if a publickey is known. Even, when the configuration option `IdentitiesOnly` is enabled.

If the client was configured with `IdentitiesOnly`, `SSH_MSG_USERAUTH_REQUEST` with a signature is directly sent to the server. This makes the OpenSSH Client compatible with the server.

### Other clients

I have created a patch for PuTTY, to make PuTTY compatible with the new setting: https://github.com/manfred-kaiser/putty/commit/5e33243c57aef8aa12a9c8aa0d198c66834aaaa1

This patch was sent to Simon Tatham (PuTTY developer), with a request to merge it in the next release.

WinSCP, Filezille and other clients, which are based on PuTTY can use the new configuration option. So they should be compatible in the near future.

