### PR TITLE
Add a Makefile target for sk-libfido2.so

### DIFF
--- a/.github/configs
+++ b/.github/configs
@@ -181,7 +181,7 @@ case "$config" in
 	CONFIGFLAGS="--with-selinux"
 	;;
     sk)
-	CONFIGFLAGS="--with-security-key-builtin"
+	CONFIGFLAGS="--with-security-key-builtin --with-security-key-standalone"
         ;;
     without-openssl)
 	LIBCRYPTOFLAGS="--without-openssl"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ survey.sh
 **/*.o
 **/*.lo
 **/*.so
+**/*.dylib
+**/*.dll
 **/*.out
 **/*.a
 **/*.un~

--- a/Makefile.in
+++ b/Makefile.in
@@ -33,6 +33,7 @@ SSH_PRIVSEP_USER=@SSH_PRIVSEP_USER@
 STRIP_OPT=@STRIP_OPT@
 TEST_SHELL=@TEST_SHELL@
 BUILDDIR=@abs_top_builddir@
+SK_STANDALONE=@SK_STANDALONE@
 
 PATHS= -DSSHDIR=\"$(sysconfdir)\" \
 	-D_PATH_SSH_PROGRAM=\"$(SSH_PROGRAM)\" \
@@ -73,7 +74,7 @@ MKDIR_P=@MKDIR_P@
 
 .SUFFIXES: .lo
 
-TARGETS=ssh$(EXEEXT) sshd$(EXEEXT) sshd-session$(EXEEXT) sshd-auth$(EXEEXT) ssh-add$(EXEEXT) ssh-keygen$(EXEEXT) ssh-keyscan${EXEEXT} ssh-keysign${EXEEXT} ssh-pkcs11-helper$(EXEEXT) ssh-agent$(EXEEXT) scp$(EXEEXT) sftp-server$(EXEEXT) sftp$(EXEEXT) ssh-sk-helper$(EXEEXT)
+TARGETS=ssh$(EXEEXT) sshd$(EXEEXT) sshd-session$(EXEEXT) sshd-auth$(EXEEXT) ssh-add$(EXEEXT) ssh-keygen$(EXEEXT) ssh-keyscan${EXEEXT} ssh-keysign${EXEEXT} ssh-pkcs11-helper$(EXEEXT) ssh-agent$(EXEEXT) scp$(EXEEXT) sftp-server$(EXEEXT) sftp$(EXEEXT) ssh-sk-helper$(EXEEXT) $(SK_STANDALONE)
 
 XMSS_OBJS=\
 	ssh-xmss.o \
@@ -271,6 +272,16 @@ sftp$(EXEEXT): $(LIBCOMPAT) libssh.a $(SFTP_OBJS)
 # test driver for the loginrec code - not built by default
 logintest: logintest.o $(LIBCOMPAT) libssh.a loginrec.o
 	$(LD) -o $@ logintest.o $(LDFLAGS) loginrec.o -lopenbsd-compat -lssh $(LIBS)
+
+# compile libssh objects with -fPIC for use in the sk_libfido2 shared library
+LIBSSH_PIC_OBJS=$(LIBSSH_OBJS:.o=.lo)
+libssh-pic.a: $(LIBSSH_PIC_OBJS)
+	$(AR) rv $@ $(LIBSSH_PIC_OBJS)
+	$(RANLIB) $@
+
+$(SK_STANDALONE): sk-usbhid.c $(LIBCOMPAT) libssh-pic.a
+	$(CC) -o $@ -shared $(CFLAGS_NOPIE) $(CPPFLAGS) -DSK_STANDALONE $(PICFLAG) sk-usbhid.c \
+	libssh-pic.a $(LDFLAGS_NOPIE) -lopenbsd-compat $(LIBS) $(LIBFIDO2) $(CHANNELLIBS)
 
 $(MANPAGES): $(MANPAGES_IN)
 	if test "$(MANTYPE)" = "cat"; then \

