### PR TITLE
New flag: whether to use PAM for Password Authentication

### DIFF
--- a/auth-passwd.c
+++ b/auth-passwd.c
@@ -112,7 +112,7 @@ auth_password(struct ssh *ssh, const char *password)
 	}
 #endif
 #ifdef USE_PAM
-	if (options.use_pam)
+	if (options.use_pam && options.passwd_use_pam)
 		return (sshpam_auth_passwd(authctxt, password) && ok);
 #endif
 #if defined(USE_SHADOW) && defined(HAS_SHADOW_EXPIRE)

--- a/servconf.c
+++ b/servconf.c
@@ -91,6 +91,7 @@ initialize_server_options(ServerOptions *options)
 
 	/* Portable-specific options */
 	options->use_pam = -1;
+	options->passwd_use_pam = -1;
 
 	/* Standard Options */
 	options->num_ports = 0;
@@ -279,8 +280,10 @@ fill_default_server_options(ServerOptions *options)
 	u_int i;
 
 	/* Portable-specific options */
-	if (options->use_pam == -1)
+	if (options->use_pam == -1){
 		options->use_pam = 0;
+		options->passwd_use_pam = 1;
+	}
 
 	/* Standard Options */
 	if (options->num_host_key_files == 0) {
@@ -500,6 +503,7 @@ typedef enum {
 	sBadOption,		/* == unknown option */
 	/* Portable-specific options */
 	sUsePAM,
+	sPasswdUsePAM,
 	/* Standard Options */
 	sPort, sHostKeyFile, sLoginGraceTime,
 	sPermitRootLogin, sLogFacility, sLogLevel, sLogVerbose,
@@ -550,8 +554,10 @@ static struct {
 	/* Portable-specific options */
 #ifdef USE_PAM
 	{ "usepam", sUsePAM, SSHCFG_GLOBAL },
+	{ "passwdusepam", sPasswdUsePAM, SSHCFG_GLOBAL },
 #else
 	{ "usepam", sUnsupported, SSHCFG_GLOBAL },
+	{ "passwdusepam", sUnsupported, SSHCFG_GLOBAL },
 #endif
 	{ "pamauthenticationviakbdint", sDeprecated, SSHCFG_GLOBAL },
 	/* Standard Options */
@@ -1399,6 +1405,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 	/* Portable-specific options */
 	case sUsePAM:
 		intptr = &options->use_pam;
+		goto parse_flag;
+
+	case sPasswdUsePAM:
+		intptr = &options->passwd_use_pam;
 		goto parse_flag;
 
 	/* Standard Options */

--- a/servconf.h
+++ b/servconf.h
@@ -200,6 +200,7 @@ typedef struct {
 	char   *adm_forced_command;
 
 	int	use_pam;		/* Enable auth via PAM */
+	int	passwd_use_pam;
 
 	int	permit_tun;
 

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1363,6 +1363,15 @@ The default is
 Specifies whether password authentication is allowed.
 The default is
 .Cm yes .
+.It Cm PasswdUsePAM
+When
+.Cm UsePAM
+is
+.Cm yes ,
+it specifies, whether to use Pluggable Authentication Module (PAM) for password
+authentication.
+The default is
+.Cm yes .
 .It Cm PermitEmptyPasswords
 When password authentication is allowed, it specifies whether the
 server allows login to accounts with empty password strings.


### PR DESCRIPTION
This patch adds a new flag in "sshd_config" named `PasswdUsePAM`. It controls whether to use PAM for password authentication, when the authentication method is "password" and PAM is enabled.

This would be useful if PAM for sshd is configured to use OTP (e.g., using pam-google-authenticator) and the "AuthenticationMethods" is set as:
```
AuthenticationMethods publickey,keyboard-interactive password,keyboard-interactive
```

Without setting "PasswdUsePAM" to no, the OpenSSH will use PAM and duplicate the password sent in for SSH password authentication to "libpam-google-authenticator", which fails the authentication. 