### PR TITLE
ssh: don't make the umask more permissive than the user has set

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -679,7 +679,7 @@ main(int ac, char **av)
 	 * writable only by the owner, which is ok for all files for which we
 	 * don't set the modes explicitly.
 	 */
-	umask(022);
+	umask(022 | umask(0));
 
 	msetlocale();
 


### PR DESCRIPTION
Daniel Kahn Gillmor suggested this exact change on the openssh-unix-dev mailing list in 2008, but I couldn't find any reply. [1]

Ignoring the current umask makes it hard to fulfill the Defense Information Systems Agency's Security Technical Implementation Guide. In particular, it requires:

"The Red Hat Enterprise Linux operating system must be configured so that all files and directories contained in local interactive user home directories have a mode of 0750 or less permissive." [2]

"The Red Hat Enterprise Linux operating system must set the umask value to 077 for all local interactive user accounts." [3]

[1] https://lists.mindrot.org/pipermail/openssh-unix-dev/2008-October/026935.html [2] https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-05-15/finding/V-72027 [3] https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2020-05-15/finding/V-72049