### PR TITLE
[ssh-copy-id] Show identity file in 'ssh' command

### DIFF
--- a/contrib/ssh-copy-id
+++ b/contrib/ssh-copy-id
@@ -379,7 +379,7 @@ else
 
 	Number of key(s) added: $ADDED
 
-	Now try logging into the machine, with:   "${SFTP:-ssh}${SSH_PORT:+ -${PORT_OPT:-p} $SSH_PORT}${SEEN_OPT_I:+-i $PRIV_ID_FILE} ${OPTS_USER_HOST}"
+	Now try logging into the machine, with:   "${SFTP:-ssh}${SSH_PORT:+ -${PORT_OPT:-p} $SSH_PORT}${SEEN_OPT_I:+ -i $PRIV_ID_FILE} ${OPTS_USER_HOST}"
 	and check to make sure that only the key(s) you wanted were added.
 
 	EOF

--- a/contrib/ssh-copy-id
+++ b/contrib/ssh-copy-id
@@ -379,7 +379,7 @@ else
 
 	Number of key(s) added: $ADDED
 
-	Now try logging into the machine, with:   "${SFTP:-ssh}${SSH_PORT:+ -${PORT_OPT:-p} $SSH_PORT} ${OPTS_USER_HOST}"
+	Now try logging into the machine, with:   "${SFTP:-ssh}${SSH_PORT:+ -${PORT_OPT:-p} $SSH_PORT}${SEEN_OPT_I:+-i $PRIV_ID_FILE} ${OPTS_USER_HOST}"
 	and check to make sure that only the key(s) you wanted were added.
 
 	EOF


### PR DESCRIPTION
- Previously no identity file is shown in "ssh" command output on the line "Now try logging into the..."
- This commit makes sure whenever "ssh-copy-id" with "-i" is invoked, it also reflects in "ssh" command
- Example:

Before:
```
$ ./ssh-copy-id root@192.168.xxx.xx
[...]
Now try logging into the machine, with:   "ssh 'root@192.168.xxx.xx'"
and check to make sure that only the key(s) you wanted were added.

$ ./ssh-copy-id -i ~/.ssh/test_lab root@192.168.xxx.xx
[...]
Now try logging into the machine, with:   "ssh 'root@192.168.xxx.xx'"
and check to make sure that only the key(s) you wanted were added.
```

After:

```
$ ./ssh-copy-id root@192.168.xxx.xx
[...]
Now try logging into the machine, with:   "ssh  'root@192.168.xxx.xx'"
and check to make sure that only the key(s) you wanted were added.

$ ./ssh-copy-id -i ~/.ssh/test_lab root@192.168.xxx.xx
[...]
Now try logging into the machine, with:   "ssh  -i ~/.ssh/test_lab 'root@192.168.xxx.xx'" <=== Change is only in this case
and check to make sure that only the key(s) you wanted were added.
```