### PR TITLE
fix error support clang

### DIFF
--- a/ssh-ecdsa.c
+++ b/ssh-ecdsa.c
@@ -42,7 +42,7 @@
 #include "digest.h"
 #define SSHKEY_INTERNAL
 #include "sshkey.h"
-
+#include "ssh-pkcs11.h"
 #include "openbsd-compat/openssl-compat.h"
 
 static u_int

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -26,7 +26,7 @@
 
 #include <stdarg.h>
 #include <string.h>
-
+#include "ssh-pkcs11.h"
 #include "sshbuf.h"
 #include "ssherr.h"
 #define SSHKEY_INTERNAL


### PR DESCRIPTION
I meet problems like this when I use clang:
[  172s] ssh-ecdsa.c:267:6: error: call to undeclared function 'is_ecdsa_pkcs11'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
[  172s]   267 |         if (is_ecdsa_pkcs11(key->ecdsa)) {
[  172s]       |             ^
[  172s] 1 warning and 1 error generated.
so i need to add head support