### PR TITLE
Mptcp support

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -892,6 +892,10 @@ struct winsize {
 # define SSH_IOBUFSZ 8192
 #endif
 
+#ifndef IPPROTO_MPTCP
+#define IPPROTO_MPTCP 262
+#endif
+
 /*
  * We want functions in openbsd-compat, if enabled, to override system ones.
  * We no-op out the weak symbol definition rather than remove it to reduce

--- a/readconf.c
+++ b/readconf.c
@@ -175,7 +175,7 @@ typedef enum {
 	oFingerprintHash, oUpdateHostkeys, oHostbasedAcceptedAlgorithms,
 	oPubkeyAcceptedAlgorithms, oCASignatureAlgorithms, oProxyJump,
 	oSecurityKeyProvider, oKnownHostsCommand,
-	oIgnore, oIgnoredUnknownOption, oDeprecated, oUnsupported
+	oIgnore, oIgnoredUnknownOption, oDeprecated, oUnsupported, oUseMPTCP
 } OpCodes;
 
 /* Textual representations of the tokens. */
@@ -320,6 +320,7 @@ static struct {
 	{ "proxyjump", oProxyJump },
 	{ "securitykeyprovider", oSecurityKeyProvider },
 	{ "knownhostscommand", oKnownHostsCommand },
+	{ "usemptcp", oUseMPTCP},
 
 	{ NULL, oBadOption }
 };
@@ -2176,6 +2177,10 @@ parse_pubkey_algos:
 			*charptr = xstrdup(arg);
 		break;
 
+	case oUseMPTCP:
+		intptr = &options->use_mptcp;
+		goto parse_flag;
+
 	case oDeprecated:
 		debug("%s line %d: Deprecated option \"%s\"",
 		    filename, linenum, keyword);
@@ -2423,6 +2428,7 @@ initialize_options(Options * options)
 	options->hostbased_accepted_algos = NULL;
 	options->pubkey_accepted_algos = NULL;
 	options->known_hosts_command = NULL;
+	options->use_mptcp = -1;
 }
 
 /*
@@ -2612,6 +2618,8 @@ fill_default_options(Options * options)
 		options->canonicalize_hostname = SSH_CANONICALISE_NO;
 	if (options->fingerprint_hash == -1)
 		options->fingerprint_hash = SSH_FP_HASH_DEFAULT;
+	if (options->use_mptcp == -1)
+		options->use_mptcp = 0;
 #ifdef ENABLE_SK_INTERNAL
 	if (options->sk_provider == NULL)
 		options->sk_provider = xstrdup("internal");
@@ -3300,6 +3308,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oVerifyHostKeyDNS, o->verify_host_key_dns);
 	dump_cfg_fmtint(oVisualHostKey, o->visual_host_key);
 	dump_cfg_fmtint(oUpdateHostkeys, o->update_hostkeys);
+	dump_cfg_fmtint(oUseMPTCP, o->use_mptcp);
 
 	/* Integer options */
 	dump_cfg_int(oCanonicalizeMaxDots, o->canonicalize_max_dots);

--- a/readconf.h
+++ b/readconf.h
@@ -177,6 +177,7 @@ typedef struct {
 	char   *known_hosts_command;
 
 	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
+	int use_mptcp; /* decides whether to use multipath TCP */
 }       Options;
 
 #define SSH_PUBKEY_AUTH_NO	0x00

--- a/scp.1
+++ b/scp.1
@@ -219,6 +219,7 @@ For full details of the options listed below, and their possible values, see
 .It StrictHostKeyChecking
 .It TCPKeepAlive
 .It UpdateHostKeys
+.It UseMPTCP
 .It User
 .It UserKnownHostsFile
 .It VerifyHostKeyDNS

--- a/servconf.c
+++ b/servconf.c
@@ -195,6 +195,7 @@ initialize_server_options(ServerOptions *options)
 	options->fingerprint_hash = -1;
 	options->disable_forwarding = -1;
 	options->expose_userauth_info = -1;
+	options->use_mptcp = -1;
 }
 
 /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
