### PR TITLE
ssh: suppress warning on identical names

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -277,7 +277,8 @@ resolve_host(const char *name, int port, int logerr, char *cname, size_t clen)
 		return NULL;
 	}
 	if (cname != NULL && res->ai_canonname != NULL) {
-		if (!valid_domain(res->ai_canonname, 0, &errstr)) {
+		if (strcmp(cname, res->ai_canonname) > 0 &&
+		    !valid_domain(res->ai_canonname, 0, &errstr)) {
 			error("ignoring bad CNAME \"%s\" for host \"%s\": %s",
 			    res->ai_canonname, name, errstr);
 		} else if (strlcpy(cname, res->ai_canonname, clen) >= clen) {


### PR DESCRIPTION
Running systemd-resolved on a linux host some synthetic records [0] are available, for example _gateway for all current default routing gateway addresses. Connecting to that name gives an error message:

> ignoring bad CNAME "_gateway" for host "_gateway": domain name "_gateway" starts with invalid character

Let's suppress the message if cononical name and cname are identical.

[0] https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#Synthetic%20Records