### PR TITLE
Improve SSHFP handling

### DIFF
--- a/dns.h
+++ b/dns.h
@@ -50,7 +50,7 @@ typedef struct s_sshfp_record {
 	u_int8_t dnskey_digest_type;
 	u_char *dnskey_digest;
 	size_t dnskey_digest_len;
-} t_sshfp_record;
+} sshfp_record_t;
 
 #define DNS_RDATACLASS_IN	1
 #define DNS_RDATATYPE_SSHFP	44
@@ -59,10 +59,10 @@ typedef struct s_sshfp_record {
 
 #define DNS_VERIFY_FOUND			0x00000001
 #define DNS_VERIFY_MATCH 			0x00000002
-#define DNS_VERIFY_SECURE			0x00000004
-#define DNS_VERIFY_FAILED			0x00000008
-#define DNS_VERIFY_MATCH_SHA1		0x00000010
-#define DNS_VERIFY_MATCH_SHA256		0x00000020
+#define DNS_VERIFY_MATCH_SHA1		0x00000004
+#define DNS_VERIFY_MATCH_SHA256		0x00000008
+#define DNS_VERIFY_SECURE			0x00000010
+#define DNS_VERIFY_FAILED			0x00000020
 
 int	verify_host_key_dns(const char *, struct sockaddr *,
     struct sshkey *, int *);

--- a/dns.h
+++ b/dns.h
@@ -34,6 +34,11 @@ enum sshfp_types {
 	SSHFP_KEY_DSA = 2,
 	SSHFP_KEY_ECDSA = 3,
 	SSHFP_KEY_ED25519 = 4,
+	/* FIXME: This is not RFC-compliant. 
+	* 5 is unassigned
+	www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.txt
+	* RFC 8709 defines 6 as ED448.
+	*/
 	SSHFP_KEY_XMSS = 5,
 	SSHFP_KEY_MAX = 6
 };

--- a/dns.h
+++ b/dns.h
@@ -34,7 +34,8 @@ enum sshfp_types {
 	SSHFP_KEY_DSA = 2,
 	SSHFP_KEY_ECDSA = 3,
 	SSHFP_KEY_ED25519 = 4,
-	SSHFP_KEY_XMSS = 5
+	SSHFP_KEY_XMSS = 5,
+	SSHFP_KEY_MAX = 6
 };
 
 enum sshfp_hashes {
@@ -44,13 +45,24 @@ enum sshfp_hashes {
 	SSHFP_HASH_MAX = 3
 };
 
+typedef struct s_sshfp_record {
+	u_int8_t dnskey_algorithm;
+	u_int8_t dnskey_digest_type;
+	u_char *dnskey_digest;
+	size_t dnskey_digest_len;
+} t_sshfp_record;
+
 #define DNS_RDATACLASS_IN	1
 #define DNS_RDATATYPE_SSHFP	44
 
-#define DNS_VERIFY_FOUND	0x00000001
-#define DNS_VERIFY_MATCH	0x00000002
-#define DNS_VERIFY_SECURE	0x00000004
-#define DNS_VERIFY_FAILED	0x00000008
+#define DNS_MAX_RECORDS		256
+
+#define DNS_VERIFY_FOUND			0x00000001
+#define DNS_VERIFY_MATCH 			0x00000002
+#define DNS_VERIFY_SECURE			0x00000004
+#define DNS_VERIFY_FAILED			0x00000008
+#define DNS_VERIFY_MATCH_SHA1		0x00000010
+#define DNS_VERIFY_MATCH_SHA256		0x00000020
 
 int	verify_host_key_dns(const char *, struct sockaddr *,
     struct sshkey *, int *);

--- a/readconf.c
+++ b/readconf.c
@@ -159,7 +159,7 @@ typedef enum {
 	oDynamicForward, oPreferredAuthentications, oHostbasedAuthentication,
 	oHostKeyAlgorithms, oBindAddress, oBindInterface, oPKCS11Provider,
 	oClearAllForwardings, oNoHostAuthenticationForLocalhost,
-	oEnableSSHKeysign, oRekeyLimit, oVerifyHostKeyDNS, oConnectTimeout,
+	oEnableSSHKeysign, oRekeyLimit, oVerifyHostKeyDNS, oInsecureDNS, oConnectTimeout,
 	oAddressFamily, oGssAuthentication, oGssDelegateCreds,
 	oServerAliveInterval, oServerAliveCountMax, oIdentitiesOnly,
 	oSendEnv, oSetEnv, oControlPath, oControlMaster, oControlPersist,
@@ -276,6 +276,7 @@ static struct {
 	{ "clearallforwardings", oClearAllForwardings },
 	{ "enablesshkeysign", oEnableSSHKeysign },
 	{ "verifyhostkeydns", oVerifyHostKeyDNS },
+	{ "insecuredns", oInsecureDNS },
 	{ "nohostauthenticationforlocalhost", oNoHostAuthenticationForLocalhost },
 	{ "rekeylimit", oRekeyLimit },
 	{ "connecttimeout", oConnectTimeout },
@@ -1135,6 +1136,11 @@ parse_time:
 	case oVerifyHostKeyDNS:
 		intptr = &options->verify_host_key_dns;
 		multistate_ptr = multistate_yesnoask;
+		goto parse_multistate;
+
+	case oInsecureDNS:
+		intptr = &options->insecure_dns;
+		multistate_ptr = multistate_flag;
 		goto parse_multistate;
 
 	case oStrictHostKeyChecking:
@@ -2388,6 +2394,7 @@ initialize_options(Options * options)
 	options->rekey_limit = - 1;
 	options->rekey_interval = -1;
 	options->verify_host_key_dns = -1;
+	options->insecure_dns = -1;
 	options->server_alive_interval = -1;
 	options->server_alive_count_max = -1;
 	options->send_env = NULL;
@@ -2574,6 +2581,8 @@ fill_default_options(Options * options)
 		options->rekey_interval = 0;
 	if (options->verify_host_key_dns == -1)
 		options->verify_host_key_dns = 0;
+	if (options->insecure_dns == -1)
+		options->insecure_dns = 0;
 	if (options->server_alive_interval == -1)
 		options->server_alive_interval = 0;
 	if (options->server_alive_count_max == -1)
@@ -3125,6 +3134,8 @@ fmt_intarg(OpCodes code, int val)
 	case oVerifyHostKeyDNS:
 	case oUpdateHostkeys:
 		return fmt_multistate_int(val, multistate_yesnoask);
+	case oInsecureDNS:
+		return fmt_multistate_int(val, multistate_flag);
 	case oStrictHostKeyChecking:
 		return fmt_multistate_int(val, multistate_strict_hostkey);
 	case oControlMaster:
@@ -3306,6 +3317,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oTCPKeepAlive, o->tcp_keep_alive);
 	dump_cfg_fmtint(oTunnel, o->tun_open);
 	dump_cfg_fmtint(oVerifyHostKeyDNS, o->verify_host_key_dns);
+	dump_cfg_fmtint(oInsecureDNS, o->insecure_dns);
 	dump_cfg_fmtint(oVisualHostKey, o->visual_host_key);
 	dump_cfg_fmtint(oUpdateHostkeys, o->update_hostkeys);
 

--- a/readconf.h
+++ b/readconf.h
@@ -84,6 +84,7 @@ typedef struct {
 	char   *pkcs11_provider; /* PKCS#11 provider */
 	char   *sk_provider; /* Security key provider */
 	int	verify_host_key_dns;	/* Verify host key using DNS */
+	int insecure_dns; /* Accept insecure DNS responses (missing DNSSEC validation/'ad' flag in response) */
 
 	int     num_identity_files;	/* Number of files for RSA/DSA identities. */
 	char   *identity_files[SSH_MAX_IDENTITY_FILES];

--- a/ssh.1
+++ b/ssh.1
@@ -545,6 +545,7 @@ For full details of the options listed below, and their possible values, see
 .It IdentitiesOnly
 .It IdentityAgent
 .It IdentityFile
+.It InsecureDNS
 .It IPQoS
 .It KbdInteractiveAuthentication
 .It KbdInteractiveDevices
@@ -1297,6 +1298,13 @@ is added to a zonefile
 and the connecting client is able to match the fingerprint
 with that of the key presented.
 .Pp
+RFC 4255 mandates secure transmission of SSHFP records (i.e. DNSSEC).
+By default, the DNS resolver's answer is checked for the 'ad' flag
+(indicating DNSSEC validation) and unauthenticated records are not considered.
+This can be changed using the
+.Cm InsecureDNS
+option.
+.Pp
 In this example, we are connecting a client to a server,
 .Dq host.example.com .
 The SSHFP resource records should first be added to the zonefile for
@@ -1320,7 +1328,9 @@ Are you sure you want to continue connecting (yes/no)?
 .Pp
 See the
 .Cm VerifyHostKeyDNS
-option in
+and
+.Cm InsecureDNS
+options in
 .Xr ssh_config 5
 for more information.
 .Sh SSH-BASED VIRTUAL PRIVATE NETWORKS

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1097,6 +1097,16 @@ or
 .Cm Host
 block
 to perform conditional inclusion.
+.It Cm InsecureDNS
+Specifies that non-DNSSEC-validated DNS data should be trusted,
+although it implies certain security risks (i.e. MITM) due to lack of
+authenticity. This setting is mostly relevant in combination with the
+.Cm VerifyHostKeyDNS
+option. Valid values are
+.Cm yes
+or
+.Cm no
+(the default).
 .It Cm IPQoS
 Specifies the IPv4 type-of-service or DSCP class for connections.
 Accepted values are

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1506,9 +1506,14 @@ verify_host_key(char *host, struct sockaddr *hostaddr, struct sshkey *host_key,
 			sshkey_drop_cert(plain);
 		if (verify_host_key_dns(host, hostaddr, plain, &flags) == 0) {
 			if (flags & DNS_VERIFY_FOUND) {
+				if (options.insecure_dns == 0 &&
+					! (flags & DNS_VERIFY_SECURE)) {
+					error("The authenticity of the SSHFP records cannot be established. Use a DNSSEC validating DNS resolver or -o InsecureDNS=yes to get rid of the message.");
+				}
 				if (options.verify_host_key_dns == 1 &&
 				    flags & DNS_VERIFY_MATCH &&
-				    flags & DNS_VERIFY_SECURE) {
+				    (flags & DNS_VERIFY_SECURE ||
+				    options.insecure_dns == 1)) {
 					r = 0;
 					goto out;
 				}


### PR DESCRIPTION
Hello,

I did some research on SSHFP records [0,1] and while I was happy that openssh has support for it, I discovered and implemented a few improvements:

- The change discussed and introduced with Bugzilla #3322 [2] prevents host key rotations, because it requires all SSHFP records to match, while a smooth key rotation requires the *old* and *new* SSHFP records in the DNS at least until the TTL expires [3]. This change fixes this issue by checking if the host's fingerprints *exist* in the SSHFP record set - removing the *all must match* requirement. Further, the RFC [0] states that only *one* match is required for a successful validation. To prevent SHA256->SHA1 downgrade attacks, which were discussed in bz#3322, this change still requires a SHA-256 FP match if a SHA-1 FP match is encountered.

- It appears like openssh only checks the `ad` (DNSSEC validated) flag from the system's resolver if it is compiled with `ldns`, which makes sense. Versions without `ldns` always ask the user to manually verify the fingerprints, but tell the user that `Matching host key fingerprint found in DNS.`, which might let the user believe that everything is fine and they can answer with `yes`.  However, in some scenarios there DNSSEC might not be available, although a secure transport channel is (i.e. internal DNS server in trusted networks, VPNs, etc.). For these, I have added a `InsecureDNS=n|y` option (default: No). If set to `yes`, the SSHFP records are considered for host key verification, although they are considered `insecure`. A debatable downside is that users could enable this option to workaround DNSSEC validation with public DNS, thereby losing any security guarantees. On the other hand, this might help the adoption in internal networks, assuming people know what they are doing. (Maybe this should be put more clearly in the man pages or in debug messages?) 

- I noticed that the `sshfp_types` enum in `dns.h` does not match IANA's assignments [4]:
    - Algo 5 is not `XMSS`, but reserved.
    - Algo 6 should be `ED448`, but this key algorithm does not seem to be implemented (yet)?

This might lead to some confusion or other side effects, but I wanted to have your opinion first, before changing things.

You can test with the following endpoints and commands (remember to build with `./configure --with-ldns` for DNSSEC support):
- With DNSSEC: `./ssh -o VerifyHostKeyDNS=yes -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=rsa-sha2-512 -p2222 -v ssh.neef.it` 
- No DNSSEC: `./ssh -o VerifyHostKeyDNS=yes -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=rsa-sha2-512 -p2222 -v ssh.0rn.de` 

Last, but not least, I'm not a C-programmer, although I tried to adhere to the overall code style. I'm happy to take any advice and improve the code if necessary. 

Kind regards,
Sebastian

[0] https://www.rfc-editor.org/rfc/rfc4255.html
[1] Oh SSH-it, what's my fingerprint? A Large-Scale Analysis of SSH Host Key Fingerprint Verification Records in the DNS; S. Neef & N. Wisiol; 2022;
[2] https://bugzilla.mindrot.org/show_bug.cgi?id=3322
[3] https://marc.info/?l=openssh-unix-dev&m=164700394009668&w=2
[4] https://www.iana.org/assignments/dns-sshfp-rr-parameters/dns-sshfp-rr-parameters.txt
