### PR TITLE
ssh-agent: enable systemd-style socket activation

### DIFF
--- a/ssh-agent.1
+++ b/ssh-agent.1
@@ -247,6 +247,14 @@ starts, it creates a
 socket and stores its pathname in this variable.
 It is accessible only to the current user,
 but is easily abused by root or another instance of the same user.
+.It Ev SD_LISTEN_FDS
+When
+.Nm
+starts, if no socket path has been specified, but this variable and the
+accompanying SD_LISTEN_PID are set as described in
+.Xr sd_listen_fds 3 ,
+.Nm
+uses the socket passed in by the systemd supervisor.
 .El
 .Sh FILES
 .Bl -tag -width Ds

--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -2303,8 +2303,11 @@ main(int ac, char **av)
 
 		pidstr = getenv(SSH_AGENTPID_ENV_NAME);
 		if (pidstr == NULL) {
-			fprintf(stderr, "%s not set, cannot kill agent\n",
-			    SSH_AGENTPID_ENV_NAME);
+			execlp("systemctl", "systemctl", "--user", "stop", "ssh-agent.service", (char*)NULL);
+			fprintf(stderr, "%s not set, cannot kill agent directly.\n"
+					"'systemctl --user stop ssh-agent.service' did not run: %d (%s).\n",
+					SSH_AGENTPID_ENV_NAME,
+					errno, strerror(errno));
 			exit(1);
 		}
 		pid = (int)strtonum(pidstr, 2, INT_MAX, &errstr);


### PR DESCRIPTION
The systemd service manager on many Linux-based OSes provides a handy [socket activation](https://systemd.io/DAEMON_SOCKET_ACTIVATION/) mechanism: the service manager opens the relevant sockets, and then automatically spawns the correct daemon when someone connects to it.  The service manager also reaps relevant processes when the session lifecycle demands it.

`ssh-agent` needs a few small changes to enable socket activation on such a system.   This only involves a single user, as it is not a system service.  systemd's "user" session manager handles single-user services in the same way.

The changes in this series take the following two steps:

- recognize a socket passed in as a file descriptor a la `sd_listen_fds(3)` when launched.
- enable killing the agent via `systemd --user` in case `$SSH_AGENT_PID` is unset.

Neither step should have any effect on a non-systemd system, and the two steps together enable a user who is already running a systemd user session manager to have a socket-activated, session-manager-governed `ssh-agent` process.

I've been running ssh-agent from a systemd-supervised user session with these patches  for about 2½ months now and have had no problems with it.