### PR TITLE
Fix leak in sftp-server.c process_read()

### DIFF
--- a/sftp-server.c
+++ b/sftp-server.c
@@ -819,7 +819,7 @@ process_read(u_int32_t id)
 	}
 	if (len > buflen) {
 		debug3_f("allocate %zu => %u", buflen, len);
-		if ((buf = realloc(NULL, len)) == NULL)
+		if ((buf = realloc(buf, len)) == NULL)
 			fatal_f("realloc failed");
 		buflen = len;
 	}


### PR DESCRIPTION
process_read() has a static local u_char* buf that can grow using realloc. When growing, the function was allocating a new buffer with realloc(NULL, ...) aka malloc(...) and assigning the result into buf. This leaks if the buffer is allocated more that once. This changes the growth path to call realloc(buf, ...) to reuse or free the old buffer as needed.