### PR TITLE
fix utmpx ifdef

### DIFF
--- a/loginrec.c
+++ b/loginrec.c
@@ -723,7 +723,7 @@ set_utmpx_time(struct logininfo *li, struct utmpx *utx)
 void
 construct_utmpx(struct logininfo *li, struct utmpx *utx)
 {
-# ifdef HAVE_ADDR_V6_IN_UTMP
+# ifdef HAVE_ADDR_V6_IN_UTMPX
 	struct sockaddr_in6 *sa6;
 #  endif
 	memset(utx, '\0', sizeof(*utx));
@@ -769,7 +769,7 @@ construct_utmpx(struct logininfo *li, struct utmpx *utx)
 	if (li->hostaddr.sa.sa_family == AF_INET)
 		utx->ut_addr = li->hostaddr.sa_in.sin_addr.s_addr;
 # endif
-# ifdef HAVE_ADDR_V6_IN_UTMP
+# ifdef HAVE_ADDR_V6_IN_UTMPX
 	/* this is just a 128-bit IPv6 address */
 	if (li->hostaddr.sa.sa_family == AF_INET6) {
 		sa6 = ((struct sockaddr_in6 *)&li->hostaddr.sa);


### PR DESCRIPTION
02e16ad95fb1f56ab004b01a10aab89f7103c55d did a copy-paste for utmpx, but forgot to change the ifdef appropriately

This fix also has been done in the alpine repo: https://github.com/alpinelinux/aports/blob/master/main/openssh/fix-utmp.patch#L31