### PR TITLE
Add `reserved` fields to the agent protocol specification

### DIFF
--- a/PROTOCOL.agent
+++ b/PROTOCOL.agent
@@ -49,10 +49,13 @@ Where a constraint consists of:
 
 	string		from_username (must be empty)
 	string		from_hostname
+	string		reserved
 	keyspec[]	from_hostkeys
 	string		to_username
 	string		to_hostname
+	string		reserved
 	keyspec[]	to_hostkeys
+	string		reserved
 
 And a keyspec consists of:
 


### PR DESCRIPTION
The ssh client appends empty `reserved` fields to the [destination constraint extension][0]. This was found when working on our Rust-based [library for writing SSH agents][1] which includes tests for messages captured using the OpenSSH client.

This patch adjusts the documentation of the agent protocol to include the reserved fields.

I have not found out the reasoning for this reserved value in commit 5e950d7657 and as such I didn't expand the documentation to include further context but I think it would be a good idea to add it.

Thanks for your time! :wave: 

[0]: https://github.com/openssh/openssh-portable/blob/88351eca17dcc55189991ba60e50819b6d4193c1/authfd.c#L469
[1]: https://github.com/wiktor-k/ssh-agent-lib/blob/2605fba8497075d35daedc1f78522f3e2c17bf8d/src/proto/extension.rs#L71