### PR TITLE
Updated gitignore to ignore sshd-session and sshd-auth targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ ssh-keysign
 ssh-pkcs11-helper
 ssh-sk-helper
 sshd
+sshd-session
+sshd-auth
 !regress/misc/fuzz-harness/Makefile
 !regress/unittests/sshsig/Makefile
 tags


### PR DESCRIPTION
sshd-session and sshd-auth targets were missing in .gitignore file, showing up as untracked files in git status command