### PR TITLE
Fix OpenSSL ED25519 support detection in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3184,7 +3184,7 @@ if test "x$openssl" = "xyes" ; then
 		]], [[
 		unsigned char buf[64];
 		memset(buf, 0, sizeof(buf));
-		exit(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519,
+		exit(EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL,
 		    buf, sizeof(buf)) == NULL);
 		]])],
 		[


### PR DESCRIPTION
The function EVP_PKEY_new_raw_private_key was used incorrectly for detecting OpenSSL ED25519 support (introduced in 76e91e7238cdc5662bc818e2a48d466283840d23).

Existing code missed the second ENGINE argument ([official signature in openssl](https://github.com/openssl/openssl/blob/52a75f4088f2b2c59721152d9ec6ecf4d17c7e43/include/openssl/evp.h#L1820)):
```c
EVP_PKEY *EVP_PKEY_new_raw_private_key(int type, ENGINE *e,
                                       const unsigned char *priv,
                                       size_t len);
```
Thus the recent support for ED25519 private keys in PEM PKCS8 format seems to be always disabled.


PS: the aforementioned 76e91e7238cdc5662bc818e2a48d466283840d23 may also be able to close the out-dated PR #253.