### PR TITLE
Create parent directory for forwarded socket

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1894,6 +1894,16 @@ unix_listener(const char *path, int backlog, int unlink_first)
 		if (unlink(path) != 0 && errno != ENOENT)
 			error("unlink(%s): %.100s", path, strerror(errno));
 	}
+
+	/* create parent directory if does not exist */
+	mode_t old_umask = umask(077); /* relax umask to create executable dir */
+	char *path_copy = xstrdup(path); /* dirname modifies the argument in place */
+	if (mkdir(dirname(path_copy), 0700) != 0 && errno != EEXIST)
+		error("cannot create socket parent dir %s: %s",
+				path, strerror(errno));
+	free(path_copy);
+	(void) umask(old_umask);
+
 	if (bind(sock, (struct sockaddr *)&sunaddr, sizeof(sunaddr)) == -1) {
 		saved_errno = errno;
 		error_f("cannot bind to path %s: %s", path, strerror(errno));


### PR DESCRIPTION
If the directory does not exist on the remote host. The current behaviour is to report a forwarding failure in such a case.

One use case where this is particularly valuable is forwarding of the GPG socket. GPG expects the socket in a transient directory (`$XDG_DATA_DIR` or `/run/user/1000/gnupg`) which is cleaned-up on log-out. `RemoteCommand` is executed after socket binding has happened and can't be used to ensure the directory exists. Without the support from SSH there's really no good solution for reliable forwarding, besides watching the state of the filesystem on remote host at regular intervals and recreating the directory if missing.

While I don't think many depend on this, it's technically a backward incompatible change. If this is a concern, I would be happy to introduce a new configuration parameter (e.g. `StreamLocalBindCreateDir`) that would allow to opt in into the behaviour. Also I'm happy to follow-up to extend the test suite to cover the changes.

A thread on openssh-unix-dev from 2016 discussing the idea: https://marc.info/?t=147569613200003