### PR TITLE
Inherit DESTDIR from the environment.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,7 +18,6 @@ top_srcdir=@top_srcdir@
 abs_top_srcdir=@abs_top_srcdir@
 abs_top_builddir=@abs_top_builddir@
 
-DESTDIR=
 VPATH=@srcdir@
 SSH_PROGRAM=@bindir@/ssh
 ASKPASS_PROGRAM=$(libexecdir)/ssh-askpass


### PR DESCRIPTION
autoconf packages conventionally inherit the DESTDIR variable from the environment.