### PR TITLE
protocol: Fix type also for last privatekeyN

### DIFF
--- a/PROTOCOL.key
+++ b/PROTOCOL.key
@@ -40,7 +40,7 @@ of the cipher block size.
 	byte[]	privatekey2
 	string	comment2
 	...
-	string	privatekeyN
+	byte[]	privatekeyN
 	string	commentN
 	byte	1
 	byte	2


### PR DESCRIPTION
The key specification was wrongly marking all keys as strings until 24fee8973abdf1c521cd2c0047d89e86d9c3fc38, which fixed this for key1 and key2, but not for the keyN.

This is mostly cosmetic fix as the OpenSSH supports only one key in a file, but it can take some time to wrap a head around this to verify which one is correct.