### PR TITLE
sftp: Fix drawing of prompt in interactive mode w/o editline

### DIFF
--- a/sftp.c
+++ b/sftp.c
@@ -2301,8 +2301,10 @@ interactive_loop(struct sftp_conn *conn, char *file1, char *file2)
 			break;
 		}
 		if (el == NULL) {
-			if (interactive)
+			if (interactive) {
 				printf("sftp> ");
+				fflush(stdout);
+			}
 			if (fgets(cmd, sizeof(cmd), infile) == NULL) {
 				if (interactive)
 					printf("\n");


### PR DESCRIPTION
When sftp is compiled without editline support, the prompt is printed using `printf(3)`. However, since printf uses buffered I/O it may not be displayed directly (e.g. if the output is line-buffered). To workaround that, force flushing of stdout.

This is patch has [been applied in downstream Alpine Linux since 2014](https://git.alpinelinux.org/aports/commit/?id=3996dc08a5472b107a380cbdb79c6d49ff5779ba). In an effort to reduce the patchset of the Alpine Linux OpenSSH package, I would like to see this patch integrated upstream.