### PR TITLE
Stop complaining about deprecated OpenSSL functions

### DIFF
--- a/includes.h
+++ b/includes.h
@@ -165,6 +165,12 @@
 
 #ifdef WITH_OPENSSL
 #include <openssl/opensslv.h> /* For OPENSSL_VERSION_NUMBER */
+/*
+ * OpenSSL 3.0 deprecates the OpenSSL's ENGINE API.
+ *
+ * Remove this if/when that API is no longer used
+ */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 #include "defines.h"


### PR DESCRIPTION
```
 sshbuf-getput-crypto.c: In function ‘sshbuf_get_eckey’:
 sshbuf-getput-crypto.c:97:9: warning: ‘EC_KEY_get0_group’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
    97 |         EC_POINT *pt = EC_POINT_new(EC_KEY_get0_group(v));
       |         ^~~~~~~~
 In file included from sshbuf-getput-crypto.c:29:
 /usr/include/openssl/ec.h:1032:39: note: declared here
  1032 | OSSL_DEPRECATEDIN_3_0 const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
       |                                       ^~~~~~~~~~~~~~~~~
```

 Ref: https://github.com/torvalds/linux/commit/6bfb56e93bcef41859c2d5ab234ffd80b691be35