### PR TITLE
Optimize aesctr_inc to avoid undefined behavior

### DIFF
--- a/cipher-aesctr.c
+++ b/cipher-aesctr.c
@@ -32,17 +32,17 @@
 static inline void
 aesctr_inc(u8 *ctr, u32 len)
 {
-	ssize_t i;
+	u32 i;
 
 #ifndef CONSTANT_TIME_INCREMENT
-	for (i = len - 1; i >= 0; i--)
-		if (++ctr[i])	/* continue on overflow */
+	for (i = len; i;)
+		if (++ctr[--i])	/* continue on overflow */
 			return;
 #else
 	u8 x, add = 1;
 
-	for (i = len - 1; i >= 0; i--) {
-		ctr[i] += add;
+	for (i = len; i;) {
+		ctr[--i] += add;
 		/* constant time for: x = ctr[i] ? 1 : 0 */
 		x = ctr[i];
 		x = (x | (x >> 4)) & 0xf;
@@ -71,7 +71,7 @@ aesctr_encrypt_bytes(aesctr_ctx *x,const u8 *m,u8 *c,u32 bytes)
 	u32 n = 0;
 	u8 buf[AES_BLOCK_SIZE];
 
-	while ((bytes--) > 0) {
+	for (; bytes; bytes--) {
 		if (n == 0) {
 			rijndaelEncrypt(x->ek, x->rounds, x->ctr, buf);
 			aesctr_inc(x->ctr, AES_BLOCK_SIZE);


### PR DESCRIPTION
We can ensure that an underflow for "i" never happens by only subtracting after the check for "i" being 0.