--- a/configure.ac
+++ b/configure.ac
@@ -614,6 +614,9 @@ SPP_MSG="no"
 # the --with-solaris-privs option and --with-sandbox=solaris).
 SOLARIS_PRIVS="no"
 
+# Default shared library extension
+SHLIBEXT=".so"
+
 # Check for some target-specific stuff
 case "$host" in
 *-*-aix*)
@@ -732,6 +735,7 @@ case "$host" in
 	# Cygwin defines optargs, optargs as declspec(dllimport) for historical
 	# reasons which cause compile warnings, so we disable those warnings.
 	OSSH_CHECK_CFLAG_COMPILE([-Wno-attributes])
+	SHLIBEXT=".dll"
 	;;
 *-*-dgux*)
 	AC_DEFINE([IP_TOS_IS_BROKEN], [1],
@@ -791,6 +795,7 @@ int main(void) { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
 	# cf. Apple bug 3710161 (not public, but searchable)
 	AC_DEFINE([BROKEN_POLL], [1],
 	    [System poll(2) implementation is broken])
+	SHLIBEXT=".dylib"
 	;;
 *-*-dragonfly*)
 	SSHDLIBS="$SSHDLIBS"
@@ -2080,6 +2085,12 @@ AC_ARG_WITH([security-key-builtin],
 	[ enable_sk_internal=$withval ]
 )
 
+enable_sk_standalone=
+AC_ARG_WITH([security-key-standalone],
+	[  --with-security-key-standalone build standalone sk-libfido2 SecurityKeyProvider],
+	[ enable_sk_standalone=$withval ]
+)
+
 enable_dsa=
 AC_ARG_ENABLE([dsa-keys],
 	[  --enable-dsa-keys       enable DSA key support [no]],
@@ -3315,6 +3326,16 @@ if test "x$enable_sk" = "xyes" -a "x$enable_sk_internal" != "xno" ; then
 		])
 		LIBS="$saved_LIBS"
 	fi
+fi
+
+# Check for standalone SecurityKeyProvider
+AC_MSG_CHECKING([whether to build standlone sk-libfido2])
+if test "x$enable_sk_standalone" = "xyes" ; then
+	AC_MSG_RESULT([yes])
+	AC_SUBST([SK_STANDALONE], [sk-libfido2$SHLIBEXT])
+else
+	AC_MSG_RESULT([no])
+	AC_SUBST([SK_STANDALONE], [""])
 fi
 
 AC_CHECK_FUNCS([ \

--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -77,10 +77,11 @@
 #define FIDO_CRED_PROT_UV_OPTIONAL_WITH_ID 0
 #endif
 
+# include "misc.h"
+
 #ifndef SK_STANDALONE
 # include "log.h"
 # include "xmalloc.h"
-# include "misc.h"
 /*
  * If building as part of OpenSSH, then rename exported functions.
  * This must be done before including sk-api.h.


### PR DESCRIPTION
Compiles the standalone FIDO2 security key shared library, suitable for use with the **SecurityKeyProvider** option. misc.h is required even when `SK_STANDALONE` is defined, because of the use of `monotime_tv` in `sk_select_by_touch`.

The distributed OpenSSH client in macOS is compiled with security key support, but without linking against libfido2. As a result, on the latest versions of macOS (15.0.1), `*-sk` key types do not work out of the box without an external SecurityKeyProvider library (https://github.com/Yubico/libfido2/issues/464). This library used to be provided by libfido2, but was removed a number of years ago because the code was included upstream in OpenSSH (https://github.com/Yubico/libfido2/blob/e1c761a9a03ffe95fbb11367252a0d091ea6a1d5/NEWS#L127).

OpenSSH has all of the code needed to produce the shared library to support usb FIDO2 devices via the **SecurityKeyProvider** option that is normally builtin. It is just missing the Makefile target to compile it. Ultimately I would like to add a official homebrew recipe for sk-libfido2, that only depends on the OpenSSH source code.

Thanks to @scottgeary for help with compiling and testing.