### PR TITLE
Update openssl-devel dependency

### DIFF
--- a/contrib/redhat/openssh.spec
+++ b/contrib/redhat/openssh.spec
@@ -31,10 +31,13 @@
 %global build6x 1
 %endif
 
-%if 0%{?fedora} >= 26
-%global compat_openssl 1
-%else
-%global compat_openssl 0
+%global without_openssl 0
+# build without openssl where 1.1.1 is not available
+%if 0%{?fedora} <= 28
+%global without_openssl 1
+%endif
+%if 0%{?rhel} <= 7
+%global without_openssl 1
 %endif
 
 # Do we want kerberos5 support (1=yes 0=no)
@@ -96,11 +99,8 @@ PreReq: initscripts >= 5.00
 Requires: initscripts >= 5.20
 %endif
 BuildRequires: perl
-%if %{compat_openssl}
-BuildRequires: compat-openssl10-devel
-%else
-BuildRequires: openssl-devel >= 1.0.1
-BuildRequires: openssl-devel < 1.1
+%if ! %{without_openssl}
+BuildRequires: openssl-devel >= 1.1.1
 %endif
 BuildRequires: /bin/login
 %if ! %{build6x}
@@ -214,6 +214,9 @@ CFLAGS="$RPM_OPT_FLAGS -Os"; export CFLAGS
 	--mandir=%{_mandir} \
 	--with-mantype=man \
 	--disable-strip \
+%if %{without_openssl}
+	--without-openssl \
+%endif
 %if %{scard}
 	--with-smartcard \
 %endif
@@ -421,6 +424,8 @@ fi
 %changelog
 * Mon Oct 16 2023 Fabio Pedretti <pedretti.fabio@gmail.com>
 - Remove reference of dropped sshd.pam.old file
+- Update openssl-devel dependency to require >= 1.1.1
+- Build with --without-openssl elsewhere
 
 * Thu Oct 28 2021 Damien Miller <djm@mindrot.org>
 - Remove remaining traces of --with-md5-passwords


### PR DESCRIPTION
since openssh 9.4, openssl >= 1.1.1 is required
build with --without-openssl elsewhere
according to https://repology.org/project/openssl/versions openssl 1.1.1 is available on fedora >= 29 and rhel >= 8 successfully build tested, installed and run on rhel 6