### PR TITLE
sk-usbhid: fix key_lookup() on tokens with built-in UV

### DIFF
--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -783,6 +783,7 @@ key_lookup(fido_dev_t *dev, const char *application, const uint8_t *user_id,
 	fido_assert_t *assert = NULL;
 	uint8_t message[32];
 	int r = FIDO_ERR_INTERNAL;
+	int sk_supports_uv, uv;
 	size_t i;
 
 	memset(message, '\0', sizeof(message));
@@ -802,7 +803,15 @@ key_lookup(fido_dev_t *dev, const char *application, const uint8_t *user_id,
 		goto out;
 	}
 	if ((r = fido_assert_set_up(assert, FIDO_OPT_FALSE)) != FIDO_OK) {
-		skdebug(__func__, "fido_assert_up: %s", fido_strerr(r));
+		skdebug(__func__, "fido_assert_set_up: %s", fido_strerr(r));
+		goto out;
+	}
+	uv = FIDO_OPT_OMIT;
+	if (pin == NULL && check_sk_options(dev, "uv", &sk_supports_uv) == 0 &&
+	    sk_supports_uv != -1)
+		uv = FIDO_OPT_TRUE;
+	if ((r = fido_assert_set_uv(assert, uv)) != FIDO_OK) {
+		skdebug(__func__, "fido_assert_set_uv: %s", fido_strerr(r));
 		goto out;
 	}
 	if ((r = fido_dev_get_assert(dev, assert, pin)) != FIDO_OK) {


### PR DESCRIPTION
`key_lookup()` relied on `pin != NULL`. With ssh-keygen.c r1.458 (git 2a108c0e), that premise is violated. Given we enforce `FIDO_CRED_PROT_UV_{REQUIRED,OPTIONAL_WITH_ID}`, `key_lookup()` will never succeed in finding resident keys if `pin == NULL`.

On tokens without built-in UV, `sk_enroll()` fails, we retry with `pin != NULL`, and `key_lookup()` works. On tokens with built-in UV, `sk_enroll()` does not fail, and any existing resident key is silently overwritten. To fix this, we need to check if `pin == NULL` in `key_lookup()` and, if so, check whether the device supports built-in UV, in which case we enable UV in the assertion used by `key_lookup()`, allowing it to find existing resident keys. This is implemented in the present PR.

To reproduce using a Yubikey Bio:

```                                  
$ ssh-keygen -t ecdsa-sk -O resident -f /tmp/key                                
Generating public/private ecdsa-sk key pair.                                    
You may need to touch your authenticator to authorize key generation.           
Enter passphrase (empty for no passphrase):                                     
Enter same passphrase again:                                                    
Your identification has been saved in /tmp/key                                  
Your public key has been saved in /tmp/key.pub                                  
(...)           
$ ssh-keygen -t ecdsa-sk -O resident -f /tmp/key                                
Generating public/private ecdsa-sk key pair.                                    
You may need to touch your authenticator to authorize key generation.           
Enter passphrase (empty for no passphrase):                                     
Enter same passphrase again:                                                    
Your identification has been saved in /tmp/key                                  
Your public key has been saved in /tmp/key.pub                                  
(...)
```
                                                                        
Expected behaviour:

```                                                                               
$ ssh-keygen -t ecdsa-sk -O resident -f /tmp/key                                
Generating public/private ecdsa-sk key pair.                                    
You may need to touch your authenticator to authorize key generation.           
A resident key scoped to 'ssh:' with user id 'null' already exists.             
Overwrite key in token (y/n)?
```