### PR TITLE
Define u_short and u_long if needed.

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -216,7 +216,9 @@ including rpc/rpc.h breaks Solaris 6
 /* (or die trying) */
 
 #ifndef HAVE_U_INT
+typedef unsigned short u_short;
 typedef unsigned int u_int;
+typedef unsigned long u_long;
 #endif
 
 #ifndef HAVE_INTXX_T


### PR DESCRIPTION
I could add autoconf tests for HAVE_U_SHORT and HAVE_U_LONG too if you prefer? My reasoning here is that platforms probably either have all of them, or none of them.