### PR TITLE
new sRouteCookieId option for FreeBSD proposal.

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -247,6 +247,22 @@ set_rdomain(int fd, const char *name)
 }
 
 int
+set_cookieid(int fd, u_int32_t route_cookieid)
+{
+#if defined(__FreeBSD__)
+	if (setsockopt(fd, SOL_SOCKET, SO_USER_COOKIE,
+            (void *)&route_cookieid, sizeof(route_cookieid)) == -1) {
+		error("Failed to set route cookie id %u on fd %d: %s",
+		    route_cookieid, fd, strerror(errno));
+		return -1;
+        }
+#else
+	error("Setting cookie id is not supported on this platform");
+	return -1;
+#endif
+}
+
+int
 get_sock_af(int fd)
 {
 	struct sockaddr_storage to;

--- a/misc.h
+++ b/misc.h
@@ -55,6 +55,7 @@ void	 set_nodelay(int);
 int	 set_reuseaddr(int);
 char	*get_rdomain(int);
 int	 set_rdomain(int, const char *);
+int	 set_cookieid(int, u_int32_t);
 int	 get_sock_af(int);
 void	 set_sock_tos(int, int);
 int	 waitrfd(int, int *);

--- a/servconf.c
+++ b/servconf.c
@@ -195,6 +195,7 @@ initialize_server_options(ServerOptions *options)
 	options->fingerprint_hash = -1;
 	options->disable_forwarding = -1;
 	options->expose_userauth_info = -1;
+	options->route_cookieid = 0;
 }
 
 /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
@@ -517,6 +518,7 @@ typedef enum {
 	sStreamLocalBindMask, sStreamLocalBindUnlink,
 	sAllowStreamLocalForwarding, sFingerprintHash, sDisableForwarding,
 	sExposeAuthInfo, sRDomain, sPubkeyAuthOptions, sSecurityKeyProvider,
+	sRouteCookieId,
 	sDeprecated, sIgnore, sUnsupported
 } ServerOpCodes;
 
@@ -676,6 +678,7 @@ static struct {
 	{ "rdomain", sRDomain, SSHCFG_ALL },
 	{ "casignaturealgorithms", sCASignatureAlgorithms, SSHCFG_ALL },
 	{ "securitykeyprovider", sSecurityKeyProvider, SSHCFG_GLOBAL },
+	{ "routecookieid", sRouteCookieId, SSHCFG_GLOBAL },
 	{ NULL, sBadOption, 0 }
 };
 
@@ -2430,6 +2433,24 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			    filename, linenum);
 		if (*activep && *charptr == NULL)
 			*charptr = xstrdup(arg);
+		break;
+
+	case sRouteCookieId:
+		arg = argv_next(&ac, &av);
+		if (strcmp(arg, "default") == 0) {
+			val64 = 0;
+		} else {
+			if (scan_scaled(arg, &val64) == -1)
+				fatal("%.200s line %d: Bad %s number '%s': %s",
+				    filename, linenum, keyword,
+				    arg, strerror(errno));
+			if (val64 < 0 || val64 > UINT_MAX)
+				fatal("%.200s line %d: Bad %s number '%s'",
+				    filename, linenum, keyword,
+				    arg);
+		}
+		if (*activep)
+			options->route_cookieid = (u_int32_t)val64;
 		break;
 
 	case sDeprecated:

--- a/servconf.h
+++ b/servconf.h
@@ -229,6 +229,7 @@ typedef struct {
 	int	expose_userauth_info;
 	u_int64_t timing_secret;
 	char   *sk_provider;
+	u_int32_t route_cookieid;
 }       ServerOptions;
 
 /* Information about the incoming connection as used by Match */

--- a/sshd.c
+++ b/sshd.c
@@ -1090,6 +1090,7 @@ listen_on_addrs(struct listenaddr *la)
 		if (listen(listen_sock, SSH_LISTEN_BACKLOG) == -1)
 			fatal("listen on [%s]:%s: %.100s",
 			    ntop, strport, strerror(errno));
+		set_cookieid(listen_sock, options.route_cookieid);
 		logit("Server listening on %s port %s%s%s.",
 		    ntop, strport,
 		    la->rdomain == NULL ? "" : " rdomain ",


### PR DESCRIPTION
FreeBSD via the SO_USER_COOKIE socket option allows to attribute
an ID for routing purpose.