### PR TITLE
sandbox-seccomp-filter: allow gettid

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -225,6 +225,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_getpid
 	SC_ALLOW(__NR_getpid),
 #endif
+#ifdef __NR_gettid
+	SC_ALLOW(__NR_gettid),
+#endif
 #ifdef __NR_getrandom
 	SC_ALLOW(__NR_getrandom),
 #endif


### PR DESCRIPTION
Some allocators (such as Scudo) use gettid [while tracing allocations][1].
Allow gettid in preauth to prevent sshd from crashing with Scudo.
[This NixOS issue][2] has some background info.

[1]: https://github.com/llvm/llvm-project/blob/llvmorg-13.0.0/compiler-rt/lib/gwp_asan/common.cpp#L46
[2]: https://github.com/NixOS/nixpkgs/issues/157451