### PR TITLE
harden Linux seccomp sandbox

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -134,23 +134,25 @@
 	/* reload syscall number; all rules expect it in accumulator */ \
 	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
 		offsetof(struct seccomp_data, nr))
-/* Deny unless syscall argument matches value */
-#define SC_DENY_UNLESS_ARG(_nr, _arg_nr, _arg_val, _errno) \
-	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 6), \
-	/* load and test syscall argument, low word */ \
+/* Deny unless syscall argument contains only values in mask */
+#define SC_DENY_UNLESS_ARG_MASK(_nr, _arg_nr, _arg_mask, _errno) \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 8), \
+	/* load, mask and test syscall argument, low word */ \
 	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
 	    offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_LO_OFFSET), \
-	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, \
-	    ((_arg_val) & 0xFFFFFFFF), 0, 2), \
-	/* load and test syscall argument, high word */ \
+	BPF_STMT(BPF_ALU+BPF_AND+BPF_K, ~((_arg_mask) & 0xFFFFFFFF)), \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 0, 3), \
+	/* load, mask and test syscall argument, high word */ \
 	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
 	    offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_HI_OFFSET), \
-	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, \
-	    (((uint32_t)((uint64_t)(_arg_val) >> 32)) & 0xFFFFFFFF), 1, 0), \
+	BPF_STMT(BPF_ALU+BPF_AND+BPF_K, \
+	    ~(((uint32_t)((uint64_t)(_arg_mask) >> 32)) & 0xFFFFFFFF)), \
+	BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 1, 0), \
 	BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ERRNO|(_errno)), \
 	/* reload syscall number; all rules expect it in accumulator */ \
 	BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
 		offsetof(struct seccomp_data, nr))
+#define SC_DENY_UNLESS_MASK(_nr, _arg_nr, _arg_val, _errno) \
 /* Special handling for futex(2) that combines a bitmap and operation number */
 #if defined(__NR_futex) || defined(__NR_futex_time64)
 #define SC_FUTEX_MASK (FUTEX_PRIVATE_FLAG|FUTEX_CLOCK_REALTIME)
@@ -184,6 +186,14 @@
 	SC_ALLOW_FUTEX_OP(__NR_futex, FUTEX_REQUEUE), \
 	SC_ALLOW_FUTEX_OP(__NR_futex, FUTEX_CMP_REQUEUE)
 #endif /* __NR_futex || __NR_futex_time64 */
+
+#if defined(__NR_mmap) || defined(__NR_mmap2)
+/* Use this for both mmap variants */
+# define SC_MMAP(_nr) \
+	SC_DENY_UNLESS_ARG_MASK(_nr, 3, \
+	    MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED|MAP_FIXED_NOREPLACE, EINVAL), \
+	SC_ALLOW_ARG_MASK(_nr, 2, PROT_READ|PROT_WRITE|PROT_NONE)
+#endif /* __NR_mmap || __NR_mmap2 */
 
 /* Syscall filtering set for preauth. */
 static const struct sock_filter preauth_insns[] = {
@@ -305,12 +315,10 @@ static const struct sock_filter preauth_insns[] = {
 	SC_DENY(__NR_madvise, EINVAL),
 #endif
 #ifdef __NR_mmap
-	SC_DENY_UNLESS_ARG(__NR_mmap, 3, MAP_PRIVATE|MAP_ANONYMOUS, EINVAL),
-	SC_ALLOW_ARG_MASK(__NR_mmap, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+	SC_MMAP(__NR_mmap),
 #endif
 #ifdef __NR_mmap2
-	SC_DENY_UNLESS_ARG(__NR_mmap2, 3, MAP_PRIVATE|MAP_ANONYMOUS, EINVAL),
-	SC_ALLOW_ARG_MASK(__NR_mmap2, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+	SC_MMAP(__NR_mmap2),
 #endif
 #ifdef __NR_mprotect
 	SC_ALLOW_ARG_MASK(__NR_mprotect, 2, PROT_READ|PROT_WRITE|PROT_NONE),

--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -296,6 +296,8 @@ static const struct sock_filter preauth_insns[] = {
 	SC_ALLOW(__NR_getuid32),
 #endif
 #ifdef __NR_madvise
+	SC_ALLOW_ARG(__NR_madvise, 2, MADV_NORMAL),
+	SC_ALLOW_ARG(__NR_madvise, 2, MADV_FREE),
 	SC_ALLOW_ARG(__NR_madvise, 2, MADV_DONTNEED),
 	SC_ALLOW_ARG(__NR_madvise, 2, MADV_DONTFORK),
 	SC_ALLOW_ARG(__NR_madvise, 2, MADV_DONTDUMP),


### PR DESCRIPTION
Linux mmap(2) and madvise(2) syscalls support quite a number of funky flags that we don't expect that sshd/libc will ever need. We can exclude this kernel attack surface by filtering the mmap(2) flags and the madvise(2) advice arguments.

Similarly, the sandboxed process in sshd is a single-threaded program that does not use shared memory for synchronisation or communication. Therefore, there should be no reason for the advanced priority inheritance futex(2) operations to be necessary. These can also be excluded.

Motivated by Jann Horn pointing out that there have been kernel bugs in nearby Linux kernel code, e.g. CVE-2020-29368, CVE-2020-29374 and CVE-2022-42703.