@@ -441,6 +442,8 @@ fill_default_server_options(ServerOptions *options)
 		options->expose_userauth_info = 0;
 	if (options->sk_provider == NULL)
 		options->sk_provider = xstrdup("internal");
+	if (options->use_mptcp == -1)
+		options->use_mptcp = 0;
 
 	assemble_algorithms(options);
 
@@ -517,7 +520,7 @@ typedef enum {
 	sStreamLocalBindMask, sStreamLocalBindUnlink,
 	sAllowStreamLocalForwarding, sFingerprintHash, sDisableForwarding,
 	sExposeAuthInfo, sRDomain, sPubkeyAuthOptions, sSecurityKeyProvider,
-	sDeprecated, sIgnore, sUnsupported
+	sDeprecated, sIgnore, sUnsupported, sUseMPTCP
 } ServerOpCodes;
 
 #define SSHCFG_GLOBAL		0x01	/* allowed in main section of config */
@@ -676,6 +679,7 @@ static struct {
 	{ "rdomain", sRDomain, SSHCFG_ALL },
 	{ "casignaturealgorithms", sCASignatureAlgorithms, SSHCFG_ALL },
 	{ "securitykeyprovider", sSecurityKeyProvider, SSHCFG_GLOBAL },
+	{ "usemptcp", sUseMPTCP, SSHCFG_GLOBAL},
 	{ NULL, sBadOption, 0 }
 };
 
@@ -2438,6 +2442,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			*charptr = xstrdup(arg);
 		break;
 
+	case sUseMPTCP:
+		intptr = &options->use_mptcp;
+		goto parse_flag;
+
 	case sDeprecated:
 	case sIgnore:
 	case sUnsupported:
@@ -2920,6 +2928,7 @@ dump_config(ServerOptions *o)
 	dump_cfg_fmtint(sStreamLocalBindUnlink, o->fwd_opts.streamlocal_bind_unlink);
 	dump_cfg_fmtint(sFingerprintHash, o->fingerprint_hash);
 	dump_cfg_fmtint(sExposeAuthInfo, o->expose_userauth_info);
+	dump_cfg_fmtint(sUseMPTCP, o->use_mptcp);
 
 	/* string arguments */
 	dump_cfg_string(sPidFile, o->pid_file);

--- a/servconf.h
+++ b/servconf.h
@@ -229,6 +229,7 @@ typedef struct {
 	int	expose_userauth_info;
 	u_int64_t timing_secret;
 	char   *sk_provider;
+	int use_mptcp;
 }       ServerOptions;
 
 /* Information about the incoming connection as used by Match */

--- a/sftp.1
+++ b/sftp.1
@@ -278,6 +278,7 @@ For full details of the options listed below, and their possible values, see
 .It StrictHostKeyChecking
 .It TCPKeepAlive
 .It UpdateHostKeys
+.It UseMPTCP
 .It User
 .It UserKnownHostsFile
 .It VerifyHostKeyDNS

--- a/ssh.1
+++ b/ssh.1
@@ -584,6 +584,7 @@ For full details of the options listed below, and their possible values, see
 .It Tunnel
 .It TunnelDevice
 .It UpdateHostKeys
+.It UseMPTCP
 .It User
 .It UserKnownHostsFile
 .It VerifyHostKeyDNS

--- a/ssh_config
+++ b/ssh_config
@@ -44,3 +44,4 @@
 #   ProxyCommand ssh -q -W %h:%p gateway.example.com
 #   RekeyLimit 1G 1h
 #   UserKnownHostsFile ~/.ssh/known_hosts.d/%k
+#   UseMPTCP no

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1930,6 +1930,12 @@ Presently, only
 from OpenSSH 6.8 and greater support the
 .Qq hostkeys@openssh.com
 protocol extension used to inform the client of all the server's hostkeys.
+.It Cm UseMPTCP
+If set to
+.Cm yes ,
+this will enable Multipath TCP (MPTCP) instead of TCP (this only works on Linux).
+The default is
+.Cm no .
 .It Cm User
 Specifies the user to log in as.
 This can be useful when a different user name is used on different machines.

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -359,7 +359,10 @@ ssh_create_socket(struct addrinfo *ai)
 #endif
 	char ntop[NI_MAXHOST];
 
