### PR TITLE
Fix leak of hostkey types string in do_ssh2_kex

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -2367,7 +2367,7 @@ do_ssh2_kex(struct ssh *ssh)
 {
 	char *myproposal[PROPOSAL_MAX] = { KEX_SERVER };
 	struct kex *kex;
-	char *prop_kex = NULL, *prop_enc = NULL, *prop_hostkey = NULL;
+	char *prop_kex = NULL, *prop_enc = NULL, *hostkey_types = NULL, *prop_hostkey = NULL;
 	int r;
 
 	myproposal[PROPOSAL_KEX_ALGS] = prop_kex = compat_kex_proposal(ssh,
@@ -2387,8 +2387,9 @@ do_ssh2_kex(struct ssh *ssh)
 		ssh_packet_set_rekey_limits(ssh, options.rekey_limit,
 		    options.rekey_interval);
 
+	hostkey_types = list_hostkey_types();
 	myproposal[PROPOSAL_SERVER_HOST_KEY_ALGS] = prop_hostkey =
-	   compat_pkalg_proposal(ssh, list_hostkey_types());
+	   compat_pkalg_proposal(ssh, hostkey_types);
 
 	/* start key exchange */
 	if ((r = kex_setup(ssh, myproposal)) != 0)
@@ -2425,6 +2426,7 @@ do_ssh2_kex(struct ssh *ssh)
 #endif
 	free(prop_kex);
 	free(prop_enc);
+	free(hostkey_types);
 	free(prop_hostkey);
 	debug("KEX done");
 }


### PR DESCRIPTION
do_ssh2_kex() calls list_hostkey_types() which allocates a new string buffer using strdup. It then passes this to compat_pkalg_proposal() which returns a duplicate. The hostkey types buffer must be freed after calling  compat_pkalg_proposal().

This leak is detectable by LeakSanitizer and mentioned as the second leak in https://bugzilla.mindrot.org/show_bug.cgi?id=3244. It appears this was fixed in: https://github.com/openssh/openssh-portable/commit/646686136c34c2dbf6a01296dfaa9ebee029386d#diff-f42dba1d7d6991fccb9cdfd6a94f90b480ae2e5e17a5217d635b0a1b1edfff64

which had to be rolled back in:
https://github.com/openssh/openssh-portable/commit/2369a2810187e08f2af5d58b343956062fb96ee8#diff-f42dba1d7d6991fccb9cdfd6a94f90b480ae2e5e17a5217d635b0a1b1edfff64

The subsequent reland did not include the fix for the hostkey_types leak: https://github.com/openssh/openssh-portable/commit/6c31ba10e97b6953c4f325f526f3e846dfea647a#diff-f42dba1d7d6991fccb9cdfd6a94f90b480ae2e5e17a5217d635b0a1b1edfff64