### PR TITLE
Fix detection of setres*id on GNU/Hurd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1347,6 +1347,12 @@ EOD
 	AC_DEFINE([BROKEN_SETVBUF], [1],
 	    [LynxOS has broken setvbuf() implementation])
 	;;
+*-*-gnu*)
+       dnl Target SUSv3/POSIX.1-2001 plus BSD specifics.
+       dnl _DEFAULT_SOURCE is the new name for _BSD_SOURCE
+       dnl _GNU_SOURCE is needed for setres*id prototypes.
+       CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600 -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_GNU_SOURCE"
+       ;;
 esac
 
 AC_MSG_CHECKING([compiler and flags for sanity])


### PR DESCRIPTION
Like Linux, proper _SOURCE macros need to be set to get declarations of various standard functions, notably setres*id. Now that Debian is using -Werror=implicit-function-declaration this is really required. While at it, define other _SOURCE macros like on GNU/Linux, since GNU/Hurd uses the same glibc.