### PR TITLE
systemd: unit files, `sd_notify` support; OpenRC init scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4835,6 +4835,29 @@ AC_SUBST([GSSLIBS])
 AC_SUBST([K5LIBS])
 AC_SUBST([CHANNELLIBS])
 
+# Check whether user wants systemd support
+SYSTEMD_MSG="no"
+AC_ARG_WITH(systemd,
+	[  --with-systemd          Enable systemd support],
+	[ if test "x$withval" != "xno" ; then
+		AC_PATH_TOOL([PKGCONFIG], [pkg-config], [no])
+		if test "$PKGCONFIG" != "no"; then
+			AC_MSG_CHECKING([for libsystemd])
+			if $PKGCONFIG --exists libsystemd; then
+				SYSTEMD_CFLAGS=`$PKGCONFIG --cflags libsystemd`
+				SYSTEMD_LIBS=`$PKGCONFIG --libs libsystemd`
+				CPPFLAGS="$CPPFLAGS $SYSTEMD_CFLAGS"
+				SSHDLIBS="$SSHDLIBS $SYSTEMD_LIBS"
+				AC_MSG_RESULT([yes])
+				AC_DEFINE(HAVE_SYSTEMD, 1, [Define if you want systemd support.])
+				SYSTEMD_MSG="yes"
+			else
+				AC_MSG_RESULT([no])
+			fi
+		fi
+	fi ]
+)
+
 # Looking for programs, paths and files
 
 PRIVSEP_PATH=/var/empty
@@ -5634,6 +5657,7 @@ echo "                   libldns support: $LDNS_MSG"
 echo "  Solaris process contract support: $SPC_MSG"
 echo "           Solaris project support: $SP_MSG"
 echo "         Solaris privilege support: $SPP_MSG"
+echo "                   systemd support: $SYSTEMD_MSG"
 echo "       IP address in \$DISPLAY hack: $DISPLAY_HACK_MSG"
 echo "           Translate v4 in v6 hack: $IPV4_IN6_HACK_MSG"
 echo "                  BSD Auth support: $BSD_AUTH_MSG"

--- a/contrib/gentoo/sshd.confd
+++ b/contrib/gentoo/sshd.confd
@@ -1,0 +1,33 @@
+# /etc/conf.d/sshd: config file for /etc/init.d/sshd
+
+# Where is your sshd_config file stored?
+
+SSHD_CONFDIR="${RC_PREFIX%/}/etc/ssh"
+
+
+# Any random options you want to pass to sshd.
+# See the sshd(8) manpage for more info.
+
+SSHD_OPTS=""
+
+
+# Wait one second (length chosen arbitrarily) to see if sshd actually
+# creates a PID file, or if it crashes for some reason like not being
+# able to bind to the address in ListenAddress.
+
+#SSHD_SSD_OPTS="--wait 1000"
+
+
+# Pid file to use (needs to be absolute path).
+
+#SSHD_PIDFILE="${RC_PREFIX%/}/run/sshd.pid"
+
+
+# Path to the sshd binary (needs to be absolute path).
+
+#SSHD_BINARY="${RC_PREFIX%/}/usr/sbin/sshd"
+
+
+# Path to the ssh-keygen binary (needs to be absolute path).
+
+#SSHD_KEYGEN_BINARY="${RC_PREFIX%/}/usr/bin/ssh-keygen"

