### PR TITLE
Security Key: allow specifying a prompt command.

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -228,8 +228,8 @@ struct notifier_ctx;
 
 char	*read_passphrase(const char *, int);
 int	 ask_permission(const char *, ...) __attribute__((format(printf, 1, 2)));
-struct notifier_ctx *notify_start(int, const char *, ...)
-	__attribute__((format(printf, 2, 3)));
+struct notifier_ctx *notify_start(const char *, int, const char *, ...)
+	__attribute__((format(printf, 3, 4)));
 void	notify_complete(struct notifier_ctx *, const char *, ...)
 	__attribute__((format(printf, 2, 3)));
 

--- a/readconf.c
+++ b/readconf.c
@@ -173,8 +173,8 @@ typedef enum {
 	oStreamLocalBindMask, oStreamLocalBindUnlink, oRevokedHostKeys,
 	oFingerprintHash, oUpdateHostkeys, oHostbasedAcceptedAlgorithms,
 	oPubkeyAcceptedAlgorithms, oCASignatureAlgorithms, oProxyJump,
-	oSecurityKeyProvider, oKnownHostsCommand, oRequiredRSASize,
-	oEnableEscapeCommandline,
+	oSecurityKeyPromptCommand, oSecurityKeyProvider, oKnownHostsCommand,
+	oRequiredRSASize, oEnableEscapeCommandline,
 	oIgnore, oIgnoredUnknownOption, oDeprecated, oUnsupported
 } OpCodes;
 
