### PR TITLE
Use SHA2 when client supports it

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -935,6 +935,35 @@ kex_choose_conf(struct ssh *ssh)
 		free(ext);
 	}
 
+	/* Check whether client supports rsa-sha2 algorithms */
+	if (kex->server && (kex->flags & KEX_INITIAL)) {
+		char *ext;
+
+		ext = match_list("rsa-sha2-256", peer[PROPOSAL_SERVER_HOST_KEY_ALGS], NULL);
+		if (ext) {
+			kex->flags |= KEX_RSA_SHA2_256_SUPPORTED;
+			free(ext);
+		}
+
+		ext = match_list("rsa-sha2-512", peer[PROPOSAL_SERVER_HOST_KEY_ALGS], NULL);
+		if (ext) {
+			kex->flags |= KEX_RSA_SHA2_512_SUPPORTED;
+			free(ext);
+		}
+
+		ext = match_list("rsa-sha2-256-cert-v01@openssh.com", peer[PROPOSAL_SERVER_HOST_KEY_ALGS], NULL);
+		if (ext) {
+			kex->flags |= KEX_RSA_SHA2_256_SUPPORTED;
+			free(ext);
+		}
+
+		ext = match_list("rsa-sha2-512-cert-v01@openssh.com", peer[PROPOSAL_SERVER_HOST_KEY_ALGS], NULL);
+		if (ext) {
+			kex->flags |= KEX_RSA_SHA2_512_SUPPORTED;
+			free(ext);
+		}
+	}
+
 	/* Algorithm Negotiation */
 	if ((r = choose_kex(kex, cprop[PROPOSAL_KEX_ALGS],
 	    sprop[PROPOSAL_KEX_ALGS])) != 0) {

--- a/kex.h
+++ b/kex.h
@@ -109,6 +109,8 @@ enum kex_exchange {
 #define KEX_INIT_SENT			0x0001
 #define KEX_INITIAL			0x0002
 #define KEX_HAS_PUBKEY_HOSTBOUND	0x0004
+#define KEX_RSA_SHA2_256_SUPPORTED 	0x0008
+#define KEX_RSA_SHA2_512_SUPPORTED 	0x0010
 
 struct sshenc {
 	char	*name;


### PR DESCRIPTION
Intended to fix #3375