### PR TITLE
Fix memory leaks detected by the sanitizer in the unit tests.

### DIFF
--- a/auth-options.c
+++ b/auth-options.c
@@ -153,6 +153,7 @@ cert_option_list(struct sshauthopt *opts, struct sshbuf *oblob,
 				if (addr_match_cidr_list(NULL, allowed) == -1) {
 					error("Certificate source-address "
 					    "contents invalid");
+					free(allowed);
 					goto out;
 				}
 				opts->required_from_host_cert = allowed;

--- a/regress/unittests/misc/test_expand.c
+++ b/regress/unittests/misc/test_expand.c
@@ -72,18 +72,23 @@ test_expand(void)
 	log_init("test_misc", SYSLOG_LEVEL_INFO, SYSLOG_FACILITY_AUTH, 1);
 	TEST_DONE();
 
+#define ASSERT_STRING_EQ_FREE(x, y) do { \
+	char *str = (x); \
+	ASSERT_STRING_EQ(str, (y)); \
+	free(str); \
+} while(0)
 	TEST_START("percent_expand");
-	ASSERT_STRING_EQ(percent_expand("%%", "%h", "foo", NULL), "%");
-	ASSERT_STRING_EQ(percent_expand("%h", "h", "foo", NULL), "foo");
-	ASSERT_STRING_EQ(percent_expand("%h ", "h", "foo", NULL), "foo ");
-	ASSERT_STRING_EQ(percent_expand(" %h", "h", "foo", NULL), " foo");
-	ASSERT_STRING_EQ(percent_expand(" %h ", "h", "foo", NULL), " foo ");
-	ASSERT_STRING_EQ(percent_expand(" %a%b ", "a", "foo", "b", "bar", NULL),
+	ASSERT_STRING_EQ_FREE(percent_expand("%%", "%h", "foo", NULL), "%");
+	ASSERT_STRING_EQ_FREE(percent_expand("%h", "h", "foo", NULL), "foo");
+	ASSERT_STRING_EQ_FREE(percent_expand("%h ", "h", "foo", NULL), "foo ");
+	ASSERT_STRING_EQ_FREE(percent_expand(" %h", "h", "foo", NULL), " foo");
+	ASSERT_STRING_EQ_FREE(percent_expand(" %h ", "h", "foo", NULL), " foo ");
+	ASSERT_STRING_EQ_FREE(percent_expand(" %a%b ", "a", "foo", "b", "bar", NULL),
 	    " foobar ");
 	TEST_DONE();
 
 	TEST_START("percent_dollar_expand");
-	ASSERT_STRING_EQ(percent_dollar_expand("%h${FOO}", "h", "foo", NULL),
+	ASSERT_STRING_EQ_FREE(percent_dollar_expand("%h${FOO}", "h", "foo", NULL),
 	    "foobar");
 	TEST_DONE();
 }

--- a/regress/unittests/sshbuf/test_sshbuf_getput_basic.c
+++ b/regress/unittests/sshbuf/test_sshbuf_getput_basic.c
@@ -575,6 +575,7 @@ sshbuf_getput_basic_tests(void)
 	s2 = sshbuf_dtob16(p1);
 	ASSERT_PTR_NE(s2, NULL);
 	ASSERT_STRING_EQ(s2, "00000000000000000000");
+	free(s2);
 	sshbuf_free(p1);
 	TEST_DONE();
 
@@ -609,6 +610,7 @@ sshbuf_getput_basic_tests(void)
 	s2 = sshbuf_dtob16(p1);
 	ASSERT_PTR_NE(s2, NULL);
 	ASSERT_STRING_EQ(s2, "00000000000000000000");
+	free(s2);
 	sshbuf_free(p1);
 	TEST_DONE();
 
@@ -643,6 +645,7 @@ sshbuf_getput_basic_tests(void)
 	s2 = sshbuf_dtob16(p1);
 	ASSERT_PTR_NE(s2, NULL);
 	ASSERT_STRING_EQ(s2, "00000000000000000000");
+	free(s2);
 	sshbuf_free(p1);
 	TEST_DONE();
 
@@ -673,6 +676,7 @@ sshbuf_getput_basic_tests(void)
 	s2 = sshbuf_dtob16(p1);
 	ASSERT_PTR_NE(s2, NULL);
 	ASSERT_STRING_EQ(s2, "00000000000000000000");
+	free(s2);
 	sshbuf_free(p1);
 	TEST_DONE();
 
@@ -707,6 +711,7 @@ sshbuf_getput_basic_tests(void)
 	s2 = sshbuf_dtob16(p1);
 	ASSERT_PTR_NE(s2, NULL);
 	ASSERT_STRING_EQ(s2, "00000000000000000000");
+	free(s2);
 	sshbuf_free(p1);
 	TEST_DONE();
 }

--- a/regress/unittests/sshbuf/test_sshbuf_misc.c
+++ b/regress/unittests/sshbuf/test_sshbuf_misc.c
@@ -182,6 +182,7 @@ sshbuf_misc_tests(void)
 	ASSERT_INT_EQ(sshbuf_cmp(p1, 1000, "silence", 7),
 	    SSH_ERR_MESSAGE_INCOMPLETE);
 	ASSERT_INT_EQ(sshbuf_cmp(p1, 0, msg, sizeof(msg) - 1), 0);
+	sshbuf_free(p1);
 	TEST_DONE();
 
 	TEST_START("sshbuf_find");
@@ -212,6 +213,7 @@ sshbuf_misc_tests(void)
 	    SSH_ERR_MESSAGE_INCOMPLETE);
 	ASSERT_INT_EQ(sshbuf_find(p1, 0, msg + 1, sizeof(msg) - 2, &sz), 0);
 	ASSERT_SIZE_T_EQ(sz, 1);
+	sshbuf_free(p1);
 	TEST_DONE();
 }
 


### PR DESCRIPTION
If the project is built with the memory sanitizer enabled, the unit tests fail.