### PR TITLE
Don't skip audit before exitting cleanup_exit

### DIFF
--- a/sshd-session.c
+++ b/sshd-session.c
@@ -1502,13 +1502,13 @@ cleanup_exit(int i)
 			}
 		}
 	}
-	/* Override default fatal exit value when auth was attempted */
-	if (i == 255 && auth_attempted)
-		_exit(EXIT_AUTH_ATTEMPTED);
 #ifdef SSH_AUDIT_EVENTS
 	/* done after do_cleanup so it can cancel the PAM auth 'thread' */
 	if (the_active_state != NULL && mm_is_monitor())
 		audit_event(the_active_state, SSH_CONNECTION_ABANDON);
 #endif
+	/* Override default fatal exit value when auth was attempted */
+	if (i == 255 && auth_attempted)
+		_exit(EXIT_AUTH_ATTEMPTED);
 	_exit(i);
 }


### PR DESCRIPTION
This fixes an issue where the SSH_CONNECTION_ABANDON event is not audited because cleanup_exit overrides the regular _exit too soon and as a result, failed auth attempts are not logged correctly.

The problem was introduced in 81c1099d22b81ebfd20a334ce986c4f753b0db29 where the code from upstream was merged before the audit_event call when it should have been merged right before the _exit call in order to honor the comment that just mentions an override of the exit value.