### PR TITLE
Only free allocated memory on UnixWare

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -150,7 +150,8 @@ allowed_user(struct ssh *ssh, struct passwd * pw)
 			locked = 1;
 #endif
 #ifdef USE_LIBIAF
-		free((void *) passwd);
+		if (spw != NULL)
+			free((void *) passwd);
 #endif /* USE_LIBIAF */
 		if (locked) {
 			logit("User %.100s not allowed because account is locked",


### PR DESCRIPTION
If libaif is compiled in together with shadow support, then a
misconfigured system could trigger invalid free calls:

The "spw" variable can be NULL even though a password entry
exists. This can be reproduced on systems with shadow support if
/etc/shadow lacks a user entry which exists in /etc/passwd: Thus
it requires a misconfigured system to trigger this bug.

If "spw" is NULL then get_iaf_password is never called, which
means that "passwd" still points to memory within the pw struct.

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)