### PR TITLE
Be strict about masklength

### DIFF
--- a/addr.c
+++ b/addr.c
@@ -385,7 +385,7 @@ addr_pton_cidr(const char *p, struct xaddr *n, u_int *l)
 		*mp = '\0';
 		mp++;
 		masklen = strtoul(mp, &cp, 10);
-		if (*mp == '\0' || *cp != '\0' || masklen > 128)
+		if (*mp < '0' || *mp > '9' || *cp != '\0' || masklen > 128)
 			return -1;
 	}
 


### PR DESCRIPTION
strtoul is too lax about characters which are used for numbers.
Manually check that masklength starts with digit.
PoC
Add following match block to your sshd_config
 Match address "127.0.0.1/  +0032"
        ForceCommand ls
If you access your server with `ssh 127.0.0.1` then ls is executed.
This behaviour is unexpected as masklength should not be valid.

Shoutout to [@c3h2_ctf](
https://twitter.com/c3h2_ctf
)