### PR TITLE
Fix proxy multiplexing mode

### DIFF
--- a/clientloop.c
+++ b/clientloop.c
@@ -517,7 +517,7 @@ send_chaff(struct ssh *ssh)
 {
 	int r;
 
-	if ((ssh->kex->flags & KEX_HAS_PING) == 0)
+	if (ssh->kex == NULL || (ssh->kex->flags & KEX_HAS_PING) == 0)
 		return 0;
 	/* XXX probabilistically send chaff? */
 	/*


### PR DESCRIPTION
The changes introduced by 7603ba71264e7fa938325c37eca993e2fa61272f broke proxy multiplexing mode. This commit makes it work again.