### PR TITLE
Add flag to filter default algorithms

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -264,6 +264,15 @@ kex_assemble_names(char **listp, const char *def, const char *all)
 		}
 		free(list);
 		list = tmp;
+	} else if (*list == '&') {
+		/* Filter default list */
+		if ((*listp = match_filter_allowlist(def, list + 1)) == NULL) {
+			r = SSH_ERR_ALLOC_FAIL;
+			goto fail;
+		}
+		free(list);
+		/* filtering has already been done */
+		return 0;
 	} else {
 		/* Explicit list, overrides default - just use "list" as is */
 	}

--- a/readconf.c
+++ b/readconf.c
@@ -1392,7 +1392,7 @@ parse_int:
 			    filename, linenum);
 			goto out;
 		}
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !ciphers_valid(*arg == '+' || *arg == '^' ? arg + 1 : arg)){
 			error("%.200s line %d: Bad SSH2 cipher spec '%s'.",
 			    filename, linenum, arg ? arg : "<NONE>");
@@ -1409,7 +1409,7 @@ parse_int:
 			    filename, linenum);
 			goto out;
 		}
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !mac_valid(*arg == '+' || *arg == '^' ? arg + 1 : arg)) {
 			error("%.200s line %d: Bad SSH2 MAC spec '%s'.",
 			    filename, linenum, arg ? arg : "<NONE>");
@@ -1426,7 +1426,7 @@ parse_int:
 			    filename, linenum);
 			goto out;
 		}
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !kex_names_valid(*arg == '+' || *arg == '^' ?
 		    arg + 1 : arg)) {
 			error("%.200s line %d: Bad SSH2 KexAlgorithms '%s'.",
@@ -1446,7 +1446,7 @@ parse_pubkey_algos:
 			    filename, linenum);
 			goto out;
 		}
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !sshkey_names_valid2(*arg == '+' || *arg == '^' ?
 		    arg + 1 : arg, 1)) {
 			error("%s line %d: Bad key types '%s'.",

--- a/servconf.c
+++ b/servconf.c
@@ -1508,7 +1508,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		if (!arg || *arg == '\0')
 			fatal("%s line %d: Missing argument.",
 			    filename, linenum);
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !sshkey_names_valid2(*arg == '+' || *arg == '^' ?
 		    arg + 1 : arg, 1))
 			fatal("%s line %d: Bad key types '%s'.",
@@ -1821,7 +1821,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		if (!arg || *arg == '\0')
 			fatal("%s line %d: %s missing argument.",
 			    filename, linenum, keyword);
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !ciphers_valid(*arg == '+' || *arg == '^' ? arg + 1 : arg))
 			fatal("%s line %d: Bad SSH2 cipher spec '%s'.",
 			    filename, linenum, arg ? arg : "<NONE>");
@@ -1834,7 +1834,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		if (!arg || *arg == '\0')
 			fatal("%s line %d: %s missing argument.",
 			    filename, linenum, keyword);
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !mac_valid(*arg == '+' || *arg == '^' ? arg + 1 : arg))
 			fatal("%s line %d: Bad SSH2 mac spec '%s'.",
 			    filename, linenum, arg ? arg : "<NONE>");
@@ -1847,7 +1847,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		if (!arg || *arg == '\0')
 			fatal("%s line %d: %s missing argument.",
 			    filename, linenum, keyword);
-		if (*arg != '-' &&
+		if (*arg != '-' && *arg != '&' &&
 		    !kex_names_valid(*arg == '+' || *arg == '^' ?
 		    arg + 1 : arg))
 			fatal("%s line %d: Bad SSH2 KexAlgorithms '%s'.",

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -231,6 +231,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
 	 * that are in the list that are supported by known_hosts keys.
 	 */
 	if (options.hostkeyalgorithms == NULL ||
+	    options.hostkeyalgorithms[0] == '&' ||
 	    options.hostkeyalgorithms[0] == '-' ||
 	    options.hostkeyalgorithms[0] == '+')
 		use_known_hosts_order = 1;


### PR DESCRIPTION
Allows you to more easily select a subset of algorithms you want to use, without also overriding the priority, or enabling something that is no longer deemed safe to use.