### PR TITLE
Actually document the agent channel

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -344,6 +344,32 @@ signal to a session attached to a channel. OpenSSH supports one
 extension signal "INFO@openssh.com" that allows sending SIGINFO on
 BSD-derived systems.
 
+2.7. connection: Request agent forward "auth-agent-req@openssh.com"
+
+SSH Agent forwarding may be requested for a session by sending a
+SSH_MSG_CHANNEL_REQUEST message.
+
+      byte      SSH_MSG_CHANNEL_REQUEST
+      uint32    recipient channel
+      string    "auth-agent-req@openssh.com"
+      boolean   want reply
+
+2.8. connection: Agent channels "auth-agent@openssh.com"
+
+To actually communicate with an SSH Agent, send an SSH_MSG_CHANNEL_OPEN
+with "auth-agent@openssh.com".
+
+      byte      SSH_MSG_CHANNEL_OPEN
+      string    "auth-agent@openssh.com"
+      uint32    sender channel
+      uint32    initial window size
+      uint32    maximum packet size
+
+The recipient should respond with SSH_MSG_CHANNEL_OPEN_CONFIRMATION
+or SSH_MSG_CHANNEL_OPEN_FAILURE.
+
+The protocol used inside of this channel is documented in section 5.5.
+
 3. Authentication protocol changes
 
 3.1. Host-bound public key authentication


### PR DESCRIPTION
I can't actually find anyplace anywhere where the agent channel handshake is actually documented. So I'm adding it here.

(Because I had to go back to the RFCs, splunk two code bases, and guess in order to figure it out for https://github.com/paramiko/paramiko/issues/2182)

What's not really documented yet in this PR is that the client sends a `auth-agent-req@openssh.com` basically advertising that an agent is available, and the server opens an `auth-agent@openssh.com` channel to talk to it. But this isn't documented in the RFC about X11 forwarding either.

I also didn't write down any requirements, things like:

> Implementations MUST reject any agent channel open requests if they have not requested agent forwarding.

Since I don't actually know if OpenSSH considers this a requirement.