--- a/contrib/gentoo/sshd.initd
+++ b/contrib/gentoo/sshd.initd
@@ -1,0 +1,85 @@
+#!/sbin/openrc-run
+
+extra_commands="checkconfig"
+extra_started_commands="reload"
+
+: ${SSHD_CONFDIR:=${RC_PREFIX%/}/etc/ssh}
+: ${SSHD_CONFIG:=${SSHD_CONFDIR}/sshd_config}
+: ${SSHD_PIDFILE:=${RC_PREFIX%/}/run/${SVCNAME}.pid}
+: ${SSHD_BINARY:=${RC_PREFIX%/}/usr/sbin/sshd}
+: ${SSHD_KEYGEN_BINARY:=${RC_PREFIX%/}/usr/bin/ssh-keygen}
+
+command="${SSHD_BINARY}"
+pidfile="${SSHD_PIDFILE}"
+command_args="${SSHD_OPTS} -o PidFile=${pidfile} -f ${SSHD_CONFIG}"
+
+# Wait one second (length chosen arbitrarily) to see if sshd actually
+# creates a PID file, or if it crashes for some reason like not being
+# able to bind to the address in ListenAddress (https://bugs.gentoo.org/617596).
+: ${SSHD_SSD_OPTS:=--wait 1000}
+start_stop_daemon_args="${SSHD_SSD_OPTS}"
+
+depend() {
+	# Entropy can be used by ssh-keygen, among other things, but
+	# is not strictly required (https://bugs.gentoo.org/470020).
+	use logger dns entropy
+	if [ "${rc_need+set}" = "set" ] ; then
+		: # Do nothing, the user has explicitly set rc_need
+	else
+		local x warn_addr
+		for x in $(awk '/^ListenAddress/{ print $2 }' "$SSHD_CONFIG" 2>/dev/null) ; do
+			case "${x}" in
+				0.0.0.0|0.0.0.0:*) ;;
+				::|\[::\]*) ;;
+				*) warn_addr="${warn_addr} ${x}" ;;
+			esac
+		done
+		if [ -n "${warn_addr}" ] ; then
+			need net
+			ewarn "You are binding an interface in ListenAddress statement in your sshd_config!"
+			ewarn "You must add rc_need=\"net.FOO\" to your ${RC_PREFIX%/}/etc/conf.d/sshd"
+			ewarn "where FOO is the interface(s) providing the following address(es):"
+			ewarn "${warn_addr}"
+		fi
+	fi
+}
+
+checkconfig() {
+	checkpath --mode 0755 --directory "${RC_PREFIX%/}/var/empty"
+
+	if [ ! -e "${SSHD_CONFIG}" ] ; then
+		eerror "You need an ${SSHD_CONFIG} file to run sshd"
+		eerror "There is a sample file in /usr/share/doc/openssh"
+		return 1
+	fi
+
+	${SSHD_KEYGEN_BINARY} -A || return 2
+
+	"${command}" -t ${command_args} || return 3
+}
+
+start_pre() {
+	# Make sure that the user's config isn't busted before we try
+	# to start the daemon (this will produce better error messages
+	# than if we just try to start it blindly).
+	#
+	# We always need to call checkconfig because this function will
+	# also generate any missing host key and you can start a
+	# non-running service with "restart" argument.
+	checkconfig || return $?
+}
+
+stop_pre() {
+	# If this is a restart, check to make sure the user's config
+	# isn't busted before we stop the running daemon.
+	if [ "${RC_CMD}" = "restart" ] ; then
+		checkconfig || return $?
+	fi
+}
+
+reload() {
+	checkconfig || return $?
+	ebegin "Reloading ${SVCNAME}"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
+	eend $?
+}

--- a/contrib/gentoo/sshd.service
+++ b/contrib/gentoo/sshd.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=OpenSSH server daemon
+Documentation=man:sshd(8) man:sshd_config(5)
+After=network.target auditd.service
+
+[Service]
+ExecStartPre=/usr/bin/ssh-keygen -A
+ExecStart=/usr/sbin/sshd -D -e
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+OOMPolicy=continue
+Restart=on-failure
+RestartSec=42s
+Type=notify
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/gentoo/sshd.socket
+++ b/contrib/gentoo/sshd.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=OpenSSH Server Socket
+Conflicts=sshd.service
+
+[Socket]
+ListenStream=22
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/contrib/gentoo/sshd_at.service
+++ b/contrib/gentoo/sshd_at.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=OpenSSH per-connection server daemon
+Documentation=man:sshd(8) man:sshd_config(5)
+After=auditd.service
+
+[Service]
+ExecStart=-/usr/sbin/sshd -i -e
+StandardInput=socket
+StandardError=journal


### PR DESCRIPTION
Add OpenRC and systemd init files for cross-distribution compatibility. Also includes a rebased and updated `sd_notify` support patch from #251, in line with usage by Red Hat/Fedora, OpenSuSE, and Debian. Feedback welcome.