### PR TITLE
Fix some memory leaks

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -217,7 +217,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
     const struct ssh_conn_info *cinfo)
 {
 	char *myproposal[PROPOSAL_MAX] = { KEX_CLIENT };
-	char *s, *all_key;
+	char *s, *all_key, *hostkeyalgs = NULL;
 	int r, use_known_hosts_order = 0;
 
 	xxx_host = host;
@@ -255,9 +255,11 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
 	    myproposal[PROPOSAL_MAC_ALGS_STOC] = options.macs;
 	if (use_known_hosts_order) {
 		/* Query known_hosts and prefer algorithms that appear there */
+		if ((hostkeyalgs = order_hostkeyalgs(host, hostaddr, port, cinfo)) == NULL)
+			fatal("order_hostkeyalgs failed");
 		myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] =
-		    compat_pkalg_proposal(ssh,
-		    order_hostkeyalgs(host, hostaddr, port, cinfo));
+		    compat_pkalg_proposal(ssh, hostkeyalgs);
+		free(hostkeyalgs);
 	} else {
 		/* Use specified HostkeyAlgorithms exactly */
 		myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] =

--- a/sshd.c
+++ b/sshd.c
@@ -2363,6 +2363,7 @@ static void
 do_ssh2_kex(struct ssh *ssh)
 {
 	char *myproposal[PROPOSAL_MAX] = { KEX_SERVER };
+	char *hostkey_types = NULL;
 	struct kex *kex;
 	int r;
 
@@ -2384,8 +2385,11 @@ do_ssh2_kex(struct ssh *ssh)
 		ssh_packet_set_rekey_limits(ssh, options.rekey_limit,
 		    options.rekey_interval);
 
+	if ((hostkey_types = list_hostkey_types()) == NULL)
+		fatal("list_hostkey_types failed");
 	myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] = compat_pkalg_proposal(
-	    ssh, list_hostkey_types());
+	    ssh, hostkey_types);
+	free(hostkey_types);
 
 	/* start key exchange */
 	if ((r = kex_setup(ssh, myproposal)) != 0)


### PR DESCRIPTION
If I am not mistaken, the functions `order_hostkeyalgs()` and `list_hostkey_types()` both return pointer to dynamically allocated memory. However, the pointers are forever lost as they are just passed into funtion `compat_pkalg_proposal()` where the pointer gets overwritten by newly allocated one.

Signed-off-by: Zoltan Fridrich <zfridric@redhat.com>