### PR TITLE
Fix segfault in ssh-keygen -Y check-novalidate when -n option is miss…

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -3538,6 +3538,12 @@ main(int argc, char **argv)
 			return sig_sign(identity_file, cert_principals,
 			    argc, argv, opts, nopts);
 		} else if (strncmp(sign_op, "check-novalidate", 16) == 0) {
+			if (cert_principals == NULL ||
+			    *cert_principals == '\0') {
+				error("Too few arguments for check-novalidate: "
+				    "missing namespace");
+				exit(1);
+			}
 			if (ca_key_path == NULL) {
 				error("Too few arguments for check-novalidate: "
 				    "missing signature file");


### PR DESCRIPTION
I found a bug in `ssh-keygen`

Steps to reproduce:
```
$ ssh-keygen -Y check-novalidate -s anyfile.txt.sig < anyfile.txt
Segmentation fault (core dumped)
```
The problem is missing `-n` option resulting in null pointer being passed to `strcmp()`

```
(gdb) bt
#0  __strcmp_sse2_unaligned () at ../sysdeps/x86_64/multiarch/strcmp-sse2-unaligned.S:31
#1  0x0000563613b33dcf in sshsig_wrap_verify (signature=signature@entry=0x563614433040, hashalg=0x5636144332f0 "sha512", 
    h_message=<optimized out>, expect_namespace=expect_namespace@entry=0x0, sign_keyp=sign_keyp@entry=0x7fffb358fed0, 
    sig_details=sig_details@entry=0x7fffb358fed8) at sshsig.c:339
#2  0x0000563613b354f0 in sshsig_verify_fd (signature=0x563614433040, fd=0, expect_namespace=0x0, sign_keyp=0x7fffb358fed0, 
    sig_details=0x7fffb358fed8) at sshsig.c:605
#3  0x0000563613b2c566 in sig_verify (signature=0x7fffb35926d0 "nauka1.txt.sig", sig_namespace=0x0, principal=0x0, 
    allowed_keys=0x0, revoked_keys=0x0, opts=<optimized out>, nopts=0) at ssh-keygen.c:2753
#4  0x0000563613b321b8 in main (argc=0, argv=0x7fffb3590560) at ssh-keygen.c:3546
```
