### PR TITLE
Print user@host when connecting with sftp

### DIFF
--- a/sftp.c
+++ b/sftp.c
@@ -2670,7 +2670,10 @@ main(int argc, char **argv)
 
 	if (!quiet) {
 		if (sftp_direct == NULL)
-			fprintf(stderr, "Connected to %s.\n", host);
+			if (user != NULL)
+				fprintf(stderr, "Connected to %s@%s.\n", user, host);
+			else
+				fprintf(stderr, "Connected to %s.\n", host);
 		else
 			fprintf(stderr, "Attached to %s.\n", sftp_direct);
 	}


### PR DESCRIPTION
Prior to d989217110932490ba8ce92127a9a6838878928b, using sftp user@host would print "Connected to user@host", because the 'host' variable would also contain the username.

Parsing switched in the above mentioned commit for good reasons, but some users prefer to see the username if it was specified on the command line and never noticed that it did not show up when they specified a path on connection.

Restore the behavior of showing the username if one was specified and make it consistent regardless of whether a path was passed on the command line or not.