### PR TITLE
make tests fails with code compiled on AIX

### DIFF
--- a/regress/unittests/misc/test_ptimeout.c
+++ b/regress/unittests/misc/test_ptimeout.c
@@ -5,6 +5,8 @@
  * Placed in the public domain.
  */
 
+#include "includes.h"
+
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
make command ---- successful
make install ---- successful
make tests failed with following errors 


```
"/usr/include/sys/mman.h", line 148.25: 1506-343 (S) Redeclaration of mmap64 differs from previous declaration on line 143 of "/usr/include/sys/mman.h".
"/usr/include/sys/mman.h", line 148.25: 1506-377 (I) The type "long long" of parameter 6 differs from the previous type "long".
"/usr/include/unistd.h", line 201.17: 1506-343 (S) Redeclaration of lseek64 differs from previous declaration on line 199 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 201.17: 1506-050 (I) Return type "long long" in redeclaration is not compatible with the previous return type "long".
"/usr/include/unistd.h", line 201.17: 1506-377 (I) The type "long long" of parameter 2 differs from the previous type "long".
"/usr/include/sys/lockf.h", line 64.20: 1506-343 (S) Redeclaration of lockf64 differs from previous declaration on line 62 of "/usr/include/sys/lockf.h".
"/usr/include/sys/lockf.h", line 64.20: 1506-377 (I) The type "long long" of parameter 3 differs from the previous type "long".
"/usr/include/unistd.h", line 920.33: 1506-343 (S) Redeclaration of ftruncate64 differs from previous declaration on line 918 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 920.33: 1506-377 (I) The type "long long" of parameter 2 differs from the previous type "long".
"/usr/include/unistd.h", line 977.33: 1506-343 (S) Redeclaration of truncate64 differs from previous declaration on line 975 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 977.33: 1506-377 (I) The type "long long" of parameter 2 differs from the previous type "long".
"/usr/include/unistd.h", line 996.33: 1506-343 (S) Redeclaration of pread64 differs from previous declaration on line 993 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 996.33: 1506-377 (I) The type "long long" of parameter 4 differs from the previous type "long".
"/usr/include/unistd.h", line 997.33: 1506-343 (S) Redeclaration of pwrite64 differs from previous declaration on line 994 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 997.33: 1506-377 (I) The type "long long" of parameter 4 differs from the previous type "long".
"/usr/include/unistd.h", line 1086.25: 1506-343 (S) Redeclaration of fclear64 differs from previous declaration on line 1083 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 1086.25: 1506-050 (I) Return type "long long" in redeclaration is not compatible with the previous return type "long".
"/usr/include/unistd.h", line 1086.25: 1506-377 (I) The type "long long" of parameter 2 differs from the previous type "long".
"/usr/include/unistd.h", line 1087.25: 1506-343 (S) Redeclaration of fsync_range64 differs from previous declaration on line 1084 of "/usr/include/unistd.h".
"/usr/include/unistd.h", line 1087.25: 1506-377 (I) The type "long long" of parameter 3 differs from the previous type "long".
make: 1254-004 The error code from the last command is 1.


Stop.

```


Similar issue was reported in past also - https://lists.mindrot.org/pipermail/openssh-unix-dev/2013-March/031069.html