### PR TITLE
[loginrec.c] Fix "undeclared 'ut'" error by replacing it with 'utx'

### DIFF
--- a/loginrec.c
+++ b/loginrec.c
@@ -1033,7 +1033,7 @@ utmpx_perform_login(struct logininfo *li)
 		return (0);
 	}
 # else
-	if (!utmpx_write_direct(li, &ut)) {
+	if (!utmpx_write_direct(li, &utx)) {
 		logit("%s: utmp_write_direct() failed", __func__);
 		return (0);
 	}


### PR DESCRIPTION
In the `utmpx_perform_login` function there are no `ut` declarations, but there is `utx`. I believe this mistake was made during copy-paste from `utmp_perform_login` function where `ut` is used.