### PR TITLE
ssh-keygen: generate, screen - arg for stdout

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -2981,8 +2981,9 @@ do_moduli_gen(const char *out_file, char **opts, size_t nopts)
 			    "generation", opts[i]);
 		}
 	}
-
-	if ((out = fopen(out_file, "w")) == NULL) {
+	
+	out = (strcmp(out_file, "-") != 0) ? fopen(out_file, "w") : stdout;
+	if (out == NULL) {
 		fatal("Couldn't open modulus candidate file \"%s\": %s",
 		    out_file, strerror(errno));
 	}
@@ -3047,7 +3048,8 @@ do_moduli_screen(const char *out_file, char **opts, size_t nopts)
 		}
 	}
 
-	if ((out = fopen(out_file, "a")) == NULL) {
+	out = (strcmp(out_file, "-") != 0) ? fopen(out_file, "a") : stdout;
+	if (out == NULL) {
 		fatal("Couldn't open moduli file \"%s\": %s",
 		    out_file, strerror(errno));
 	}


### PR DESCRIPTION
Although [2007 patch](https://lists.mindrot.org/pipermail/openssh-unix-dev/2007-March/025141.html) didn't take, it's inconsistent and a surprise these are missing.

Allows: ssh-keygen -M generate -O bits=4096 - | parallel --pipe -N1 ssh-keygen -M screen -f - - >> /etc/moduli

