### PR TITLE
Specify "remote port" when timeouts are logged

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -367,7 +367,7 @@ grace_alarm_handler(int sig)
 	}
 
 	/* Log error and exit. */
-	sigdie("Timeout before authentication for %s port %d",
+	sigdie("Timeout before authentication for %s on remote port %d",
 	    ssh_remote_ipaddr(the_active_state),
 	    ssh_remote_port(the_active_state));
 }


### PR DESCRIPTION
When timeouts are logged by sshd, it does not specify that the port
number being logged is in fact a remote port, not a local one. This can
be a source of confusion and ambiguity. This commit removes this
ambiguity by specifying that this port is a remote one.

An example of this confusion occurring in the wild can be found here:
https://unix.stackexchange.com/questions/32090/why-logs-show-a-different-ssh-connection-port-than-the-one-specified

Note that this may break log parsers, if they incorrectly assumed the OpenSSH log format was a stable API of some sort.