### PR TITLE
Prefer mkdtemp over mktemp

### DIFF
--- a/regress/netcat.c
+++ b/regress/netcat.c
@@ -329,8 +329,8 @@ main(int argc, char *argv[])
 		} else {
 			strlcpy(unix_dg_tmp_socket_buf, "/tmp/nc.XXXXXXXXXX",
 				UNIX_DG_TMP_SOCKET_SIZE);
-			if (mktemp(unix_dg_tmp_socket_buf) == NULL)
-				err(1, "mktemp");
+			if (mkdtemp(unix_dg_tmp_socket_buf) == NULL)
+				err(1, "mkdtemp");
 			unix_dg_tmp_socket = unix_dg_tmp_socket_buf;
 		}
 	}


### PR DESCRIPTION
mktemp is deprecated and potentially dangerous.