### PR TITLE
Removed outdated note from PROTOCOL.mux

### DIFF
--- a/PROTOCOL.mux
+++ b/PROTOCOL.mux
@@ -188,8 +188,6 @@ For dynamically allocated listen port the server replies with
 
 7. Requesting closure of port forwards
 
-Note: currently unimplemented (server will always reply with MUX_S_FAILURE).
-
 A client may request the master to close a port forward:
 
 	uint32	MUX_C_CLOSE_FWD


### PR DESCRIPTION
Port forward close by control master is already implemented by [`mux_master_process_close_fwd` in `mux.c`](https://github.com/openssh/openssh-portable/blob/b6b49130a0089b297245ee39e769231d7c763014/mux.c#L848)