### PR TITLE
regress/test-exec: use the absolute path in the SSH env

### DIFF
--- a/regress/test-exec.sh
+++ b/regress/test-exec.sh
@@ -175,6 +175,11 @@ if [ "x$TEST_SSH_OPENSSL" != "x" ]; then
 fi
 
 # Path to sshd must be absolute for rexec
+case "$SSH" in
+/*) ;;
+*) SSH=`which $SSH` ;;
+esac
+
 case "$SSHD" in
 /*) ;;
 *) SSHD=`which $SSHD` ;;


### PR DESCRIPTION
The SSHAGENT_BIN was changed in [1] to SSH_BIN but the last one don't use the absolute path and consequently the function increase_datafile_size can loops forever if the binary not found.

[1] https://github.com/openssh/openssh-portable/commit/a68f80f2511f0e0c5cef737a8284cc2dfabad818