### PR TITLE
Improve openssh to check is getentropy() supported and use compat way…

### DIFF
--- a/openbsd-compat/arc4random.h
+++ b/openbsd-compat/arc4random.h
@@ -33,9 +33,9 @@
 #define _ARC4_ATFORK(f)
 
 static inline void
-_getentropy_fail(void)
+_getentropy_fail(int err)
 {
-	fatal("getentropy failed");
+	fatal("getentropy failed with error: %s", strerror(err));
 }
 
 static volatile sig_atomic_t _rs_forked;

--- a/openbsd-compat/bsd-getentropy.c
+++ b/openbsd-compat/bsd-getentropy.c
@@ -18,8 +18,6 @@
 
 #include "includes.h"
 
-#ifndef HAVE_GETENTROPY
-
 #ifndef SSH_RANDOM_DEV
 # define SSH_RANDOM_DEV "/dev/urandom"
 #endif /* SSH_RANDOM_DEV */
@@ -79,4 +77,3 @@ _ssh_compat_getentropy(void *s, size_t len)
 #endif /* WITH_OPENSSL */
 	return 0;
 }
-#endif /* WITH_GETENTROPY */


### PR DESCRIPTION
The version 9.1_p1 is broken for very old kernels. Call getentropy() and goto fatal when error occurred, with no check error for "function is not implemented". The patch make improve to use old compatible method for getting entropy. No any side effects for devices with a fresh kernel.