### PR TITLE
Remove unused <netinet/in_systm.h> and <resolv.h> inclusions.

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -55,7 +55,6 @@ enum
 /*
  * Definitions for IP type of service (ip_tos)
  */
-#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #ifndef IPTOS_LOWDELAY
 # define IPTOS_LOWDELAY          0x10

--- a/hostfile.c
+++ b/hostfile.c
@@ -44,7 +44,6 @@
 #include <netinet/in.h>
 
 #include <errno.h>
-#include <resolv.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/includes.h
+++ b/includes.h
@@ -109,7 +109,6 @@
 #endif
 
 #include <netinet/in.h>
-#include <netinet/in_systm.h> /* For typedefs */
 #ifdef HAVE_RPC_TYPES_H
 # include <rpc/types.h> /* For INADDR_LOOPBACK */
 #endif

--- a/misc.c
+++ b/misc.c
@@ -51,7 +51,6 @@
 #include <unistd.h>
 
 #include <netinet/in.h>
-#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>

--- a/readconf.c
+++ b/readconf.c
@@ -22,7 +22,6 @@
 
 #include <net/if.h>
 #include <netinet/in.h>
-#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #include <arpa/inet.h>
 

--- a/servconf.c
+++ b/servconf.c
@@ -20,7 +20,6 @@
 #endif
 
 #include <netinet/in.h>
-#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #ifdef HAVE_NET_ROUTE_H
 #include <net/route.h>

--- a/sshbuf-misc.c
+++ b/sshbuf-misc.c
@@ -28,7 +28,6 @@
 #include <stdio.h>
 #include <limits.h>
 #include <string.h>
-#include <resolv.h>
 #include <ctype.h>
 #include <unistd.h>
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -44,7 +44,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <resolv.h>
 #include <time.h>
 #ifdef HAVE_UTIL_H
 #include <util.h>


### PR DESCRIPTION
netinet/in_systm.h defines n_short, n_long, and n_time which are not used anywhere in openssh.

resolv.h is not used in the affected files.