### PR TITLE
File exists control added before opening remote connection (SCP)

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -421,6 +421,7 @@ void run_err(const char *,...)
 int note_err(const char *,...)
     __attribute__((__format__ (printf, 1, 2)));
 void verifydir(char *);
+void verify_file_exists(char *);
 
 struct passwd *pwd;
 uid_t userid;
@@ -678,6 +679,7 @@ main(int argc, char **argv)
 	else {
 		if (targetshouldbedirectory)
 			verifydir(argv[argc - 1]);
+		// verify_file_exists(argv[argc - 1]);
 		tolocal(argc, argv, mode, sftp_direct);	/* Dest is local host. */
 	}
 	/*
@@ -1160,6 +1162,7 @@ toremote(int argc, char **argv, enum scp_mode_e mode, char *sftp_direct)
 				errs = 1;
 		} else {	/* local to remote */
 			if (mode == MODE_SFTP) {
+				verify_file_exists(argv[i]);
 				if (remin == -1) {
 					/* Connect to remote now */
 					conn = do_sftp_connect(thost, tuser,
@@ -2152,6 +2155,17 @@ verifydir(char *cp)
 	}
 	run_err("%s: %s", cp, strerror(errno));
 	killchild(0);
+}
+
+void
+verify_file_exists(char *cp)
+{
+	struct stat stb;
+
+	if (!stat(cp, &stb)) {
+		return;
+	}
+	fatal("stat local \"%s\": %s", cp, strerror(errno));
 }
 
 int


### PR DESCRIPTION
I have such a long password for the remote PC and getting `No such file or directory` after writing the password is so annoying. This is why I add a check before creating a connection. I didn't remove the existing control after entering the password because at that time folder can be removed.

````console
$ ./scp nonExistFolder  ubuntu@192.168.1.11:/home/ubuntu/folder
./scp: stat local "nonExistFolder": No such file or directory
````

Tests are successful. 

````console
test_hostkeys: .................. 18 tests ok
test_match: ...... 6 tests ok
test_misc: ........................................... 43 tests ok
make[1]: Leaving directory '/home/macorapci/Desktop/openssh-portable/regress'
unit tests passed
echo all tests passed
all tests passed
````

https://github.com/macorapci/openssh-portable/blob/ca9bb068015321c2045d02c5ba7fa4616abba4d8/scp.c#L682

I wanna add the condition for `tolocal` but the tests fail so I add it with the comment line. I can delete the line if it breaks something.