### PR TITLE
gss-serv.c: `MAXHOSTNAMELEN` -> `HOST_NAME_MAX`

### DIFF
--- a/gss-serv.c
+++ b/gss-serv.c
@@ -105,7 +105,7 @@ ssh_gssapi_acquire_cred(Gssctxt *ctx)
 		gss_create_empty_oid_set(&status, &oidset);
 		gss_add_oid_set_member(&status, ctx->oid, &oidset);
 
-		if (gethostname(lname, MAXHOSTNAMELEN)) {
+		if (gethostname(lname, HOST_NAME_MAX)) {
 			gss_release_oid_set(&status, &oidset);
 			return (-1);
 		}


### PR DESCRIPTION
`MAXHOSTNAMELEN` is not defined in POSIX, which breaks on musl: https://pubs.opengroup.org/onlinepubs/9699919799/functions/gethostname.html

Bug: https://bugs.gentoo.org/834044