### PR TITLE
Provide a system-wide kill switch for SCP protocol

### DIFF
--- a/pathnames.h
+++ b/pathnames.h
@@ -42,6 +42,7 @@
 #define _PATH_HOST_XMSS_KEY_FILE	SSHDIR "/ssh_host_xmss_key"
 #define _PATH_HOST_RSA_KEY_FILE		SSHDIR "/ssh_host_rsa_key"
 #define _PATH_DH_MODULI			SSHDIR "/moduli"
+#define _PATH_SCP_KILL_SWITCH		SSHDIR "/disable_scp"
 
 #ifndef _PATH_SSH_PROGRAM
 #define _PATH_SSH_PROGRAM		"/usr/bin/ssh"

--- a/scp.1
+++ b/scp.1
@@ -278,6 +278,13 @@ to print debugging messages about their progress.
 This is helpful in
 debugging connection, authentication, and configuration problems.
 .El
+.Pp
+Usage of SCP protocol can be blocked by creating a world-readable
+.Ar /etc/ssh/disable_scp
+file. If this file exists, when SCP protocol is in use (either remotely or 
+via the
+.Fl O
+option), the program will exit.
 .Sh EXIT STATUS
 .Ex -std scp
 .Sh SEE ALSO

--- a/scp.c
+++ b/scp.c
@@ -596,6 +596,14 @@ main(int argc, char **argv)
 	if (iamremote)
 		mode = MODE_SCP;
 
+	if (mode == MODE_SCP) {
+		FILE *f = fopen(_PATH_SCP_KILL_SWITCH, "r");
+		if (f != NULL) {
+			fclose(f);
+			fatal("SCP protocol is forbidden via %s", _PATH_SCP_KILL_SWITCH);
+		}
+	}
+
 	if ((pwd = getpwuid(userid = getuid())) == NULL)
 		fatal("unknown user %u", (u_int) userid);
 


### PR DESCRIPTION
As we use SFTP by default, and SCP is considered insecure, we may want
to disable it totally. As scp utility doesn't use the system-wide
config, we suggest implementing it via the kill switch file.