### PR TITLE
doc: Improve IdentityFile documentation

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1011,6 +1011,10 @@ section.
 .It Cm IdentityFile
 Specifies a file from which the user's DSA, ECDSA, authenticator-hosted ECDSA,
 Ed25519, authenticator-hosted Ed25519 or RSA authentication identity is read.
+You can also specify a public key file to use the corresponding
+private key that is loaded in
+.Xr ssh-agent 1
+when the private key file is not present locally.
 The default is
 .Pa ~/.ssh/id_rsa ,
 .Pa ~/.ssh/id_ecdsa ,


### PR DESCRIPTION
The IdentityFile option in ssh_config can also be used to specify a public key file, as documented in ssh.1 for the -i option. Document this also for IdentityFile in ssh_config.5, for documentation completeness.