### PR TITLE
Add support for IDN 2008 encoded names

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -670,7 +670,7 @@ remote_hostname(struct ssh *ssh)
 	debug3("Trying to reverse map address %.100s.", ntop);
 	/* Map the IP address to a host name. */
 	if (getnameinfo((struct sockaddr *)&from, fromlen, name, sizeof(name),
-	    NULL, 0, NI_NAMEREQD) != 0) {
+	    NULL, 0, NI_NAMEREQD|NI_IDN) != 0) {
 		/* Host name not found.  Use ip address. */
 		return xstrdup(ntop);
 	}

--- a/configure.ac
+++ b/configure.ac
@@ -2581,6 +2581,10 @@ if test "x$ac_cv_func_getaddrinfo" = "xyes"; then
 	    [#include <sys/types.h>
 	     #include <sys/socket.h>
 	     #include <netdb.h>])
+	AC_CHECK_DECLS([NI_IDN], [], [],
+	    [#include <sys/types.h>
+	     #include <sys/socket.h>
+	     #include <netdb.h>])
 fi
 
 if test "x$check_for_conflicting_getspnam" = "x1"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2569,7 +2569,15 @@ if test "x$ac_cv_func_getaddrinfo" = "xyes" && \
 fi
 
 if test "x$ac_cv_func_getaddrinfo" = "xyes"; then
-	AC_CHECK_DECLS(AI_NUMERICSERV, , ,
+	AC_CHECK_DECLS([AI_NUMERICSERV], [], [],
+	    [#include <sys/types.h>
+	     #include <sys/socket.h>
+	     #include <netdb.h>])
+	AC_CHECK_DECLS([AI_IDN], [], [],
+	    [#include <sys/types.h>
+	     #include <sys/socket.h>
+	     #include <netdb.h>])
+	AC_CHECK_DECLS([AI_CANONIDN], [], [],
 	    [#include <sys/types.h>
 	     #include <sys/socket.h>
 	     #include <netdb.h>])

--- a/defines.h
+++ b/defines.h
@@ -681,6 +681,12 @@ struct winsize {
 # if defined(HAVE_DECL_AI_NUMERICSERV) && HAVE_DECL_AI_NUMERICSERV == 0
 #   define AI_NUMERICSERV	0
 # endif
+# if defined(HAVE_DECL_AI_IDN) && HAVE_DECL_AI_IDN == 0
+#   define AI_IDN	0
+# endif
+# if defined(HAVE_DECL_AI_CANONIDN) && HAVE_DECL_AI_CANONIDN == 0
+#   define AI_CANONIDN	0
+# endif
 #endif
 
 #if defined(BROKEN_UPDWTMPX) && defined(HAVE_UPDWTMPX)

--- a/defines.h
+++ b/defines.h
@@ -687,6 +687,9 @@ struct winsize {
 # if defined(HAVE_DECL_AI_CANONIDN) && HAVE_DECL_AI_CANONIDN == 0
 #   define AI_CANONIDN	0
 # endif
+# if defined(HAVE_DECL_NI_IDN) && HAVE_DECL_NI_IDN == 0
+#   define NI_IDN	0
+# endif
 #endif
 
 #if defined(BROKEN_UPDWTMPX) && defined(HAVE_UPDWTMPX)

--- a/ssh.c
+++ b/ssh.c
@@ -268,8 +268,10 @@ resolve_host(const char *name, int port, int logerr, char *cname, size_t clen)
 	hints.ai_family = options.address_family == -1 ?
 	    AF_UNSPEC : options.address_family;
 	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_IDN;
 	if (cname != NULL)
-		hints.ai_flags = AI_CANONNAME;
+		/* TODO: valid_domain should allow libidn2 checked hostnames. */
+		hints.ai_flags |= AI_CANONNAME/* |AI_CANONIDN */;
 	if ((gaierr = getaddrinfo(name, strport, &hints, &res)) != 0) {
 		if (logerr || (gaierr != EAI_NONAME && gaierr != EAI_NODATA))
 			loglevel = SYSLOG_LEVEL_ERROR;
@@ -345,7 +347,7 @@ resolve_addr(const char *name, int port, char *caddr, size_t clen)
 	hints.ai_family = options.address_family == -1 ?
 	    AF_UNSPEC : options.address_family;
 	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags = AI_NUMERICHOST|AI_NUMERICSERV;
+	hints.ai_flags = AI_NUMERICHOST|AI_NUMERICSERV|AI_IDN;
 	if ((gaierr = getaddrinfo(name, strport, &hints, &res)) != 0) {
 		debug2_f("could not resolve name %.100s as address: %s",
 		    name, ssh_gai_strerror(gaierr));


### PR DESCRIPTION
There are possible valid hostnames recognized by common software, such as browsers or ping utility. They can accept names encoded in national characters. It should allow using ssh on extended latin names such as münchen.de or háčkyčárky.cz. It should allow also other alphabets, like domains reserved at https://www.iana.org/domains/reserved.