### PR TITLE
sshconnect2: Remove redundant NULL check

### DIFF
--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1711,7 +1711,7 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 			    "certificate", options.identity_files[i]);
 			continue;
 		}
-		if (key && sshkey_is_sk(key) && options.sk_provider == NULL) {
+		if (sshkey_is_sk(key) && options.sk_provider == NULL) {
 			debug_f("ignoring authenticator-hosted key "
 			    "certificate %s as no "
 			    "SecurityKeyProvider has been specified",


### PR DESCRIPTION
NULL-pointer check for key in sshconnect2.c:1714 is not necessary because it is performed in sshconnect2.c:1708 by calling of `sshkey_is_cert()` function.

Found by RASU JCS.