### PR TITLE
set SSH_KEY_ID if present

### DIFF
--- a/session.c
+++ b/session.c
@@ -1184,6 +1184,15 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
 		child_set_env(&env, &envsize, "SSH_ORIGINAL_COMMAND",
 		    original_command);
 
+	if(
+		s->authctxt->auth_method_key != NULL
+		&& s->authctxt->auth_method_key->cert != NULL
+		&& s->authctxt->auth_method_key->cert->key_id != NULL
+	) {
+		child_set_env(&env, &envsize, "SSH_KEY_ID",
+		    s->authctxt->auth_method_key->cert->key_id);
+	}
+
 	if (debug_flag) {
 		/* dump the environment */
 		fprintf(stderr, "Environment:\n");


### PR DESCRIPTION
When authenticating via `TrustedUserCAKeys` it is useful to know the key_id in order to be able to correlate the used key to the original identity for which the key was signed. This can be leveraged to federate authentication. The process is described [here](https://github.com/maxfortun/sshd-trusted-user).