### PR TITLE
The documented "users-groups-by-id@openssh.com" response lacked the r…

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -690,6 +690,7 @@ identifiers:
 The server will reply with a SSH_FXP_EXTENDED_REPLY:
 
 	byte		SSH_FXP_EXTENDED_REPLY
+	uint32		id
 	string		usernames
 	string		groupnames
 


### PR DESCRIPTION
…equired request ID.

Now the spec matches the implemented code.