### PR TITLE
Fix the issue where without_openssl is always set to 1.

### DIFF
--- a/contrib/redhat/openssh.spec
+++ b/contrib/redhat/openssh.spec
@@ -31,13 +31,13 @@
 %global build6x 1
 %endif
 
-%global without_openssl 0
+%global without_openssl 1
 # build without openssl where 1.1.1 is not available
-%if 0%{?fedora} <= 28
-%global without_openssl 1
+%if 0%{?fedora} > 28
+%global without_openssl 0
 %endif
-%if 0%{?rhel} <= 7
-%global without_openssl 1
+%if 0%{?rhel} > 7
+%global without_openssl 0
 %endif
 
 # Do we want kerberos5 support (1=yes 0=no)

--- a/contrib/redhat/openssh.spec
+++ b/contrib/redhat/openssh.spec
@@ -31,13 +31,13 @@
 %global build6x 1
 %endif
 
-%global without_openssl 1
+%global without_openssl 0
 # build without openssl where 1.1.1 is not available
-%if 0%{?fedora} > 28
-%global without_openssl 0
+%if %{defined fedora} && 0%{?fedora} <= 28
+%global without_openssl 1
 %endif
-%if 0%{?rhel} > 7
-%global without_openssl 0
+%if %{defined rhel} && 0%{?rhel} <= 7
+%global without_openssl 1
 %endif
 
 # Do we want kerberos5 support (1=yes 0=no)


### PR DESCRIPTION
In Fedora systems, %{?rhel} is empty. In RHEL systems, %{?fedora} is empty. Therefore, the original code always sets without_openssl to 1.