### PR TITLE
Allow ssh_config location to be set in environment

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -706,6 +706,8 @@ main(int ac, char **av)
 	logfile = NULL;
 	argv0 = av[0];
 
+    config = getenv("SSH_CONFIG");
+
  again:
 	while ((opt = getopt(ac, av, "1246ab:c:e:fgi:kl:m:no:p:qstvx"
 	    "AB:CD:E:F:GI:J:KL:MNO:PQ:R:S:TVw:W:XYy")) != -1) { /* HUZdhjruz */

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -2148,6 +2148,11 @@ and
 .Cm ProxyJump
 accept the tokens %%, %h, %n, %p, and %r.
 .Sh ENVIRONMENT VARIABLES
+The location of the default ssh configuration file can be overridden by
+setting the
+.Cm SSH_CONFIG
+environment variable.
+.Pp
 Arguments to some keywords can be expanded at runtime from environment
 variables on the client by enclosing them in
 .Ic ${} ,


### PR DESCRIPTION
Hi,

I heavily use environment modules (eg lmod) to switch between different sets of environment variables. When in a testing environment, it would be useful to override the default ssh config. I usually do this with the `-F` flag, and I understand it can be put in an alias for the session, but this has a few issues:

* This alias is not inherited by programs that use OpenSSH under the hood, such as Git and Rsync.
* Telling Git and Rsync to add extra arguments to the ssh client is doable but clumsy.
* It's not consistent with the rest of my workflow or with other common tools like Git, which eg offers a `GIT_CONFIG_GLOBAL` environment variable similar to the `SSH_CONFIG` variable proposed in this pull request.

The commit in this pull request passes all tests on my local system, including `make tests` as well as manual tests of the new functionality. It doesn't add any new dependencies because it only uses getenv from stdlib, which is already included.

When the variable is not set, `getenv("SSH_CONFIG")` simply returns NULL, so nothing changes for people not using this variable. If the user also adds a `-F` argument, it overrides the environment variable.