### PR TITLE
ssh-sk-helper: observe SSH_SK_HELPER_TIMEOUT

### DIFF
--- a/regress/misc/sk-dummy/sk-dummy.c
+++ b/regress/misc/sk-dummy/sk-dummy.c
@@ -59,7 +59,7 @@
 
 /* #define SK_DEBUG 1 */
 
-#if SSH_SK_VERSION_MAJOR != 0x000a0000
+#if SSH_SK_VERSION_MAJOR != 0x000b0000
 # error SK API has changed, sk-dummy.c needs an update
 #endif
 
@@ -242,12 +242,14 @@ check_options(struct sk_option **options)
 int
 sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
     const char *application, uint8_t flags, const char *pin,
-    struct sk_option **options, struct sk_enroll_response **enroll_response)
+    struct sk_option **options, struct sk_enroll_response **enroll_response,
+    int timeout)
 {
 	struct sk_enroll_response *response = NULL;
 	int ret = SSH_SK_ERR_GENERAL;
 
 	(void)flags; /* XXX; unused */
+	(void)timeout; /* XXX; unused */
 
 	if (enroll_response == NULL) {
 		skdebug(__func__, "enroll_response == NULL");
@@ -491,12 +493,14 @@ int
 sk_sign(uint32_t alg, const uint8_t *data, size_t datalen,
     const char *application, const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, const char *pin, struct sk_option **options,
-    struct sk_sign_response **sign_response)
+    struct sk_sign_response **sign_response, int timeout)
 {
 	struct sk_sign_response *response = NULL;
 	int ret = SSH_SK_ERR_GENERAL;
 	SHA2_CTX ctx;
 	uint8_t message[32];
+
+	(void)timeout; /* XXX; unused */
 
 	if (sign_response == NULL) {
 		skdebug(__func__, "sign_response == NULL");
@@ -546,7 +550,7 @@ sk_sign(uint32_t alg, const uint8_t *data, size_t datalen,
 
 int
 sk_load_resident_keys(const char *pin, struct sk_option **options,
-    struct sk_resident_key ***rks, size_t *nrks)
+    struct sk_resident_key ***rks, size_t *nrks, int timeout)
 {
 	return SSH_SK_ERR_UNSUPPORTED;
 }

--- a/sk-api.h
+++ b/sk-api.h
@@ -79,7 +79,7 @@ struct sk_option {
 	uint8_t required;
 };
 
-#define SSH_SK_VERSION_MAJOR		0x000a0000 /* current API version */
+#define SSH_SK_VERSION_MAJOR		0x000b0000 /* current API version */
 #define SSH_SK_VERSION_MAJOR_MASK	0xffff0000
 
 /* Return the version of the middleware API */
@@ -88,16 +88,17 @@ uint32_t sk_api_version(void);
 /* Enroll a U2F key (private key generation) */
 int sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
     const char *application, uint8_t flags, const char *pin,
-    struct sk_option **options, struct sk_enroll_response **enroll_response);
+    struct sk_option **options, struct sk_enroll_response **enroll_response,
+    int timeout);
 
 /* Sign a challenge */
 int sk_sign(uint32_t alg, const uint8_t *data, size_t data_len,
     const char *application, const uint8_t *key_handle, size_t key_handle_len,
     uint8_t flags, const char *pin, struct sk_option **options,
-    struct sk_sign_response **sign_response);
+    struct sk_sign_response **sign_response, int timeout);
 
 /* Enumerate all resident keys */
 int sk_load_resident_keys(const char *pin, struct sk_option **options,
-    struct sk_resident_key ***rks, size_t *nrks);
+    struct sk_resident_key ***rks, size_t *nrks, int timeout);
 
 #endif /* _SK_API_H */

--- a/ssh-sk-helper.8
+++ b/ssh-sk-helper.8
@@ -14,7 +14,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd $Mdocdate: April 29 2022 $
+.Dd $Mdocdate: March 10 2023 $
 .Dt SSH-SK-HELPER 8
 .Os
 .Sh NAME
@@ -58,6 +58,14 @@ will automatically pass the
 flag to
 .Nm
 when they have themselves been placed in debug mode.
+.El
+.Sh ENVIRONMENT
+.Bl -tag -width "SSH_SK_HELPER_TIMEOUT"
+.It Ev SSH_SK_HELPER_TIMEOUT
+This variable can be used to specify a timeout value in seconds.
+By default,
+.Nm
+blocks indefinitely.
 .El
 .Sh SEE ALSO
 .Xr ssh 1 ,

--- a/ssh-sk-helper.c
+++ b/ssh-sk-helper.c
@@ -48,6 +48,7 @@
 
 #ifdef ENABLE_SK
 extern char *__progname;
+int ssh_sk_timeout = -1; /* in seconds; -1 blocks indefinitely */
 
 static struct sshbuf *reply_error(int r, char *fmt, ...)
     __attribute__((__format__ (printf, 2, 3)));
@@ -279,6 +280,7 @@ main(int argc, char **argv)
 	int in, out, ch, r, vflag = 0;
 	u_int rtype, ll = 0;
 	uint8_t version, log_stderr = 0;
+	const char *timeout = NULL, *errstr = NULL;
 
 	sanitise_stdfd();
 	log_init(__progname, log_level, log_facility, log_stderr);
@@ -331,6 +333,17 @@ main(int argc, char **argv)
 
 	if (!vflag && log_level_name((LogLevel)ll) != NULL)
 		log_init(__progname, (LogLevel)ll, log_facility, log_stderr);
+
+
+	if ((timeout = getenv("SSH_SK_HELPER_TIMEOUT")) != NULL) {
+		ssh_sk_timeout = strtonum(timeout, 1, INT_MAX, &errstr);
+		if (errstr != NULL) {
+			debug_f("invalid timeout '%s', assuming -1", timeout);
+			ssh_sk_timeout = -1;
+		} else {
+			debug_f("timing out after %d seconds", ssh_sk_timeout);
+		}
+	}
 
 	switch (rtype) {
 	case SSH_SK_HELPER_SIGN:


### PR DESCRIPTION
Interactions with FIDO authenticators may block due to user interaction (touch). Most FIDO2 authenticators (e.g. Yubikeys) observe a 30-second timeout, but that's not guaranteed by the FIDO2 spec. On U2F-only devices, there is no timeout and the operation may block indefinitely.

This commit allows a timeout to be passed to ssh-sk-helper through a SSH_SK_HELPER_TIMEOUT environment variable, passes the timeout to the security key provider (note the SSH_SK_VERSION_MAJOR bump), and calls fido_dev_set_timeout() in the built-in security key provider to observe the specified timeout.