### PR TITLE
Fix "Allocated port" message for unix sockets

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -1793,7 +1793,8 @@ ssh_confirm_remote_forward(struct ssh *ssh, int type, u_int32_t seq, void *ctxt)
 				rfwd->allocated_port = (int)port;
 				logit("Allocated port %u for remote "
 				    "forward to %s:%d",
-				    rfwd->allocated_port, rfwd->connect_host,
+				    rfwd->allocated_port, rfwd->connect_path ?
+				    rfwd->connect_path : rfwd->connect_host,
 				    rfwd->connect_port);
 				channel_update_permission(ssh,
 				    rfwd->handle, rfwd->allocated_port);


### PR DESCRIPTION
A small patch to fix the Allocated port message to be in line of the debug-message a handful of lines earlier in the code.

Currently ssh prints (null) insted of the path of the unix socket, in the message to the user, this PR fixes that