### PR TITLE
Better emulation of old scp behavior

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -1311,7 +1311,7 @@ source_sftp(int argc, char *src, char *targ, struct sftp_conn *conn)
 
 	if (src_is_dir && iamrecursive) {
 		if (upload_dir(conn, src, abs_dst, pflag,
-		    SFTP_PROGRESS_ONLY, 0, 0, 1) != 0) {
+		    SFTP_PROGRESS_ONLY, 0, 0, 1, 1) != 0) {
 			error("failed to upload directory %s to %s", src, targ);
 			errs = 1;
 		}

--- a/sftp-client.h
+++ b/sftp-client.h
@@ -111,7 +111,7 @@ int do_fsetstat(struct sftp_conn *, const u_char *, u_int, Attrib *);
 int do_lsetstat(struct sftp_conn *conn, const char *path, Attrib *a);
 
 /* Canonicalise 'path' - caller must free result */
-char *do_realpath(struct sftp_conn *, const char *);
+char *do_realpath(struct sftp_conn *, const char *, int);
 
 /* Canonicalisation with tilde expansion (requires server extension) */
 char *do_expand_path(struct sftp_conn *, const char *);
@@ -159,7 +159,7 @@ int do_upload(struct sftp_conn *, const char *, const char *, int, int, int);
  * times if 'pflag' is set
  */
 int upload_dir(struct sftp_conn *, const char *, const char *, int, int, int,
-    int, int);
+    int, int, int);
 
 /*
  * Download a 'from_path' from the 'from' connection and upload it to

--- a/sftp.c
+++ b/sftp.c
@@ -759,7 +759,7 @@ process_put(struct sftp_conn *conn, const char *src, const char *dst,
 		if (globpath_is_dir(g.gl_pathv[i]) && (rflag || global_rflag)) {
 			if (upload_dir(conn, g.gl_pathv[i], abs_dst,
 			    pflag || global_pflag, 1, resume,
-			    fflag || global_fflag, 0) == -1)
+			    fflag || global_fflag, 0, 0) == -1)
 				err = -1;
 		} else {
 			if (do_upload(conn, g.gl_pathv[i], abs_dst,
@@ -1576,7 +1576,7 @@ parse_dispatch_command(struct sftp_conn *conn, const char *cmd, char **pwd,
 		if (path1 == NULL || *path1 == '\0')
 			path1 = xstrdup(startdir);
 		path1 = make_absolute(path1, *pwd);
-		if ((tmp = do_realpath(conn, path1)) == NULL) {
+		if ((tmp = do_realpath(conn, path1, 0)) == NULL) {
 			err = 1;
 			break;
 		}
@@ -2159,7 +2159,7 @@ interactive_loop(struct sftp_conn *conn, char *file1, char *file2)
 	}
 #endif /* USE_LIBEDIT */
 
-	remote_path = do_realpath(conn, ".");
+	remote_path = do_realpath(conn, ".", 0);
 	if (remote_path == NULL)
 		fatal("Need cwd");
 	startdir = xstrdup(remote_path);


### PR DESCRIPTION
When we use scp in SFTP mode, we try to create a non-existent directory
to better emulate the old SCP behavior