### PR TITLE
Fix ssh_config Match directive typo

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -144,7 +144,7 @@ The available criteria keywords are:
 .Cm localnetwork ,
 .Cm host ,
 .Cm originalhost ,
-.Cm Tag ,
+.Cm tagged ,
 .Cm user ,
 and
 .Cm localuser .


### PR DESCRIPTION
The ssh_config.5 manpage incorrectly states that there is a Match criteria keyword called `Tag`. According to a later paragraph and the source code, this directive is actually called `tagged`