### PR TITLE
Only set PAM_RHOST if the remote host is not "UNKNOWN"

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -735,7 +735,7 @@ sshpam_init(struct ssh *ssh, Authctxt *authctxt)
 		sshpam_laddr = get_local_ipaddr(
 		    ssh_packet_get_connection_in(ssh));
 	}
-	if (sshpam_rhost != NULL) {
+	if (sshpam_rhost != NULL && strcmp(sshpam_rhost, "UNKNOWN") != 0) {
 		debug("PAM: setting PAM_RHOST to \"%s\"", sshpam_rhost);
 		sshpam_err = pam_set_item(sshpam_handle, PAM_RHOST,
 		    sshpam_rhost);


### PR DESCRIPTION
When using sshd's -i option with stdio that is not a AF_INET/AF_INET6
socket, auth_get_canonical_hostname() returns "UNKNOWN" which is then
set as the value of PAM_RHOST, causing pam to try to do a reverse DNS
query of "UNKNOWN", which times out multiple times, causing a
substantial slowdown when logging in.

To fix this, let's only set PAM_RHOST if the hostname is not "UNKNOWN".