### PR TITLE
send COLORTERM environment variable

### DIFF
--- a/session.c
+++ b/session.c
@@ -1063,6 +1063,8 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
 		child_set_env(&env, &envsize, "TZ", getenv("TZ"));
 	if (s->term)
 		child_set_env(&env, &envsize, "TERM", s->term);
+	if (s->colorterm)
+		child_set_env(&env, &envsize, "COLORTERM", s->colorterm);
 	if (s->display)
 		child_set_env(&env, &envsize, "DISPLAY", s->display);
 
@@ -2448,6 +2450,7 @@ session_close(struct ssh *ssh, Session *s)
 	if (s->ttyfd != -1)
 		session_pty_cleanup(s);
 	free(s->term);
+	free(s->colorterm);
 	free(s->display);
 	free(s->x11_chanids);
 	free(s->auth_display);

--- a/session.h
+++ b/session.h
@@ -38,7 +38,7 @@ struct Session {
 	int	forced;
 
 	/* tty */
-	char	*term;
+	char	*term, *colorterm;
 	int	ptyfd, ttyfd, ptymaster;
 	u_int	row, col, xpixel, ypixel;
 	char	tty[TTYSZ];

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1528,7 +1528,7 @@ Valid options are
 .Cm no
 or a pattern-list specifying which environment variable names to accept
 (for example
-.Qq LANG,LC_* ) .
+.Qq COLORTERM,LANG,LC_* ) .
 The default is
 .Cm no .
 Enabling environment processing may enable users to bypass access


### PR DESCRIPTION
most terminals that support truecolor set the `COLORTERM=truecolor` environment variable.

currently, openssh only sends `TERM` by default. I believe we could send COLORTERM, too, so things running on the target server may properly detect colors.

That said, it has been a long time since I last did any C, and I don't know the codebase, but this is a try... happy to work more on it with some guidance if you think this is a good thing to do.

Cheers!