### PR TITLE
Expose SSH_AUTH_INFO_0 always to PAM auth modules.

### DIFF
--- a/auth-pam.c
+++ b/auth-pam.c
@@ -1375,6 +1375,8 @@ sshpam_auth_passwd(Authctxt *authctxt, const char *password)
 		fatal("PAM: %s: failed to set PAM_CONV: %s", __func__,
 		    pam_strerror(sshpam_handle, sshpam_err));
 
+	expose_authinfo(__func__);
+
 	sshpam_err = pam_authenticate(sshpam_handle, flags);
 	sshpam_password = NULL;
 	free(fake);


### PR DESCRIPTION
The commit e8f474554e3bda102a797a2fbab0594ccc66f097 exposed SSH_AUTH_INFO_0 to PAM auth modules when a keyboard-interactive authentication method is in use. This does the same when a password authentication method is in use.