### PR TITLE
Share the TTY device with systemd-logind

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -60,6 +60,7 @@ SSHDLIBS=@SSHDLIBS@
 LIBEDIT=@LIBEDIT@
 LIBFIDO2=@LIBFIDO2@
 LIBWTMPDB=@LIBWTMPDB@
+LIBSYSTEMD=@LIBSYSTEMD@
 AR=@AR@
 AWK=@AWK@
 RANLIB=@RANLIB@
@@ -234,10 +235,10 @@ sshd$(EXEEXT): libssh.a	$(LIBCOMPAT) $(SSHDOBJS)
 	$(LD) -o $@ $(SSHDOBJS) $(LDFLAGS) -lssh -lopenbsd-compat $(SSHDLIBS) $(LIBS) $(CHANNELLIBS)
 
 sshd-session$(EXEEXT): libssh.a	$(LIBCOMPAT) $(SSHD_SESSION_OBJS)
-	$(LD) -o $@ $(SSHD_SESSION_OBJS) $(LDFLAGS) -lssh -lopenbsd-compat $(SSHDLIBS) $(LIBS) $(GSSLIBS) $(K5LIBS) $(CHANNELLIBS) $(LIBWTMPDB)
+	$(LD) -o $@ $(SSHD_SESSION_OBJS) $(LDFLAGS) -lssh -lopenbsd-compat $(SSHDLIBS) $(LIBS) $(GSSLIBS) $(K5LIBS) $(CHANNELLIBS) $(LIBWTMPDB) $(LIBSYSTEMD)
 
 sshd-auth$(EXEEXT): libssh.a $(LIBCOMPAT) $(SSHD_AUTH_OBJS)
-	$(LD) -o $@ $(SSHD_AUTH_OBJS) $(LDFLAGS) -lssh -lopenbsd-compat $(SSHDLIBS) $(LIBS) $(GSSLIBS) $(K5LIBS) $(CHANNELLIBS) $(LIBWTMPDB)
+	$(LD) -o $@ $(SSHD_AUTH_OBJS) $(LDFLAGS) -lssh -lopenbsd-compat $(SSHDLIBS) $(LIBS) $(GSSLIBS) $(K5LIBS) $(CHANNELLIBS) $(LIBWTMPDB) $(LIBSYSTEMD)
 
 scp$(EXEEXT): $(LIBCOMPAT) libssh.a $(SCP_OBJS)
 	$(LD) -o $@ $(SCP_OBJS) $(LDFLAGS) -lssh -lopenbsd-compat $(LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -1814,6 +1814,45 @@ AC_ARG_WITH([wtmpdb],
 	fi ]
 )
 
+# Check whether user wants logind/set tty support
+AC_ARG_WITH([logind],
+	[  --with-logind[[=PATH]]    Enable logind support for sshd],
+	[ if test "x$withval" != "xno" ; then
+		if test "x$withval" = "xyes" ; then
+			AC_PATH_TOOL([PKGCONFIG], [pkg-config], [no])
+			if test "x$PKGCONFIG" != "xno"; then
+				AC_MSG_CHECKING([if $PKGCONFIG knows about libsystemd])
+				if "$PKGCONFIG" libsystemd; then
+					AC_MSG_RESULT([yes])
+					use_pkgconfig_for_libsystemd=yes
+				else
+					AC_MSG_RESULT([no])
+				fi
+			fi
+		else
+			CPPFLAGS="$CPPFLAGS -I${withval}/include"
+			if test -n "${rpath_opt}"; then
+				LDFLAGS="-L${withval}/lib ${rpath_opt}${withval}/lib ${LDFLAGS}"
+			else
+				LDFLAGS="-L${withval}/lib ${LDFLAGS}"
+			fi
+		fi
+		if test "x$use_pkgconfig_for_libsystemd" = "xyes"; then
+			LIBSYSTEMD=`$PKGCONFIG --libs libsystemd`
+			CPPFLAGS="$CPPFLAGS `$PKGCONFIG --cflags libsystemd`"
+		else
+			LIBSYSTEMD="-lsystemd"
+		fi
+		OTHERLIBS=`echo $LIBSYSTEMD | sed 's/-lsystemd//'`
+		AC_CHECK_LIB([systemd], [sd_bus_open_system],
+			[ AC_DEFINE([USE_LOGIND], [1], [Use systemd-logind])
+			  AC_SUBST([LIBSYSTEMD])
+			],
+			[ AC_MSG_ERROR([libsystemd not found]) ],
+			[ $OTHERLIBS ]
+		)
+	fi ]
+)
 
 AUDIT_MODULE=none
 AC_ARG_WITH([audit],


### PR DESCRIPTION
When sshd creates a session via PAM, it does not know the TTY and sets a dummy one. As result, systemd-logind has to parse utmp and find the correct entry to get the TTY afterwards. Instead tell systemd-logind the TTY device after we know it.

utmp on 64bit bi-arch systems like x86-64 are, with glibc, not Y2038 ready and glibc maintainers want to drop it because of this and for many other reasons (https://www.thkukuk.de/blog/Y2038_glibc_utmp_64bit/). So going via utmp for the TTY will not work anymore in the near future.