### PR TITLE
openssh regress/Makefile: print logs if test fails

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -237,7 +237,7 @@ t-exec:	${LTESTS:=.sh}
 		done; \
 		if [ "x$${skip}" = "xno" ]; then \
 			echo "run test $${TEST}" ... 1>&2; \
-			(env SUDO="${SUDO}" TEST_ENV=${TEST_ENV} ${TEST_SHELL} ${.CURDIR}/test-exec.sh ${.OBJDIR} ${.CURDIR}/$${TEST}) || exit $$?; \
+			(env SUDO="${SUDO}" TEST_ENV=${TEST_ENV} ${TEST_SHELL} ${.CURDIR}/test-exec.sh ${.OBJDIR} ${.CURDIR}/$${TEST}) || (echo return value: $$?; echo capturing logs; cat *.log; exit 1); \
 		else \
 			echo skip test $${TEST} 1>&2; \
 		fi; \


### PR DESCRIPTION
Some tests are failing in yocto project CI runs uner qemu and reproduction has failed. Print the captured sshd and ssh client logs if test fails. This should help to fix the root causes.

Reference: https://bugzilla.yoctoproject.org/show_bug.cgi?id=15178