### PR TITLE
do_fingerprint: reset comment = NULL in each line

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -967,6 +967,7 @@ do_fingerprint(struct passwd *pw)
 
 	while (getline(&line, &linesize, f) != -1) {
 		lnum++;
+                comment = NULL;
 		cp = line;
 		cp[strcspn(cp, "\n")] = '\0';
 		/* Trim leading space and comments */


### PR DESCRIPTION
When running `ssh-keygen -l` on an input file that contains both
public keys with and without comment, then the indicator "no comment"
never appears again after the first comment. This is because in
`do_fingerprint()` the variable `comment` is initialized to NULL only
at the start of the function, but must actually be re-initialized for
each line read.

Demonstration of this bug:

```
$ cat bug
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBfpSaasTV3FbT+Ak92X5qL1UF3Nl0CPwWF/H3m/bBci
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ2rupphYfNkBJvdPCHcnBd/5Gq/VbQ+1VgvriXW1Oyp foo@bar
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE5zBpiRVC+ORSiXsyHdbi0adLR4eYVa1I8i2Kpu+cRZ
```

Expected behaviour:

```
$ ssh-keygen -l -f bug
256 SHA256:Rj/1gp8XmwdtWhcS46y8nC8d8fMYxhVuoqQ9y22goJk no comment (ED25519)
256 SHA256:tqCk14afznT2VHNkBPG3T8xtbPhd4Z/yNAcSWloX2Nw foo@bar (ED25519)
256 SHA256:cpUGYGuJjZ5tVYv02Mq+wFDtATo9O8vlPqoHsl3tako no comment (ED25519)
```

Actual behaviour:

```
$ ssh-keygen -l -f bug
256 SHA256:Rj/1gp8XmwdtWhcS46y8nC8d8fMYxhVuoqQ9y22goJk no comment (ED25519)
256 SHA256:tqCk14afznT2VHNkBPG3T8xtbPhd4Z/yNAcSWloX2Nw foo@bar (ED25519)
256 SHA256:cpUGYGuJjZ5tVYv02Mq+wFDtATo9O8vlPqoHsl3tako  (ED25519)
```

"no comment" is missing in the last line of output.
