### PR TITLE
ssh: accept SSH_CONFIG_FILE as a default for -F

### DIFF
--- a/regress/sshcfgparse.sh
+++ b/regress/sshcfgparse.sh
@@ -34,6 +34,12 @@ verbose "reparse minimal config"
  ${SSH} -G -F $OBJ/ssh_config.1 somehost >$OBJ/ssh_config.2 &&
  diff $OBJ/ssh_config.1 $OBJ/ssh_config.2) || fail "failed to reparse minimal"
 
+verbose 'verify -F is equivalent to $SSH_CONFIG_FILE'
+(${SSH} -G -F $OBJ/ssh_config somehost >$OBJ/ssh_config.1 &&
+ SSH_CONFIG_FILE=$OBJ/ssh_config.1 ${SSH} -G somehost >$OBJ/ssh_config.2 &&
+ diff $OBJ/ssh_config.1 $OBJ/ssh_config.2) \
+    || fail "difference between -F and SSH_CONFIG_FILE"
+
 verbose "ssh -W opts"
 f=`${SSH} -GF $OBJ/ssh_config host | awk '/exitonforwardfailure/{print $2}'`
 test "$f" = "no" || fail "exitonforwardfailure default"

--- a/ssh.1
+++ b/ssh.1
@@ -1462,6 +1462,15 @@ is set.
 Identifies the path of a
 .Ux Ns -domain
 socket used to communicate with the agent.
+.It Ev SSH_CONFIG_FILE
+Specifies an alternative configuration file. If a configuration file is
+given using the environment variable, the system-wide configuration file
+.Pq Pa /etc/ssh/ssh_config
+and the default per-user configuration file
+.Pq Pa ~/.ssh/config
+are ignored. This environment variable is ignored if
+.Fl F
+is passed at the command line.
 .It Ev SSH_CONNECTION
 Identifies the client and server ends of the connection.
 The variable contains

--- a/ssh.c
+++ b/ssh.c
@@ -681,6 +681,8 @@ main(int ac, char **av)
 	 */
 	initialize_options(&options);
 
+	config = getenv("SSH_CONFIG_FILE");
+
 	/*
 	 * Prepare main ssh transport/connection structures
 	 */


### PR DESCRIPTION
Treat the environment variable SSH_CONFIG_FILE as a default
value for the `-F` argument.

This supports my use case of multiple projects and repositories
which each have significantly different SSH configurations, and
a wide enough variety of projects and repositories that it isn't
necessarily feasible to construct a per-user (~/.ssh/config)
file with Match blocks.