### PR TITLE
Fix agent handling of certificates

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1620,11 +1620,15 @@ load_identity_file(Identity *id)
 				sshkey_free(private);
 				return NULL;
 			}
-			old_type = private->type;
-			private->type = id->key->type;
+			if(sshkey_type_is_cert(id->key->type) > 0){
+				old_type = private->type;
+				private->type = id->key->type;
+				maybe_add_key_to_agent(id->filename, private, comment,
+					"");
+				private->type = sshkey_type_plain(old_type);
+			}
 			maybe_add_key_to_agent(id->filename, private, comment,
-			    passphrase);
-			private->type = old_type;
+				passphrase);
 			}
 		if (i > 0)
 			freezero(passphrase, strlen(passphrase));


### PR DESCRIPTION
Hello, I encountered an issue with OpenSSH's handling of ssh certificates and storing them in the ssh agent where the certificates would not be stored in the agent even if the key used to authenticate with them is which causes ssh agent forwarding to fail on some systems using ssh certs. Here is a fairly minimal patch that fixes it. Any feedback would be greatly appreciated.