### PR TITLE
Add configuration option for the LDNS DNSSEC Anchor file.

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -194,7 +194,7 @@ is_numeric_hostname(const char *hostname)
  */
 int
 verify_host_key_dns(const char *hostname, struct sockaddr *address,
-    struct sshkey *hostkey, int *flags)
+    struct sshkey *hostkey, int *flags, const char *ldns_anchor_file)
 {
 	u_int counter;
 	int result;
@@ -221,7 +221,7 @@ verify_host_key_dns(const char *hostname, struct sockaddr *address,
 	}
 
 	result = getrrsetbyname(hostname, DNS_RDATACLASS_IN,
-	    DNS_RDATATYPE_SSHFP, 0, &fingerprints);
+	    DNS_RDATATYPE_SSHFP, 0, &fingerprints, ldns_anchor_file);
 	if (result) {
 		verbose("DNS lookup error: %s", dns_result_totext(result));
 		return -1;

--- a/dns.h
+++ b/dns.h
@@ -53,7 +53,7 @@ enum sshfp_hashes {
 #define DNS_VERIFY_FAILED	0x00000008
 
 int	verify_host_key_dns(const char *, struct sockaddr *,
-    struct sshkey *, int *);
+    struct sshkey *, int *, const char *);
 int	export_dns_rr(const char *, struct sshkey *, FILE *, int, int);
 
 #endif /* DNS_H */

--- a/openbsd-compat/getrrsetbyname.c
+++ b/openbsd-compat/getrrsetbyname.c
@@ -190,7 +190,7 @@ static int count_dns_rr(struct dns_rr *, u_int16_t, u_int16_t);
 int
 getrrsetbyname(const char *hostname, unsigned int rdclass,
     unsigned int rdtype, unsigned int flags,
-    struct rrsetinfo **res)
+    struct rrsetinfo **res, const char *ldns_anchor_file)
 {
 	struct __res_state *_resp = _THREAD_PRIVATE(_res, _res, &_res);
 	int result;

--- a/openbsd-compat/getrrsetbyname.h
+++ b/openbsd-compat/getrrsetbyname.h
@@ -102,7 +102,7 @@ struct rrsetinfo {
 	struct rdatainfo	*rri_sigs;	/* individual signatures */
 };
 
-int		getrrsetbyname(const char *, unsigned int, unsigned int, unsigned int, struct rrsetinfo **);
+int		getrrsetbyname(const char *, unsigned int, unsigned int, unsigned int, struct rrsetinfo **, const char *);
 void		freerrset(struct rrsetinfo *);
 
 #endif /* !defined(HAVE_GETRRSETBYNAME) */

--- a/readconf.c
+++ b/readconf.c
@@ -149,6 +149,7 @@ typedef enum {
 	oGatewayPorts, oExitOnForwardFailure,
 	oPasswordAuthentication,
 	oXAuthLocation,
+	oLDNSAnchorFile,
 	oIdentityFile, oHostname, oPort, oRemoteForward, oLocalForward,
 	oPermitRemoteOpen,
 	oCertificateFile, oAddKeysToAgent, oIdentityAgent,
@@ -229,6 +230,7 @@ static struct {
 	{ "forwardx11timeout", oForwardX11Timeout },
 	{ "exitonforwardfailure", oExitOnForwardFailure },
 	{ "xauthlocation", oXAuthLocation },
+	{ "ldnsanchorfile", oLDNSAnchorFile },
 	{ "gatewayports", oGatewayPorts },
 	{ "passwordauthentication", oPasswordAuthentication },
 	{ "kbdinteractiveauthentication", oKbdInteractiveAuthentication },
@@ -1316,6 +1318,10 @@ parse_time:
 			    flags & SSHCONF_USERCONF);
 		}
 		break;
+
+	case oLDNSAnchorFile:
+		charptr=&options->ldns_anchor_file;
+		goto parse_string;
 
 	case oXAuthLocation:
 		charptr=&options->xauth_location;
@@ -2427,6 +2433,7 @@ initialize_options(Options * options)
 	options->clear_forwardings = -1;
 	options->exit_on_forward_failure = -1;
 	options->xauth_location = NULL;
+	options->ldns_anchor_file = NULL;
 	options->fwd_opts.gateway_ports = -1;
 	options->fwd_opts.streamlocal_bind_mask = (mode_t)-1;
 	options->fwd_opts.streamlocal_bind_unlink = -1;
@@ -2829,6 +2836,7 @@ free_options(Options *o)
 
 	free(o->forward_agent_sock_path);
 	free(o->xauth_location);
+	free(o->ldns_anchor_file);
 	FREE_ARRAY(u_int, o->num_log_verbose, o->log_verbose);
 	free(o->log_verbose);
 	free(o->ciphers);
@@ -3449,6 +3457,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_string(oPubkeyAcceptedAlgorithms, o->pubkey_accepted_algos);
 	dump_cfg_string(oRevokedHostKeys, o->revoked_host_keys);
 	dump_cfg_string(oXAuthLocation, o->xauth_location);
+	dump_cfg_string(oLDNSAnchorFile, o->ldns_anchor_file);
 	dump_cfg_string(oKnownHostsCommand, o->known_hosts_command);
 	dump_cfg_string(oTag, o->tag);
 

--- a/readconf.h
+++ b/readconf.h
@@ -36,6 +36,7 @@ typedef struct {
 	int     forward_x11_trusted;	/* Trust Forward X11 display. */
 	int     exit_on_forward_failure;	/* Exit if bind(2) fails for -L/-R */
 	char   *xauth_location;	/* Location for xauth program */
+	char   *ldns_anchor_file;	/* Location LDNS Anchor file */
 	struct ForwardOptions fwd_opts;	/* forwarding options */
 	int     pubkey_authentication;	/* Try ssh2 pubkey authentication. */
 	int     hostbased_authentication;	/* ssh2's rhosts_rsa */

--- a/ssh.1
+++ b/ssh.1
@@ -551,6 +551,7 @@ For full details of the options listed below, and their possible values, see
 .It KbdInteractiveDevices
 .It KexAlgorithms
 .It KnownHostsCommand
+.It LDNSAnchorFile
 .It LocalCommand
 .It LocalForward
 .It LogLevel

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1233,6 +1233,12 @@ is enabled, one more time to obtain the host key matching the server's
 address.
 If the command exits abnormally or returns a non-zero exit status then the
 connection is terminated.
+.It Cm LDNSAnchorFile
+Specifies the DNSSEC anchor file for use with the LDNS-Library. The file may be
+found in
+.Pa /etc/unbound/root.key .
+This file is used to validate DNSSEC. This is needed if ssh is compiled with ldns for DNSSEC support and the anchor option is not set in
+.Pa /etc/resolv.conf .
 .It Cm LocalCommand
 Specifies a command to execute on the local machine after successfully
 connecting to the server.

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1506,7 +1506,7 @@ verify_host_key(char *host, struct sockaddr *hostaddr, struct sshkey *host_key,
 			goto out;
 		if (sshkey_is_cert(plain))
 			sshkey_drop_cert(plain);
-		if (verify_host_key_dns(host, hostaddr, plain, &flags) == 0) {
+		if (verify_host_key_dns(host, hostaddr, plain, &flags, options.ldns_anchor_file) == 0) {
 			if (flags & DNS_VERIFY_FOUND) {
 				if (options.verify_host_key_dns == 1 &&
 				    flags & DNS_VERIFY_MATCH &&


### PR DESCRIPTION
The DNSSEC Anchor required for **VerifyHostKeyDNS** can't always be easily set in /etc/resolv.conf. DHCP and other tasks may overwrite this file or the user may want to use the DNSSEC Anchor different from what is configured in /etc/resolv.conf. This patch allows to set the DNSSEC Anchor File with the option LDNSAnchorFile.

Example:
ssh -oLDNSAnchorFile=/etc/unbound/root.key -oVerifyHostKeyDNS=yes example.com