### PR TITLE
Add validation for first GSSAPI token

### DIFF
--- a/ssh-gss.h
+++ b/ssh-gss.h
@@ -81,6 +81,7 @@ typedef struct ssh_gssapi_mech_struct {
 	char *name;
 	gss_OID_desc oid;
 	int (*dochild) (ssh_gssapi_client *);
+	int (*firsttokenvalid) (gss_buffer_desc *);
 	int (*userok) (ssh_gssapi_client *, char *);
 	int (*localname) (ssh_gssapi_client *, char **);
 	void (*storecreds) (ssh_gssapi_client *);
@@ -95,6 +96,7 @@ typedef struct {
 	gss_cred_id_t	creds; /* server */
 	gss_name_t	client; /* server */
 	gss_cred_id_t	client_creds; /* server */
+	int		first_token_validated; /* server */
 } Gssctxt;
 
 extern ssh_gssapi_mech *supported_mechs[];


### PR DESCRIPTION
From the commit description:

> After the client and server have negotiated a supported GSSAPI mechanism to
> use, there is no check to ensure that the client sends a GSSAPI token that
> matches that mechanism. For example, if the client and server agree to use the
> Kerberos mechanism, the client can then send SPNEGO tokens.
>
> The `userok` callback in `ssh_gssapi_mech_struct` ensures that authentication
> happened with the originally negotiated mechanism, so this cannot be used to
> bypass authentication. However, this increases the attack surface of the server
> because a vulnerability in, say, the SPNEGO mechanism implementation can then be
> triggered even though OpenSSH does not support SPNEGO. GSSAPI tokens are
> processed in the privileged process.
>
> This patch adds an optional `firsttokenvalid` callback to
> `ssh_gssapi_mech_struct` that allows the server to validate GSSAPI tokens
> before passing them to `gss_accept_sec_context`.
>
> Kerberos tokens have a well specified encoding (RFC 1508, Appendix B) so it is
> possible to validate the header of the token to ensure that it is well-formed.
> In practice, it is /slightly/ harder, though, because the underlying Kerberos
> library may tokens specifying non-standard mechanism OIDs. For example, the
> krb5 library supports an older OID from before Kerberos was fully standardized.
> This patch supports those non-standard OIDs to ensure maximum compatibility
> with clients.
>
> The callback only validates the first packet in the
> SSH2_MSG_USERAUTH_GSSAPI_TOKEN exchange. The assumption is that after the
> underlying GSSAPI library processes the first packet, the library does not allow
> clients to switch to another GSSAPI mechanism without triggering an error. In
> addition, the heimdal GSSAPI implementation allows a single GSSAPI token to be
> split into multiple packets, so the format of any following packets is
> undefined:
> https://github.com/heimdal/heimdal/blob/bcbe816962f0f19112f5398cc0a770a7cfacf325/lib/gssapi/mech/gss_accept_sec_context.c#L31-L58
>
> The exact increase in attack-surface depends on the underlying GSSAPI library
> that is used.
>
> With the krb5 library, the `GSSAPIStrictAcceptorCheck=yes` option has the
> side-effect of preventing clients from sending arbitrary GSSAPI tokens because
> of the use of `gss_acquire_cred`. After this is called, krb5 will validate that
> GSSAPI token matches the originally agreed upon mechanism:
> https://github.com/krb5/krb5/blob/0ba75c3221df18db9e7ff27e7e0e495688878364/src/lib/gssapi/mechglue/g_accept_sec_context.c#L241-L252
>
> If the `GSSAPIStrictAcceptorCheck=no` option is set, then the call to
> `gss_acquire_cred` is skipped and the client can then send GSSAPI tokens for
> arbitrary mechanisms.
>
> The heimdal library does not have this same behavior when calling
> `gss_acquire_cred`, so arbitrary GSSAPI tokens can be sent regardless of the
> value of the `GSSAPIStrictAcceptorCheck` option.

As a concrete example of why this hardening is beneficial, here is an example of a client triggering [CVE-2023-25565](https://github.com/gssapi/gss-ntlmssp/security/advisories/GHSA-7q7f-wqcg-mvfg), an incorrect free in the `gss-ntlmssp` krb5 plugin. The vulnerability can be triggered pre-auth in the privileged process if the host:
* is using the `krb5` library (the default on Linux afaict)
* has the `gss-ntlmssp` plugin installed (not installed by default but does not need to be configured after installation)
* and has the `GSSAPIStrictAcceptorCheck=no` option set (not default)

A `gdb` session showing a client triggering the vulnerability in `gss-ntlmssp`:

```
$ sudo gdb /usr/sbin/sshd
...
(gdb) start -d -d -d -D -p 2222 -f /etc/ssh/sshd_config -o AuthenticationMethods=gssapi-with-mic
Function "main" not defined.
Make breakpoint pending on future shared library load? (y or [n]) n
Starting program: /usr/sbin/sshd -d -d -d -D -p 2222 -f /etc/ssh/sshd_config -o AuthenticationMethods=gssapi-with-mic
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
...
free(): invalid pointer

Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (no_tid=0, signo=6, threadid=140737340187008) at ./nptl/pthread_kill.c:44
44      ./nptl/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737340187008) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140737340187008) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140737340187008, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff76c5476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff76ab7f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff770c6f6 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff785eb8c "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#6  0x00007ffff7723d7c in malloc_printerr (str=str@entry=0x7ffff785c764 "free(): invalid pointer") at ./malloc/malloc.c:5664
#7  0x00007ffff7725ac4 in _int_free (av=<optimized out>, p=<optimized out>, have_lock=0) at ./malloc/malloc.c:4439
#8  0x00007ffff77284d3 in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3391
#9  0x00007ffff7197b0e in ?? () from /usr/lib/x86_64-linux-gnu/gssntlmssp/gssntlmssp.so
#10 0x00007ffff71916a6 in ?? () from /usr/lib/x86_64-linux-gnu/gssntlmssp/gssntlmssp.so
#11 0x00007ffff798fb58 in gss_accept_sec_context () from /lib/x86_64-linux-gnu/libgssapi_krb5.so.2
#12 0x000055555559290c in ?? ()
#13 0x000055555558caa3 in ?? ()
#14 0x00005555555875f5 in ?? ()
#15 0x0000555555566ebd in ?? ()
#16 0x000055555556639b in ?? ()
#17 0x00007ffff76acd90 in __libc_start_call_main (main=main@entry=0x555555562550, argc=argc@entry=12, argv=argv@entry=0x7fffffffe5a8)
    at ../sysdeps/nptl/libc_start_call_main.h:58
#18 0x00007ffff76ace40 in __libc_start_main_impl (main=0x555555562550, argc=12, argv=0x7fffffffe5a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>,
    stack_end=0x7fffffffe598) at ../csu/libc-start.c:392
#19 0x0000555555566845 in ?? ()
(gdb)
```

---

I have tested this patch on Linux with both the `krb5` and `heimdal` GSSAPI implementations.

One possible improvement I could see for this patch series is to add a new `GSSAPITokenValidator` option which would default to `yes`. This would allow admins to disable the validation if there are any compatibility issues with GSSAPI/Kerberos implementations.