### PR TITLE
sk-api: separate flags used for FIDO signature verification from sk-api flags

### DIFF
--- a/auth2-pubkey.c
+++ b/auth2-pubkey.c
@@ -238,7 +238,7 @@ userauth_pubkey(struct ssh *ssh, const char *method)
 			    PUBKEYAUTH_TOUCH_REQUIRED) ||
 			    !authopts->no_require_user_presence;
 			if (req_presence && (sig_details->sk_flags &
-			    SSH_SK_USER_PRESENCE_REQD) == 0) {
+			    SSH_SK_FIDO_USER_PRESENT) == 0) {
 				error("public key %s signature for %s%s from "
 				    "%.128s port %d rejected: user presence "
 				    "(authenticator touch) requirement "
@@ -253,7 +253,7 @@ userauth_pubkey(struct ssh *ssh, const char *method)
 			    PUBKEYAUTH_VERIFY_REQUIRED) ||
 			    authopts->require_verify;
 			if (req_verify && (sig_details->sk_flags &
-			    SSH_SK_USER_VERIFICATION_REQD) == 0) {
+			    SSH_SK_FIDO_USER_VERIFIED) == 0) {
 				error("public key %s signature for %s%s from "
 				    "%.128s port %d rejected: user "
 				    "verification requirement not met ", key_s,

--- a/monitor.c
+++ b/monitor.c
@@ -1455,7 +1455,7 @@ mm_answer_keyverify(struct ssh *ssh, int sock, struct sshbuf *m)
 		    PUBKEYAUTH_TOUCH_REQUIRED) ||
 		    !key_opts->no_require_user_presence;
 		if (req_presence &&
-		    (sig_details->sk_flags & SSH_SK_USER_PRESENCE_REQD) == 0) {
+		    (sig_details->sk_flags & SSH_SK_FIDO_USER_PRESENT) == 0) {
 			error("public key %s %s signature for %s%s from %.128s "
 			    "port %d rejected: user presence "
 			    "(authenticator touch) requirement not met ",
@@ -1468,7 +1468,7 @@ mm_answer_keyverify(struct ssh *ssh, int sock, struct sshbuf *m)
 		req_verify = (options.pubkey_auth_options &
 		    PUBKEYAUTH_VERIFY_REQUIRED) || key_opts->require_verify;
 		if (req_verify &&
-		    (sig_details->sk_flags & SSH_SK_USER_VERIFICATION_REQD) == 0) {
+		    (sig_details->sk_flags & SSH_SK_FIDO_USER_VERIFIED) == 0) {
 			error("public key %s %s signature for %s%s from %.128s "
 			    "port %d rejected: user verification requirement "
 			    "not met ", sshkey_type(key), fp,

--- a/sk-api.h
+++ b/sk-api.h
@@ -23,6 +23,13 @@
 #include <stdint.h>
 #endif
 
+/*
+ * These are used for signature verification and need to match
+ * https://www.w3.org/TR/webauthn-2/#table-authData.
+ */
+#define SSH_SK_FIDO_USER_PRESENT	0x01
+#define SSH_SK_FIDO_USER_VERIFIED	0x04
+
 /* Flags */
 #define SSH_SK_USER_PRESENCE_REQD	0x01
 #define SSH_SK_USER_VERIFICATION_REQD	0x04


### PR DESCRIPTION
Use separate flags to reduce the risk of future confusion/conflict between WebAuthn/FIDO and sk-api flags (which are similar in concept, but serve a fundamentally different purpose).