### PR TITLE
Use gss_userok() instead of krb5_kuserok().

### DIFF
--- a/gss-serv-krb5.c
+++ b/gss-serv-krb5.c
@@ -76,40 +76,6 @@ ssh_gssapi_krb5_init(void)
 	return 1;
 }
 
-/* Check if this user is OK to login. This only works with krb5 - other
- * GSSAPI mechanisms will need their own.
- * Returns true if the user is OK to log in, otherwise returns 0
- */
-
-static int
-ssh_gssapi_krb5_userok(ssh_gssapi_client *client, char *name)
-{
-	krb5_principal princ;
-	int retval;
-	const char *errmsg;
-
-	if (ssh_gssapi_krb5_init() == 0)
-		return 0;
-
-	if ((retval = krb5_parse_name(krb_context, client->exportedname.value,
-	    &princ))) {
-		errmsg = krb5_get_error_message(krb_context, retval);
-		logit("krb5_parse_name(): %.100s", errmsg);
-		krb5_free_error_message(krb_context, errmsg);
-		return 0;
-	}
-	if (krb5_kuserok(krb_context, princ, name)) {
-		retval = 1;
-		logit("Authorized to %s, krb5 principal %s (krb5_kuserok)",
-		    name, (char *)client->displayname.value);
-	} else
-		retval = 0;
-
-	krb5_free_principal(krb_context, princ);
-	return retval;
-}
-
-
 /* This writes out any forwarded credentials from the structure populated
  * during userauth. Called after we have setuid to the user */
 
@@ -201,7 +167,6 @@ ssh_gssapi_mech gssapi_kerberos_mech = {
 	"Kerberos",
 	{9, "\x2A\x86\x48\x86\xF7\x12\x01\x02\x02"},
 	NULL,
-	&ssh_gssapi_krb5_userok,
 	NULL,
 	&ssh_gssapi_krb5_storecreds
 };

--- a/gss-serv.c
+++ b/gss-serv.c
@@ -309,9 +309,11 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_gssapi_client *client)
 		return (ctx->major);
 	}
 
-	/* We can't copy this structure, so we just move the pointer to it */
+	/* We can't copy these structures, so we just move the pointer to it */
 	client->creds = ctx->client_creds;
 	ctx->client_creds = GSS_C_NO_CREDENTIAL;
+	client->client = ctx->client;
+	ctx->client = GSS_C_NO_NAME;
 	return (ctx->major);
 }
 
@@ -365,20 +367,20 @@ ssh_gssapi_userok(char *user)
 		debug("No suitable client data");
 		return 0;
 	}
-	if (gssapi_client.mech && gssapi_client.mech->userok)
-		if ((*gssapi_client.mech->userok)(&gssapi_client, user))
-			return 1;
-		else {
-			/* Destroy delegated credentials if userok fails */
-			gss_release_buffer(&lmin, &gssapi_client.displayname);
-			gss_release_buffer(&lmin, &gssapi_client.exportedname);
-			gss_release_cred(&lmin, &gssapi_client.creds);
-			explicit_bzero(&gssapi_client,
-			    sizeof(ssh_gssapi_client));
-			return 0;
-		}
-	else
-		debug("ssh_gssapi_userok: Unknown GSSAPI mechanism");
+
+	if (gss_userok(gssapi_client.client, user))
+	  return 1;
+	else {
+	  /* Destroy delegated credentials if userok fails */
+	  gss_release_buffer(&lmin, &gssapi_client.displayname);
+	  gss_release_buffer(&lmin, &gssapi_client.exportedname);
+	  gss_release_cred(&lmin, &gssapi_client.creds);
+	  gss_release_name(&lmin, &gssapi_client.client);
+	  explicit_bzero(&gssapi_client,
+			 sizeof(ssh_gssapi_client));
+	  return 0;
+	}
+
 	return (0);
 }
 

--- a/ssh-gss.h
+++ b/ssh-gss.h
@@ -71,6 +71,7 @@ typedef struct {
 typedef struct {
 	gss_buffer_desc displayname;
 	gss_buffer_desc exportedname;
+	gss_name_t client;
 	gss_cred_id_t creds;
 	struct ssh_gssapi_mech_struct *mech;
 	ssh_gssapi_ccache store;
@@ -81,7 +82,6 @@ typedef struct ssh_gssapi_mech_struct {
 	char *name;
 	gss_OID_desc oid;
 	int (*dochild) (ssh_gssapi_client *);
-	int (*userok) (ssh_gssapi_client *, char *);
 	int (*localname) (ssh_gssapi_client *, char **);
 	void (*storecreds) (ssh_gssapi_client *);
 } ssh_gssapi_mech;


### PR DESCRIPTION
Hi

I'm exploring if it is possible to drop the run-time linking of libkrb5 for OpenSSH and instead link to libgssglue -- https://gitlab.com/gsasl/libgssglue -- which is intended as a thin generic GSS-API wrapper that `dlopen()` MIT Kerberos V5 or Heimdal depending on sysadmin preferences, or does nothing if Kerberos is not installed on the system.  This would allow people to avoid the Kerberos dependency for OpenSSH, but still allow this functionality (via libgssglue) for those people who are interested in Kerberos.

For this to work, OpenSSH shouldn't use Kerberos-specific libraries, header files or APIs, but purely call standardized GSS-API functions.  Fortunately this seems to almost already be the case, with two exceptions that have been isolated into `gss-serv-krb5.c`:

- ssh_gssapi_krb5_userok:  This function uses `krb5_userok()`.  Solaris has always had gss_userok(), and I believe MIT Kerberos V5, Heimdal and Apple Kerberos (which effectively is Heimdal as far as I remember) has support for `gss_userok()` for 10+ years.

- ssh_gssapi_krb5_storecreds: This forwards Kerberos credentials to the receiving system.  I believe GSS-API supports this via RFC 5588 -- https://datatracker.ietf.org/doc/html/rfc5588 -- and the `gss_store_cred()` should offer this functionality.

This pull request only fixes the first of these, and is offered here to get discussion, testing and code review started.  It builds on my system, but little further testing.  What seems to be lacking to have confidence in patches like this is a regression test framework that performs a Kerberos V5 authenticated SSH login.  Ideally this should be part of the GitHub actions.  Setting it up a local KDC in userspace isn't that hard -- I've done it to self-test libgsasl's GSSAPI against Dovecot in https://gitlab.com/gsasl/gsasl/-/blob/master/tests/gsasl-dovecot-gssapi.sh -- however I'm not that familiar with GitHub actions or the OpenSSH regression framework to add this myself.  Is someone interested in collaborating on adding that?  I think one job should setup a KDC, acquire a server keytab for sshd and a user ticket and perform a krb5 ssh login.

While libgssglue has still some mileage to go (for example, it should support `gss_userok` :-)), I think that regardless of that approach's merits, OpenSSH should use standardized GSS-API interfaces instead of custom krb5_*() APIs.  So this patch does nothing related to libgssglue at all, but merely try to move OpenSSH up to modern GSS-API usage first.  It will then later be possible to offer a patch that would link to libgssglue instead of libkrb5.

Thoughts?
