### PR TITLE
sshd.c: Prevent infinite loop in ppoll()

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -47,6 +47,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/resource.h>
 #ifdef HAVE_SYS_STAT_H
 # include <sys/stat.h>
 #endif
@@ -1116,6 +1117,8 @@ static void
 server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 {
 	struct pollfd *pfd = NULL;
+	struct rlimit nfiles_limit;
+	unsigned long int socksz;
 	int i, j, ret, npfd;
 	int ostartups = -1, startups = 0, listening = 0, lameduck = 0;
 	int startup_p[2] = { -1 , -1 }, *startup_pollfd;
@@ -1146,6 +1149,20 @@ server_accept_loop(int *sock_in, int *sock_out, int *newsock, int *config_s)
 	sigaddset(&nsigset, SIGQUIT);
 
 	/* sized for worst-case */
+	if (getrlimit(RLIMIT_NOFILE, &nfiles_limit) < 0)
+		fatal_f("getting open files limit: %s",	strerror(errno));
+
+	socksz = (unsigned long int)num_listen_socks + options.max_startups;
+	if (socksz > nfiles_limit.rlim_cur)
+		nfiles_limit.rlim_cur = socksz;
+
+	if (nfiles_limit.rlim_max < socksz)
+		fatal("MaxStartups full setting cannot be greater than "
+				"the hard open file ulimit");
+
+	if (setrlimit(RLIMIT_NOFILE, &nfiles_limit) < 0)
+		fatal_f("setting open files limit: %s", strerror(errno));
+
 	pfd = xcalloc(num_listen_socks + options.max_startups,
 	    sizeof(struct pollfd));
 


### PR DESCRIPTION
The `ppoll` call in `sshd.c` derives its `nfds` value from `options->max_startups`.

However, if this value is above the processes' `RLIMIT_NOFILE` soft limit, in Linux the `ppoll` call errors out with `-EINVAL`.

This is not caught correctly and produces an uncontrolled infinite loop that leaves ssh in a unprocessable state for new connections.

To avoid this, both check `RLIMIT_NOFILE` and set `rlim_cur` to ensure that `sshd` can correctly `ppoll`.

A fatal error is returned if the user tries to set a MaxStartups above the `rlim_max` setting.