### PR TITLE
Give info about ssh-keygen -R to remove offending key

### DIFF
--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1,4 +1,4 @@
-/* $OpenBSD: sshconnect.c,v 1.360 2022/11/03 21:59:20 djm Exp $ */
+/* $OpenBSD: sshconnect.c,v 1.358 2022/08/26 08:16:27 djm Exp $ */
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
  * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
@@ -935,7 +935,7 @@ check_host_key(char *hostname, const struct ssh_conn_info *cinfo,
 	char *ip = NULL, *host = NULL;
 	char hostline[1000], *hostp, *fp, *ra;
 	char msg[1024];
-	const char *type, *fail_reason = NULL;
+	const char *type, *fail_reason;
 	const struct hostkey_entry *host_found = NULL, *ip_found = NULL;
 	int len, cancelled_forwarding = 0, confirmed;
 	int local = sockaddr_is_local(hostaddr);
@@ -958,17 +958,6 @@ check_host_key(char *hostname, const struct ssh_conn_info *cinfo,
 		    "loopback/localhost.");
 		options.update_hostkeys = 0;
 		return 0;
-	}
-
-	/*
-	 * Don't ever try to write an invalid name to a known hosts file.
-	 * Note: do this before get_hostfile_hostname_ipaddr() to catch
-	 * '[' or ']' in the name before they are added.
-	 */
-	if (strcspn(hostname, "@?*#[]|'\'\"\\") != strlen(hostname)) {
-		debug_f("invalid hostname \"%s\"; will not record: %s",
-		    hostname, fail_reason);
-		readonly = RDONLY;
 	}
 
 	/*
@@ -1281,7 +1270,8 @@ check_host_key(char *hostname, const struct ssh_conn_info *cinfo,
 		error("Offending %s key in %s:%lu",
 		    sshkey_type(host_found->key),
 		    host_found->file, host_found->line);
-
+        error("If you are sure that this is not a security issue, you can run the following command to fix the problem :");
+        error("ssh-keygen -R <server>");
 		/*
 		 * If strict host key checking is in use, the user will have
 		 * to edit the key manually and we can only abort.


### PR DESCRIPTION
Giving a `sed` command in the error message about offending server (host) key allowing to just copy and paste the command in order to remove the offending key.