### PR TITLE
Include forgotten `<unistd.h>` header for systemd notification

### DIFF
--- a/openbsd-compat/port-linux.c
+++ b/openbsd-compat/port-linux.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "log.h"
 #include "xmalloc.h"


### PR DESCRIPTION
The [latest commit](https://github.com/openssh/openssh-portable/commit/08f579231cd38a1c657aaa6ddeb8ab57a1fd4f5c) adding support for direct systemd notification is currently missing the `<unistd.h>` header directive needed for `write(...)` and `close(...)`, causing a failing build when this feature is enabled such as in the `clang-12-Werror` workflow. This should fix that.