### PR TITLE
sftp-server: Fix home-directory extension to match the specification

### DIFF
--- a/sftp-server.c
+++ b/sftp-server.c
@@ -1706,14 +1706,16 @@ process_extended_home_directory(u_int32_t id)
 		fatal_fr(r, "parse");
 
 	debug3("request %u: home-directory \"%s\"", id, username);
-	if ((user_pw = getpwnam(username)) == NULL) {
+	if (username[0] == '\0') {
+		user_pw = pw;
+	} else if ((user_pw = getpwnam(username)) == NULL) {
 		send_status(id, SSH2_FX_FAILURE);
 		goto out;
 	}
 
-	verbose("home-directory \"%s\"", pw->pw_dir);
+	verbose("home-directory \"%s\"", user_pw->pw_dir);
 	attrib_clear(&s.attrib);
-	s.name = s.long_name = pw->pw_dir;
+	s.name = s.long_name = user_pw->pw_dir;
 	send_names(id, 1, &s);
  out:
 	free(username);


### PR DESCRIPTION
The `home-directory` extension does not match the specification in PROTOCOL. Right now, it:
 * does not accept the empty string username
 * It returns always the current user home directory

The proposed change updates the extension to catch both of the corner cases.