### PR TITLE
Fix a small memory leak in process_server_config_line_depth

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -1933,6 +1933,7 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		xasprintf(&options->subsystem_args[options->num_subsystems],
 		    "%s%s%s", arg, *arg2 == '\0' ? "" : " ", arg2);
 		free(arg2);
+		free(arg);
 		argv_consume(&ac);
 		options->num_subsystems++;
 		break;


### PR DESCRIPTION
The return value of argv_assemble is owned by the caller and should be free'd. When processing the sSubsystem case there are two calls to argv_assemble but only one of them is freed. This patch fixes the small (29 bytes according to valgrind) memory leak.

The output from valgrind:
```
==115369== 29 bytes in 1 blocks are definitely lost in loss record 573 of 913
==115369==    at 0x4845794: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==115369==    by 0x124A22: argv_assemble (misc.c:2165)
==115369==    by 0x1385E5: process_server_config_line_depth.constprop.0 (servconf.c:2004)
==115369==    by 0x13984D: parse_server_config_depth.constprop.0 (servconf.c:3032)
==115369==    by 0x139986: parse_server_config.constprop.0 (servconf.c:3049)
==115369==    by 0x111C6E: main (sshd.c:1445)
```