-	sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+	if (options.use_mptcp)
+		sock = socket(ai->ai_family, ai->ai_socktype, IPPROTO_MPTCP);
+	else
+		sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 	if (sock == -1) {
 		error("socket: %s", strerror(errno));
 		return -1;

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -359,10 +359,8 @@ ssh_create_socket(struct addrinfo *ai)
 #endif
 	char ntop[NI_MAXHOST];
 
-	if (options.use_mptcp)
-		sock = socket(ai->ai_family, ai->ai_socktype, IPPROTO_MPTCP);
-	else
-		sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+	sock = socket(ai->ai_family, ai->ai_socktype,
+		options.use_mptcp ? IPPROTO_MPTCP : ai->ai_protocol);
 	if (sock == -1) {
 		error("socket: %s", strerror(errno));
 		return -1;

--- a/sshd.c
+++ b/sshd.c
@@ -1046,13 +1046,8 @@ listen_on_addrs(struct listenaddr *la)
 			continue;
 		}
 		/* Create socket for listening. */
-		if (options.use_mptcp) {
-			listen_sock = socket(ai->ai_family, ai->ai_socktype,
-				IPPROTO_MPTCP);
-		} else {
-			listen_sock = socket(ai->ai_family, ai->ai_socktype,
-				ai->ai_protocol);
-		}
+		listen_sock = socket(ai->ai_family, ai->ai_socktype,
+			options.use_mptcp ? IPPROTO_MPTCP : ai->ai_protocol);
 		if (listen_sock == -1) {
 			/* kernel may not support ipv6 */
 			verbose("socket: %.100s", strerror(errno));

--- a/sshd.c
+++ b/sshd.c
@@ -1046,8 +1046,13 @@ listen_on_addrs(struct listenaddr *la)
 			continue;
 		}
 		/* Create socket for listening. */
-		listen_sock = socket(ai->ai_family, ai->ai_socktype,
-		    ai->ai_protocol);
+		if (options.use_mptcp) {
+			listen_sock = socket(ai->ai_family, ai->ai_socktype,
+				IPPROTO_MPTCP);
+		} else {
+			listen_sock = socket(ai->ai_family, ai->ai_socktype,
+				ai->ai_protocol);
+		}
 		if (listen_sock == -1) {
 			/* kernel may not support ipv6 */
 			verbose("socket: %.100s", strerror(errno));

--- a/sshd_config
+++ b/sshd_config
@@ -101,6 +101,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #PermitTunnel no
 #ChrootDirectory none
 #VersionAddendum none
+#UseMPTCP no
 
 # no default banner path
 #Banner none

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1752,6 +1752,12 @@ and
 .Cm Match
 .Cm Host
 directives.
+.It Cm UseMPTCP
+If set to
+.Cm yes ,
+this will enable Multipath TCP (MPTCP) instead of TCP (this only works on Linux).
+The default is
+.Cm no .
 .It Cm UsePAM
 Enables the Pluggable Authentication Module interface.
 If set to


### PR DESCRIPTION
The first commit on this branch of our fork is a patch aimed at providing openssh with MPTCP support, the rest are to udapte the man pages and config according to the new MPTCP support.

MPTCP stands for multipath tcp, it can be seen as an extension to tcp sockets which allows the use of multiple network interface at the same time, or to switch from one to another seamlessly. The support for MPTCP is native in the more recent linux kernels, so it is only natural that it becomes native for openssh as well.

The changes to the code base are minimal and the use of MPTCP is controlled by a yes/no configuration parameter "UseMPTCP". This port was made during the OpenWeek event of this year at UCLouvain, in collaboration with Professor Olivier Bonaventure, his research team (mainly François Michel and Maxime Piraux) along with a few students, including me (Colin Evrard), Maxime Postaire and Simon Arys. 

The main part of our work was about testing the implementation under various conditions, including real world ones, which is all described in this [blog post article](http://blog.multipath-tcp.org/blog/html/index.html). 
