### PR TITLE
Fix incomplete error check on getnameinfo()

### DIFF
--- a/addr.c
+++ b/addr.c
@@ -443,7 +443,7 @@ addr_ntop(const struct xaddr *n, char *p, size_t len)
 	if (p == NULL || len == 0)
 		return -1;
 	if (getnameinfo(_SA(&ss), slen, p, len, NULL, 0,
-	    NI_NUMERICHOST) == -1)
+	    NI_NUMERICHOST) != 0)
 		return -1;
 
 	return 0;


### PR DESCRIPTION
getnameinfo() can return a value < 0 on error, but only == -1 was checked. The other callsites of getnameinfo() perform the check correctly by checking != 0. Fix it by changing this check to also check != 0.

Found using a static analysis tool I'm developing.