### PR TITLE
ssh-add: Skip PKCS11 pin prompt with TEE identity

### DIFF
--- a/ssh-add.c
+++ b/ssh-add.c
@@ -449,14 +449,15 @@ update_card(int agent_fd, int add, const char *id, int qflag,
 {
 	char *pin = NULL;
 	int r, ret = -1;
+	int tee_identity = getenv("CKTEEC_LOGIN_TYPE") != NULL;
 
-	if (add) {
+	if (!tee_identity && add) {
 		if ((pin = read_passphrase("Enter passphrase for PKCS#11: ",
 		    RP_ALLOW_STDIN)) == NULL)
 			return -1;
 	}
 
-	if ((r = ssh_update_card(agent_fd, add, id, pin == NULL ? "" : pin,
+	if ((r = ssh_update_card(agent_fd, add, id, tee_identity ? "\n" : pin == NULL ? "" : pin,
 	    lifetime, confirm, dest_constraints, ndest_constraints)) == 0) {
 		ret = 0;
 		if (!qflag) {


### PR DESCRIPTION
TEE Identity-based authentication provides functionality to
log in without a pin but using a User or Group identity.
The feature is valuable for embedded devices where there is no
user interaction.

With the TEE Identity authentication, the pin should be empty.

The use case is:
CKTEEC_LOGIN_TYPE=user ssh-add -s /usr/lib/libckteec.so.0

For TEE Identity-based auth pin should be provided as an
empty string. But in the current implementation, if a pin
is empty the message structure will not be populated with
the pin(see sshbuf_put_string). As a result, the error:
"pin required". As a solution add a new line character.

The details about the TEE Identity-based authentication:
https://github.com/OP-TEE/optee_os/pull/4222

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>