### PR TITLE
Update sshpty.c

### DIFF
--- a/sshpty.c
+++ b/sshpty.c
@@ -117,7 +117,7 @@ pty_make_controlling_tty(int *ttyfd, const char *tty)
 	 * tty.
 	 */
 	fd = open(_PATH_TTY, O_RDWR | O_NOCTTY);
-	if (fd >= 0) {
+	if (fd < 0) {
 		error("Failed to disconnect from controlling tty.");
 		close(fd);
 	}


### PR DESCRIPTION
According to man pages `open` return -1 on error, which means a value bigger than or equal to zero is a valid file descriptor.