@@ -318,6 +318,7 @@ static struct {
 	{ "pubkeyacceptedkeytypes", oPubkeyAcceptedAlgorithms }, /* obsolete */
 	{ "ignoreunknown", oIgnoreUnknown },
 	{ "proxyjump", oProxyJump },
+	{ "securitykeypromptcommand", oSecurityKeyPromptCommand },
 	{ "securitykeyprovider", oSecurityKeyProvider },
 	{ "knownhostscommand", oKnownHostsCommand },
 	{ "requiredrsasize", oRequiredRSASize },
@@ -1314,6 +1315,10 @@ parse_char_array:
 
 	case oPKCS11Provider:
 		charptr = &options->pkcs11_provider;
+		goto parse_string;
+
+	case oSecurityKeyPromptCommand:
+		charptr = &options->sk_prompt_command;
 		goto parse_string;
 
 	case oSecurityKeyProvider:
@@ -2390,6 +2395,7 @@ initialize_options(Options * options)
 	options->bind_address = NULL;
 	options->bind_interface = NULL;
 	options->pkcs11_provider = NULL;
+	options->sk_prompt_command = NULL;
 	options->sk_provider = NULL;
 	options->enable_ssh_keysign = - 1;
 	options->no_host_authentication_for_localhost = - 1;
@@ -2681,6 +2687,7 @@ fill_default_options(Options * options)
 	CLEAR_ON_NONE(options->control_path);
 	CLEAR_ON_NONE(options->revoked_host_keys);
 	CLEAR_ON_NONE(options->pkcs11_provider);
+	CLEAR_ON_NONE(options->sk_prompt_command);
 	CLEAR_ON_NONE(options->sk_provider);
 	CLEAR_ON_NONE(options->known_hosts_command);
 	if (options->jump_host != NULL &&
@@ -2754,6 +2761,7 @@ free_options(Options *o)
 	free(o->bind_address);
 	free(o->bind_interface);
 	free(o->pkcs11_provider);
+	free(o->sk_prompt_command);
 	free(o->sk_provider);
 	for (i = 0; i < o->num_identity_files; i++) {
 		free(o->identity_files[i]);
@@ -3352,6 +3360,7 @@ dump_client_config(Options *o, const char *host)
 #ifdef ENABLE_PKCS11
 	dump_cfg_string(oPKCS11Provider, o->pkcs11_provider);
 #endif
+	dump_cfg_string(oSecurityKeyPromptCommand, o->sk_prompt_command);
 	dump_cfg_string(oSecurityKeyProvider, o->sk_provider);
 	dump_cfg_string(oPreferredAuthentications, o->preferred_authentications);
 	dump_cfg_string(oPubkeyAcceptedAlgorithms, o->pubkey_accepted_algos);

--- a/readconf.h
+++ b/readconf.h
@@ -83,6 +83,7 @@ typedef struct {
 	char   *bind_address;	/* local socket address for connection to sshd */
 	char   *bind_interface;	/* local interface for bind address */
 	char   *pkcs11_provider; /* PKCS#11 provider */
+	char   *sk_prompt_command; /* Security Key prompt */
 	char   *sk_provider; /* Security key provider */
 	int	verify_host_key_dns;	/* Verify host key using DNS */
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -103,7 +103,8 @@ LTESTS= 	connect \
 		agent-restrict \
 		hostbased \
 		channel-timeout \
-		connection-timeout
+		connection-timeout \
+		sk-prompt
 
 INTEROP_TESTS=	putty-transfer putty-ciphers putty-kex conch-ciphers
 #INTEROP_TESTS+=ssh-com ssh-com-client ssh-com-keygen ssh-com-sftp

--- a/regress/sk-prompt-notifier.sh
+++ b/regress/sk-prompt-notifier.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "TOUCH IT! $*" >&2

--- a/regress/sk-prompt.sh
+++ b/regress/sk-prompt.sh
@@ -1,0 +1,22 @@
+tid="security key prompt"
+
+sk_keys=""
+for i in ${SSH_KEYTYPES}; do
+	case "$i" in
+		sk-*)	sk_keys="$sk_keys $i" ;;
+	esac
+done
+
+# For all security key types, make sure that SecurityKeyPromptCommand actually calls the command.
+for ut in $sk_keys; do
+	verbose "KEY: $ut"
+	cat $ut.pub > $OBJ/authorized_keys_$USER  # ensure it uses this key
+
+	stderr=$(${SSH} -F $OBJ/ssh_proxy -o SecurityKeyPromptCommand=./sk-prompt-notifier.sh -i $ut host true 2>&1 > /dev/null)
+	if [ $? -ne 0 ]; then
+		fail "ssh key $ut failed"
+	fi
+	if [[ $stderr != "TOUCH IT! Confirm user presence for key"* ]]; then
+		fail "ssh key $ut did not use SecurityKeyPromptCommand, stderr was $stderr"
+	fi
+done

--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -813,7 +813,7 @@ process_sign_request2(SocketEntry *e)
 			goto send;
 		}
 		if (id->key->sk_flags & SSH_SK_USER_PRESENCE_REQD) {
-			notifier = notify_start(0,
+			notifier = notify_start(NULL, 0,
 			    "Confirm user presence for key %s %s%s%s",
 			    sshkey_type(id->key), fp,
 			    sig_dest == NULL ? "" : "\n",

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -1867,7 +1867,7 @@ do_ca_sign(struct passwd *pw, const char *ca_key_path, int prefer_agent,
 		} else {
 			if (sshkey_is_sk(ca) &&
 			    (ca->sk_flags & SSH_SK_USER_PRESENCE_REQD)) {
-				notifier = notify_start(0,
+				notifier = notify_start(NULL, 0,
 				    "Confirm user presence for key %s %s",
 				    sshkey_type(ca), ca_fp);
 			}

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1673,6 +1673,8 @@ the tokens described in the
 section and environment variables as described in the
 .Sx ENVIRONMENT VARIABLES
 section.
+.It Cm SecurityKeyPromptCommand
+Specifies a command to use to prompt the user to confirm user presence.
 .It Cm SecurityKeyProvider
 Specifies a path to a library that will be used when loading any
 FIDO authenticator-hosted keys, overriding the default of using

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1255,7 +1255,8 @@ identity_sign(struct identity *id, u_char **sigp, size_t *lenp,
 		if ((fp = sshkey_fingerprint(sign_key,
 		    options.fingerprint_hash, SSH_FP_DEFAULT)) == NULL)
 			fatal_f("fingerprint failed");
-		notifier = notify_start(options.batch_mode,
+		notifier = notify_start(options.sk_prompt_command,
+		    options.batch_mode,
 		    "Confirm user presence for key %s %s",
 		    sshkey_type(sign_key), fp);
 		free(fp);


### PR DESCRIPTION
If if specified, this will be executed instead of printing the default prompt to confirm user presence.

_Note: I'm using this to implement a graphical notifier to prompt to confirm user presence, which IMO clutters up the terminal less and doesn't get lost when ssh is called as a subprocess that redirects stderr. It also has the pleasant side effect of getting rid of the "User presence confirmed" message._

_I'm not entirely sure that this is the right way to do regression testing for this (it does pass `make LTESTS=sk-prompt t-exec`) nor am I entirely certain what the original intent of notify_start's interaction with SSH_ASKPASS was, since it seems very hard to trigger, and perhaps should be refactored. Please advise if you'd like this done differently._