### PR TITLE
ifdef ENABLE_PKCS11 on RSA_METH_xxx compat (V_8_9)

### DIFF
--- a/openbsd-compat/libressl-api-compat.c
+++ b/openbsd-compat/libressl-api-compat.c
@@ -524,6 +524,7 @@ DH_set_length(DH *dh, long length)
 }
 #endif /* HAVE_DH_SET_LENGTH */
 
+#ifdef ENABLE_PKCS11
 #ifndef HAVE_RSA_METH_FREE
 void
 RSA_meth_free(RSA_METHOD *meth)
@@ -603,6 +604,7 @@ RSA_meth_set_finish(RSA_METHOD *meth, int (*finish)(RSA *rsa))
 	return 1;
 }
 #endif /* HAVE_RSA_METH_SET_FINISH */
+#endif /* ENABLE_PKCS11 */
 
 #ifndef HAVE_EVP_PKEY_GET0_RSA
 RSA *


### PR DESCRIPTION
# Problem
The `RSA_METH_xxx` functions are only needed for PKCS11 support. When OpenSSH is compiled with the `-disable-pkcs11` flag against an alternative library, such as BoringSSL or AWS-LC, that don't provide these functions, the implementation fails to compile unless several CFLAGS (like `-DHAVE_RSA_METH_FREE=1`) are provided. 

Specifically, these implementations break b/c they expect the `RSA_METHOD` struct to contain function pointers for `rsa_priv_enc` and `rsa_priv_dec` for which there is no analog in these alternative libraries.

# Solution
This change puts a preprocessor guard around the implementation of the `RSA_METH_xxx` functions so they can only take effect when support for PKCS11 is enabled

See also [PR for the master branch](https://github.com/openssh/openssh-portable/pull/386)  and [PR for AWS-LC](https://github.com/aws/aws-lc/pull/894).