### PR TITLE
Fixed compatibility issue with getpgrp()

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -702,7 +702,7 @@ struct winsize {
 
 #ifndef GETPGRP_VOID
 # include <unistd.h>
-# define getpgrp() getpgrp(0)
+# define getpgrp() getpgrp()
 #endif
 
 #ifdef USE_BSM_AUDIT


### PR DESCRIPTION
Fixed compatibility issue with getpgrp() to conform to modern linux standards without any formal arguments