### PR TITLE
Expand environment variables in `Include` directives

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -1863,6 +1863,12 @@ parse_pubkey_algos:
 				    filename, linenum, keyword);
 				goto out;
 			}
+			if ((arg2 = dollar_expand(&r, arg)) == NULL || r) {
+				debug("%s line %d: invalid environment expansion "
+				    "%s.", filename, linenum, arg);
+				continue;
+			}
+			arg = arg2;
 			/*
 			 * Ensure all paths are anchored. User configuration
 			 * files may begin with '~/' but system configurations


### PR DESCRIPTION
This is a follow-up to https://github.com/openssh/openssh-portable/pull/308#issuecomment-1119261184.

In this patch series, I attempt (to the best of my ability) to address points 1. and 2. by changing all `fatal_f` calls in `vdollar_percent_expand` to `error_f`, and then by utilizing the `dollar_expand` function (a light wrapper around `vdollar_percent_expand`) to actually do the expansion for `Include` directives. I didn't seriously attempt point 3. because I don't know exactly what things should be expanded, how to get access to that inside `process_config_line_depth`, and if it is desirable to prevent `percent{,_dollar}_expand` from fatal'ing.

I also moved the "env var has no value" and "invalid environment expansion" messages to the debug channel to tone down the noise.

I may have been a bit overzealous in my `fatal_f` -> `error_f` migration, so please point out any instances which I should revert. It's also possible that some parts of the codebase expect `vdollar_percent_expand` to fatal -- if you know this to be the case, please point me in their directions and I'll attempt to sort it out.

If this is deemed an acceptable approach, I'll write tests.

---

I tested this with the following command line and config files:

```
[nix-shell:~/workspace/vcs/openssh-portable]$ ./ssh root@me -F sshconf -v
OpenSSH_9.0p1, OpenSSL 1.1.1n  15 Mar 2022
debug1: Reading configuration data sshconf
debug1: Reading configuration data /home/vin/workspace/vcs/openssh-portable/inc
debug1: /home/vin/workspace/vcs/openssh-portable/inc line 1: Applying options for me
debug1: vdollar_percent_expand: env var ${DNE} has no value
debug1: sshconf line 2: invalid environment expansion ${DNE}/lol.
debug1: Authenticator provider $SSH_SK_PROVIDER did not resolve; disabling
debug1: Connecting to 127.0.0.1 [127.0.0.1] port 22.
debug1: Connection established.
[...]
The authenticity of host '127.0.0.1 (127.0.0.1)' can't be established.
[...fingerprint...]
This host key is known by the following other names/addresses:
    ~/.ssh/known_hosts:3: localhost
    ~/.ssh/known_hosts:124: scadrial
Are you sure you want to continue connecting (yes/no/[fingerprint])? ^C
```

```
# sshconf
Include "${PWD}/inc"
Include "${DNE}/lol"
```

```
# ${PWD}/inc
Host me
   HostName 127.0.0.1
```