### PR TITLE
Allow ssh-askpass on Wayland by checking for $WAYLAND_DISPLAY

### DIFF
--- a/readpass.c
+++ b/readpass.c
@@ -127,8 +127,9 @@ read_passphrase(const char *prompt, int flags)
 	const char *askpass_hint = NULL;
 	const char *s;
 
-	if ((s = getenv("DISPLAY")) != NULL)
-		allow_askpass = *s != '\0';
+	if ((((s = getenv("DISPLAY")) != NULL) && (*s != '\0')) ||
+            (((s = getenv("WAYLAND_DISPLAY")) != NULL) && (*s != '\0')))
+		allow_askpass = 1;
 	if ((s = getenv(SSH_ASKPASS_REQUIRE_ENV)) != NULL) {
 		if (strcasecmp(s, "force") == 0) {
 			use_askpass = 1;
@@ -262,6 +263,7 @@ notify_start(int force_askpass, const char *fmt, ...)
 		goto out;
 	}
 	if (getenv("DISPLAY") == NULL &&
+            getenv("WAYLAND_DISPLAY") == NULL &&
 	    ((s = getenv(SSH_ASKPASS_REQUIRE_ENV)) == NULL ||
 	    strcmp(s, "force") != 0)) {
 		debug3_f("cannot notify: no display");


### PR DESCRIPTION
Currently, no part of ssh (including the agent!) will even consider running ssh-askpass unless $DISPLAY is set.  But some systems run a graphical environment (e.g. Wayland) where some versions of ssh-askpass (e.g. ssh-askpass-gnome) will still work just fine.

So expand this baseline check to to permit invoking ssh-askpass if the sentinel wayland environment variable is present as well.