### PR TITLE
Fix memory leak in ssh_kex2 function

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -260,6 +260,7 @@ ssh_kex2(struct ssh *ssh, char *host, struct sockaddr *hostaddr, u_short port,
 	    hkalgs ? hkalgs : options.hostkeyalgorithms);
 
 	free(hkalgs);
+	free(s);
 
 	/* start key exchange */
 	if ((r = kex_setup(ssh, myproposal)) != 0)


### PR DESCRIPTION
This pull request addresses a memory leak issue within the `ssh_kex2` function. The function calls `kex_names_cat` to concatenate key exchange algorithm names, which returns dynamically allocated memory. According to the design of `kex_names_cat`, the caller is responsible for freeing this memory. 

However, in the original implementation of `ssh_kex2`, the allocated memory by `kex_names_cat` (assigned to the pointer `s`) was not freed before the function returned. This oversight led to a memory leak, as the pointer to the allocated memory was lost upon function exit, with no way to reclaim or free it later.

The proposed change introduces a `free(s)` call just before the end of the `ssh_kex2` function, ensuring that the dynamically allocated memory is correctly deallocated. This change prevents the memory leak, ensuring that all allocated resources within `ssh_kex2` are properly managed and released.
