### PR TITLE
remove unnecessary if statement

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1868,12 +1868,10 @@ userauth_pubkey(struct ssh *ssh)
 		 * private key instead
 		 */
 		if (id->key != NULL) {
-			if (id->key != NULL) {
-				ident = format_identity(id);
-				debug("Offering public key: %s", ident);
-				free(ident);
-				sent = send_pubkey_test(ssh, id);
-			}
+			ident = format_identity(id);
+			debug("Offering public key: %s", ident);
+			free(ident);
+			sent = send_pubkey_test(ssh, id);
 		} else {
 			debug("Trying private key: %s", id->filename);
 			id->key = load_identity_file(id);


### PR DESCRIPTION
in file `sshconnect2.c`, function `userauth_pubkey`
checking twice if `id->key` is not NULL