### PR TITLE
fix configure for clang 15

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -713,7 +713,7 @@ case "$host" in
 	AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <mach-o/dyld.h>
 #include <stdlib.h>
-main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
+int main() { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
 		exit(0);
 	else
 		exit(1);
@@ -4259,7 +4259,7 @@ dnl test snprintf (broken on SCO w/gcc)
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_SNPRINTF
-main()
+int main()
 {
 	char buf[50];
 	char expected_out[50];
@@ -4276,7 +4276,7 @@ main()
 	exit(0);
 }
 #else
-main() { exit(0); }
+int main() { exit(0); }
 #endif
 		]])], [ true ], [ AC_DEFINE([BROKEN_SNPRINTF]) ],
 		AC_MSG_WARN([cross compiling: Assuming working snprintf()])


### PR DESCRIPTION
See https://bugzilla.mindrot.org/show_bug.cgi?id=3482

And https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics:

> The -Wimplicit-int warning diagnostic now defaults to an error in C99 and
> later. Prior to C2x, it may be downgraded to a warning with
> -Wno-error=implicit-int, or disabled entirely with -Wno-implicit-int. As of
> C2x, support for implicit int has been removed, and the warning options will
> have no effect. Specifying -Wimplicit-int in C89 mode will now issue warnings
> instead of being a noop.

The configure scripts shouldn't be using `main() {...}` but `int main() {...}`.
