### PR TITLE
Fix regular users expired password reset issue

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -216,6 +216,7 @@ initialize_server_options(ServerOptions *options)
 	options->sshd_session_path = NULL;
 	options->sshd_auth_path = NULL;
 	options->refuse_connection = -1;
+	options->notify_hostkeys = -1;
 }
 
 /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
@@ -498,6 +499,8 @@ fill_default_server_options(ServerOptions *options)
 		options->sshd_auth_path = xstrdup(_PATH_SSHD_AUTH);
 	if (options->refuse_connection == -1)
 		options->refuse_connection = 0;
+	if (options->notify_hostkeys == -1) 
+		options->notify_hostkeys = 1;
 
 	assemble_algorithms(options);
 
@@ -581,7 +584,8 @@ typedef enum {
 	sExposeAuthInfo, sRDomain, sPubkeyAuthOptions, sSecurityKeyProvider,
 	sRequiredRSASize, sChannelTimeout, sUnusedConnectionTimeout,
 	sSshdSessionPath, sSshdAuthPath, sRefuseConnection,
-	sDeprecated, sIgnore, sUnsupported
+	sDeprecated, sIgnore, sUnsupported,
+	sNotifyHostKeys
 } ServerOpCodes;
 
 #define SSHCFG_GLOBAL		0x01	/* allowed in main section of config */
@@ -750,6 +754,7 @@ static struct {
 	{ "sshdsessionpath", sSshdSessionPath, SSHCFG_GLOBAL },
 	{ "sshdauthpath", sSshdAuthPath, SSHCFG_GLOBAL },
 	{ "refuseconnection", sRefuseConnection, SSHCFG_ALL },
+	{ "notifyhostkeys", sNotifyHostKeys, SSHCFG_GLOBAL },
 	{ NULL, sBadOption, 0 }
 };
 
@@ -2726,6 +2731,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		    keyword);
 		argv_consume(&ac);
 		break;
+	case sNotifyHostKeys:
+  		intptr = &options->notify_hostkeys;
+		multistate_ptr = multistate_flag; 
+		goto parse_multistate;
 
 	default:
 		fatal("%s line %d: Missing handler for opcode %s (%d)",

--- a/servconf.h
+++ b/servconf.h
@@ -252,6 +252,7 @@ typedef struct {
 	char   *sshd_auth_path;
 
 	int	refuse_connection;
+	int	notify_hostkeys;
 }       ServerOptions;
 
 /* Information about the incoming connection as used by Match */

--- a/sshd-session.c
+++ b/sshd-session.c
@@ -1337,8 +1337,13 @@ main(int ac, char **av)
 	ssh_packet_set_timeout(ssh, options.client_alive_interval,
 	    options.client_alive_count_max);
 
-	/* Try to send all our hostkeys to the client */
-	notify_hostkeys(ssh);
+	if (options.notify_hostkeys) {
+		/* Try to send all our hostkeys to the client */
+		debug3("NotifyHostKeys is enabled. Attempting to notify host keys.");
+		notify_hostkeys(ssh);
+	} else {
+		debug3("NotifyHostKeys is disabled.");
+	}
 
 	/* Start session. */
 	do_authenticated(ssh, authctxt);

--- a/sshd_config
+++ b/sshd_config
@@ -101,7 +101,7 @@ AuthorizedKeysFile	.ssh/authorized_keys
 #PermitTunnel no
 #ChrootDirectory none
 #VersionAddendum none
-
+#NotifyHostKeys yes
 # no default banner path
 #Banner none
 


### PR DESCRIPTION
When PASSWD_NEEDS_USERNAME is enabled and a password expires, the regular user test will also run passwd test when attempting to change their password. This results in the error: passwd: Only root can specify a user name. Therefore, with PASSWD_NEEDS_USERNAME enabled, a condition needs to be added to allow only root to specify a username.