### PR TITLE
Improve sshbuf defensive measures

### DIFF
--- a/sshbuf.c
+++ b/sshbuf.c
@@ -109,6 +109,8 @@ sshbuf_set_parent(struct sshbuf *child, struct sshbuf *parent)
 	if ((r = sshbuf_check_sanity(child)) != 0 ||
 	    (r = sshbuf_check_sanity(parent)) != 0)
 		return r;
+	if (child->parent != NULL)
+		child->parent->refcount--;
 	child->parent = parent;
 	child->parent->refcount++;
 	return 0;

--- a/sshbuf.c
+++ b/sshbuf.c
@@ -179,7 +179,8 @@ sshbuf_reset(struct sshbuf *buf)
 		buf->off = buf->size;
 		return;
 	}
-	(void) sshbuf_check_sanity(buf);
+	if (sshbuf_check_sanity(buf) != 0)
+		return;
 	buf->off = buf->size = 0;
 	if (buf->alloc != SSHBUF_SIZE_INIT) {
 		if ((d = recallocarray(buf->d, buf->alloc, SSHBUF_SIZE_INIT,
@@ -188,7 +189,7 @@ sshbuf_reset(struct sshbuf *buf)
 			buf->alloc = SSHBUF_SIZE_INIT;
 		}
 	}
-	explicit_bzero(buf->d, SSHBUF_SIZE_INIT);
+	explicit_bzero(buf->d, buf->alloc);
 }
 
 size_t


### PR DESCRIPTION
- Keep track of reference count even if parent is set multiple times
- Gracefully handle failed re-allocation in sshbuf_reset

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)