### PR TITLE
*ssh.1: mention the "proxy" for ctl_cmd in man page

### DIFF
--- a/ssh.1
+++ b/ssh.1
@@ -484,6 +484,8 @@ argument is interpreted and passed to the master process.
 Valid commands are:
 .Dq check
 (check that the master process is running),
+.Dq proxy
+(mux client speaks the ssh-packet protocol directly over unix-domain socket),
 .Dq forward
 (request forwardings without command execution),
 .Dq cancel


### PR DESCRIPTION
Hi, 
The `ssh -O proxy ...` was intruduce in openssh 7.4, but the man page didn't mentioned that.
This patch try to add the "proxy" for ctl_cmd on the ssh man page.
Please help review it. 
Thanks.