### PR TITLE
ssh-keygen: New option -G for removing a key passphrase

### DIFF
--- a/ssh-keygen.1
+++ b/ssh-keygen.1
@@ -61,6 +61,7 @@
 .Op Fl m Ar format
 .Op Fl N Ar new_passphrase
 .Op Fl P Ar old_passphrase
+.Op Fl G
 .Op Fl Z Ar cipher
 .Nm ssh-keygen
 .Fl i
@@ -468,6 +469,8 @@ when generating or updating a supported private key type will cause the
 key to be stored in the legacy PEM private key format.
 .It Fl N Ar new_passphrase
 Provides the new passphrase.
+.It Fl G
+Use a new empty passphrase.
 .It Fl n Ar principals
 Specify one or more principals (user or host names) to be included in
 a certificate when signing a key.

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -107,6 +107,9 @@ static char *identity_passphrase = NULL;
 /* This is set to the new passphrase if given on the command line. */
 static char *identity_new_passphrase = NULL;
 
+/* This is the empty passphrase. */
+static char *identity_empty_passphrase = "";
+
 /* Key type when certifying */
 static u_int cert_key_type = SSH2_CERT_TYPE_USER;
 
@@ -3261,7 +3264,7 @@ usage(void)
 	    "                  [-t dsa | ecdsa | ecdsa-sk | ed25519 | ed25519-sk | rsa]\n"
 	    "                  [-w provider] [-Z cipher]\n"
 	    "       ssh-keygen -p [-a rounds] [-f keyfile] [-m format] [-N new_passphrase]\n"
-	    "                   [-P old_passphrase] [-Z cipher]\n"
+	    "                   [-P old_passphrase] [-G] [-Z cipher]\n"
 #ifdef WITH_OPENSSL
 	    "       ssh-keygen -i [-f input_keyfile] [-m key_format]\n"
 	    "       ssh-keygen -e [-f input_keyfile] [-m key_format]\n"
@@ -3354,8 +3357,8 @@ main(int argc, char **argv)
 
 	sk_provider = getenv("SSH_SK_PROVIDER");
 
-	/* Remaining characters: dGjJSTWx */
-	while ((opt = getopt(argc, argv, "ABHKLQUXceghiklopquvy"
+	/* Remaining characters: djJSTWx */
+	while ((opt = getopt(argc, argv, "ABGHKLQUXceghiklopquvy"
 	    "C:D:E:F:I:M:N:O:P:R:V:Y:Z:"
 	    "a:b:f:g:m:n:r:s:t:w:z:")) != -1) {
 		switch (opt) {
@@ -3443,6 +3446,9 @@ main(int argc, char **argv)
 			break;
 		case 'N':
 			identity_new_passphrase = optarg;
+			break;
+		case 'G':
+			identity_new_passphrase = identity_empty_passphrase;
 			break;
 		case 'Q':
 			check_krl = 1;


### PR DESCRIPTION
Hello,
I ran into a problem with `ssh-keygen` while using it from PowerShell. I needed to remove a passphrase from my private key and I determined there's no clean way to do so with the current `ssh-keygen` options and interface.

I fixed the problem by introducing a new `-G` option/switch that simply uses an empty passphrase from internal empty string.

Consider the following example:

```powershell
Start-Process -FilePath "C:\Program Files\OpenSSH\ssh-keygen.exe" -ArgumentList ("-p", "-f", "C:\Users\Administrator\.ssh\id_rsa", "-P", "<current passphrase>", "-N", "") 
```

The last argument, which is the new passphrase is empty.

```
Start-Process : Cannot validate argument on parameter 'ArgumentList'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command
again.
```

With this change applied the code becomes:

```powershell
Start-Process -FilePath "C:\Program Files\OpenSSH\ssh-keygen.exe" -ArgumentList ("-p", "-f", "C:\Users\Administrator\.ssh\id_rsa", "-P", "<current passphrase>", "-G") 
```
and the process to remove a passphrase becomes straightforward even from Powershell.

Please consider suggesting changes or merging this change.