### PR TITLE
Fix regular users expired password reset issue

### DIFF
--- a/session.c
+++ b/session.c
@@ -1438,8 +1438,11 @@ do_pwchange(Session *s)
 		setexeccon(NULL);
 #endif
 #ifdef PASSWD_NEEDS_USERNAME
-		execl(_PATH_PASSWD_PROG, "passwd", s->pw->pw_name,
-		    (char *)NULL);
+               if (getuid() != 0) {
+                       execl(_PATH_PASSWD_PROG, "passwd", (char *)NULL);
+               } else {
+                       execl(_PATH_PASSWD_PROG, "passwd", s->pw->pw_name, (char *)NULL);
+               }		
 #else
 		execl(_PATH_PASSWD_PROG, "passwd", (char *)NULL);
 #endif


### PR DESCRIPTION
When PASSWD_NEEDS_USERNAME is enabled and a password expires, a regular user like test will see the error: passwd: Only root can specify a user name upon login. Allowing regular users to change their own password is a reasonable requirement, so when PASSWD_NEEDS_USERNAME is enabled, a condition needs to be added to address this.