### PR TITLE
Providing MinRSABits option to limit RSA key length

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -2692,11 +2692,12 @@ fill_default_options(Options * options)
 	/* options->hostname will be set in the main program if appropriate */
 	/* options->host_key_alias should not be set by default */
 	/* options->preferred_authentications will be set in ssh */
-
+#ifdef WITH_OPENSSL
 	if (ssh_set_rsa_min_bits(options->min_rsa_bits) == 0)
 		ret = 0;
 	else
 		ret = -1;
+#endif
  fail:
 	free(all_cipher);
 	free(all_mac);

--- a/readconf.h
+++ b/readconf.h
@@ -176,6 +176,8 @@ typedef struct {
 
 	char   *known_hosts_command;
 
+	int    min_rsa_bits;
+
 	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
 }       Options;
 

--- a/servconf.c
+++ b/servconf.c
@@ -445,7 +445,9 @@ fill_default_server_options(ServerOptions *options)
 	if (options->min_rsa_bits == -1)
 		options->min_rsa_bits = SSH_RSA_MINIMUM_MODULUS_SIZE;
 
+#ifdef WITH_OPENSSL
 	(void)ssh_set_rsa_min_bits(options->min_rsa_bits);
+#endif
 
 	assemble_algorithms(options);
 

--- a/servconf.h
+++ b/servconf.h
@@ -229,6 +229,7 @@ typedef struct {
 	int	expose_userauth_info;
 	u_int64_t timing_secret;
 	char   *sk_provider;
+	int 	min_rsa_bits;
 }       ServerOptions;
 
 /* Information about the incoming connection as used by Match */

--- a/ssh.1
+++ b/ssh.1
@@ -554,6 +554,7 @@ For full details of the options listed below, and their possible values, see
 .It LogLevel
 .It MACs
 .It Match
+.It MinRSABits
 .It NoHostAuthenticationForLocalhost
 .It NumberOfPasswordPrompts
 .It PasswordAuthentication

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1323,7 +1323,9 @@ or
 .Cm no
 (the default).
 .It Cm MinRSABits
-Provides a minimal bits requirement for RSA keys. The default value is 1024.
+Provides a minimal bits requirement for RSA keys when used for signature and
+verification but not for the key generation. The default value is 1024 and
+can't be reduced.
 .It Cm NumberOfPasswordPrompts
 Specifies the number of password prompts before giving up.
 The argument to this keyword must be an integer.

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1322,6 +1322,8 @@ The argument to this keyword must be
 or
 .Cm no
 (the default).
+.It Cm MinRSABits
+Provides a minimal bits requirement for RSA keys. The default value is 1024.
 .It Cm NumberOfPasswordPrompts
 Specifies the number of password prompts before giving up.
 The argument to this keyword must be an integer.

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1267,7 +1267,9 @@ if there are currently start (10) unauthenticated connections.
 The probability increases linearly and all connection attempts
 are refused if the number of unauthenticated connections reaches full (60).
 .It Cm MinRSABits
-Provides a minimal bits requirement for RSA keys. The default value is 1024.
+Provides a minimal bits requirement for RSA keys when used for signature and
+verification but not for the key generation. The default value is 1024 and
+can't be reduced.
 .It Cm ModuliFile
 Specifies the
 .Xr moduli 5

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1266,6 +1266,8 @@ will refuse connection attempts with a probability of rate/100 (30%)
 if there are currently start (10) unauthenticated connections.
 The probability increases linearly and all connection attempts
 are refused if the number of unauthenticated connections reaches full (60).
+.It Cm MinRSABits
+Provides a minimal bits requirement for RSA keys. The default value is 1024.
 .It Cm ModuliFile
 Specifies the
 .Xr moduli 5

--- a/sshkey.h
+++ b/sshkey.h
@@ -286,6 +286,8 @@ int	 sshkey_private_serialize_maxsign(struct sshkey *key,
 
 void	 sshkey_sig_details_free(struct sshkey_sig_details *);
 
+int ssh_set_rsa_min_bits(int minbits);
+
 #ifdef SSHKEY_INTERNAL
 int ssh_rsa_sign(const struct sshkey *key,
     u_char **sigp, size_t *lenp, const u_char *data, size_t datalen,


### PR DESCRIPTION
There is a need to increase RSA key requirements to make the installations more secure. Just updating the default compiled-in value isn't an option because it may significantly break legacy systems compatibility. This PR introduces a new configuration option to be managed for security's sake.