### PR TITLE
regress/key-options.sh: update future key expiry date to far in the future

### DIFF
--- a/regress/key-options.sh
+++ b/regress/key-options.sh
@@ -120,5 +120,5 @@ check_valid_before() {
 check_valid_before "default"	""				"pass"
 check_valid_before "invalid"	'expiry-time="INVALID"'		"fail"
 check_valid_before "expired"	'expiry-time="19990101"'	"fail"
-check_valid_before "valid"	'expiry-time="20380101"'	"pass"
+check_valid_before "valid"	'expiry-time="25250101"'	"pass"
 


### PR DESCRIPTION
This allows testing Y2038 with system time set to after that (i.e.2040), so that actual Y2038 issues can be exposed, and not masked by key expiry time errors.