### PR TITLE
Adjust error code paths.

### DIFF
--- a/auth2-passwd.c
+++ b/auth2-passwd.c
@@ -51,16 +51,18 @@ extern ServerOptions options;
 static int
 userauth_passwd(struct ssh *ssh)
 {
-	char *password;
+	char *password = NULL;
 	int authenticated = 0, r;
 	u_char change;
-	size_t len;
+	size_t len = 0;
 
 	if ((r = sshpkt_get_u8(ssh, &change)) != 0 ||
 	    (r = sshpkt_get_cstring(ssh, &password, &len)) != 0 ||
 	    (change && (r = sshpkt_get_cstring(ssh, NULL, NULL)) != 0) ||
-	    (r = sshpkt_get_end(ssh)) != 0)
+	    (r = sshpkt_get_end(ssh)) != 0) {
+		freezero(password, len);
 		fatal_fr(r, "parse packet");
+	}
 
 	if (change)
 		logit("password change not supported");

--- a/readpass.c
+++ b/readpass.c
@@ -286,7 +286,8 @@ notify_start(int force_askpass, const char *fmt, ...)
 	}
  out_ctx:
 	if ((ret = calloc(1, sizeof(*ret))) == NULL) {
-		kill(pid, SIGTERM);
+		if (pid != -1)
+			kill(pid, SIGTERM);
 		fatal_f("calloc failed");
 	}
 	ret->pid = pid;


### PR DESCRIPTION
- Always clear password in RAM, even in error path
- Do not call kill with -1 argument by mistake

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)