### PR TITLE
Document tokens accepted by ProxyJump keyword

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -2123,7 +2123,9 @@ accepts the tokens %% and %h.
 accepts all tokens.
 .Pp
 .Cm ProxyCommand
-accepts the tokens %%, %h, %n, %p, and %r.
+and
+.Cm ProxyJump
+accept the tokens %%, %h, %n, %p, and %r.
 .Sh ENVIRONMENT VARIABLES
 Arguments to some keywords can be expanded at runtime from environment
 variables on the client by enclosing them in


### PR DESCRIPTION
`ProxyJump` translates to `ProxyCommand` under the hood and it accepts the same tokens as `ProxyCommand` if I understand it correctly.