### PR TITLE
require public key for signing only when necessary

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -2735,16 +2735,16 @@ sig_sign(const char *keypath, const char *sig_namespace, int require_agent,
 	if (sig_process_opts(opts, nopts, &hashalg, NULL, NULL) != 0)
 		goto done; /* error already logged */
 
-	if ((r = sshkey_load_public(keypath, &pubkey, NULL)) != 0) {
-		error_r(r, "Couldn't load public key %s", keypath);
-		goto done;
-	}
+	if ((r = sshkey_load_public(keypath, &pubkey, NULL)) != 0)
+		debug_r(r, "Couldn't load public key %s", keypath);
 
 	if ((r = ssh_get_authentication_socket(&agent_fd)) != 0) {
 		if (require_agent)
 			fatal("Couldn't get agent socket");
 		debug_r(r, "Couldn't get agent socket");
 	} else {
+		if (pubkey == NULL)
+			fatal("Couldn't load public key %s", keypath);
 		if ((r = ssh_agent_has_key(agent_fd, pubkey)) == 0)
 			signer = agent_signer;
 		else {


### PR DESCRIPTION
Signing a file with `ssh-keygen -Y sign -n <namespace> -f <key_file> <file>` does not actually require a public key when `<key_file>` is the path to a private key file, but `ssh-keygen` is currently failing when the public key file does not exist. To avoid being unnecessarily strict, I've moved the check for the existence of a public key file. Now, an attempt at loading the public key file is made in the same place as before, but its existence is only enforced when checking the SSH agent for the key. IIUC, this is the only place where the public key is _required_.

WDYT? :slightly_smiling_face: