### PR TITLE
ssh-agent: remove all keys upon SIGUSR1..

### DIFF
--- a/ssh-agent.1
+++ b/ssh-agent.1
@@ -219,6 +219,9 @@ will automatically use them if present.
 is also used to remove keys from
 .Nm
 and to query the keys that are held in one.
+.Nm
+will remove all keys when it receives the user signal
+.Dv SIGUSR1 .
 .Pp
 Connections to
 .Nm


### PR DESCRIPTION
With the advent of per-user temporary directories it became
hard for an administrator to remove all keys from all running
ssh-agent instances; what formerly could be done like so

   if command -v ssh-add >/dev/null 2>&1; then
      for a in /tmp/ssh-*/agent.*; do
         [ -e "$a" ] || continue
         act "SSH_AUTH_SOCK=\"$a\" ssh-add -D </dev/null >/dev/null 2>&1 &"
         inc
      done
   fi

has become a major undertaking, especially with even more
containerization.  Being able to remove all keys from all agents
with a single command seems so desirable that it is available in
other agents in the software world.