### PR TITLE
Ignore leading spaces in addr_match_list

### DIFF
--- a/addrmatch.c
+++ b/addrmatch.c
@@ -35,7 +35,8 @@
 
 /*
  * Match "addr" against list pattern list "_list", which may contain a
- * mix of CIDR addresses and old-school wildcards.
+ * mix of CIDR addresses and old-school wildcards. Leading spaces are
+ * ignored.
  *
  * If addr is NULL, then no matching is performed, but _list is parsed
  * and checked for well-formedness.
@@ -60,6 +61,8 @@ addr_match_list(const char *addr, const char *_list)
 	if ((o = list = strdup(_list)) == NULL)
 		return -1;
 	while ((cp = strsep(&list, ",")) != NULL) {
+		while (*cp == ' ')
+			cp++;
 		neg = *cp == '!';
 		if (neg)
 			cp++;

--- a/regress/unittests/match/tests.c
+++ b/regress/unittests/match/tests.c
@@ -98,6 +98,8 @@ tests(void)
 	ASSERT_INT_EQ(addr_match_list("127.0.0.1", "!127.0.0.1,10.0.0.1"), -1);
 	ASSERT_INT_EQ(addr_match_list("127.0.0.1", "10.0.0.1,127.0.0.2"), 0);
 	ASSERT_INT_EQ(addr_match_list("127.0.0.1", "127.0.0.2,10.0.0.1"), 0);
+	ASSERT_INT_EQ(addr_match_list("127.0.0.1", "127.0.0.2, 127.0.0.1"), 1);
+	ASSERT_INT_EQ(addr_match_list("127.0.0.1", "127.0.0.2,       127.0.0.1"), 1);
 	/* XXX negated ASSERT_INT_EQ(addr_match_list("127.0.0.1", "10.0.0.1,!127.0.0.2"), 1); */
 	/* XXX negated ASSERT_INT_EQ(addr_match_list("127.0.0.1", "!127.0.0.2,10.0.0.1"), 1); */
 	TEST_DONE();


### PR DESCRIPTION
Allows `from="1.2.3.4, 5.6.7.8"` in authorized_keys when previously the space would be treated as part of the list item.