### PR TITLE
sftp: implement session timeout to automatically close idle connections

### DIFF
--- a/sftp-server.8
+++ b/sftp-server.8
@@ -38,6 +38,7 @@
 .Op Fl P Ar denied_requests
 .Op Fl p Ar allowed_requests
 .Op Fl u Ar umask
+.Op Fl t Ar session_timeout
 .Ek
 .Nm
 .Fl Q Ar protocol_feature
@@ -138,6 +139,9 @@ Sets an explicit
 .Xr umask 2
 to be applied to newly-created files and directories, instead of the
 user's default mask.
+.It Fl t Ar session_timeout
+Sets a timeout for idle connections in seconds. Specify 0 to disable the
+timeout.
 .El
 .Pp
 On some systems,


### PR DESCRIPTION
See https://bugzilla.mindrot.org/show_bug.cgi?id=3484

Currently there is no way for the sftp backend (`sftp-server` or `internal-sftp`) to close idle connections (by idle I mean no order sent for some time by the `sftp` client).

This is very problematic for SFTP servers because clients can remain connected, which consumes file descriptors and resources in general, causing potentially system limits to be reached.
This is a case I handled recently, where system-wide file descriptors were exhausted, due to left-opened sftp sessions + corresponding systemd sessions.

There are `ClientAlive*` properties but these only work for dead clients.

This PR implements the functionality through a new `-t <timeout>` option passed to `sftp-server` or `internal-sftp` executables.