### PR TITLE
ssh-sk: fix leaks when a device is specified

### DIFF
--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -1393,6 +1393,7 @@ sk_load_resident_keys(const char *pin, struct sk_option **options,
 		freezero(rks[i]->user_id, rks[i]->user_id_len);
 		freezero(rks[i], sizeof(*rks[i]));
 	}
+	free(device);
 	free(rks);
 	return ret;
 }

--- a/ssh-sk-helper.c
+++ b/ssh-sk-helper.c
@@ -265,6 +265,7 @@ process_load_resident(struct sshbuf *req)
 	sshsk_free_resident_keys(srks, nsrks);
 	sshbuf_free(kbuf);
 	free(provider);
+	free(device);
 	if (pin != NULL)
 		freezero(pin, strlen(pin));
 	return resp;


### PR DESCRIPTION
e.g. ssh-keygen -K -O device=path