### PR TITLE
Improve error message when tunneling without the required permissions

### DIFF
--- a/serverloop.c
+++ b/serverloop.c
@@ -757,11 +757,14 @@ server_input_global_request(int type, u_int32_t seq, struct ssh *ssh)
 		/* check permissions */
 		if (port > INT_MAX ||
 		    (options.allow_tcp_forwarding & FORWARD_REMOTE) == 0 ||
-		    !auth_opts->permit_port_forwarding_flag ||
 		    options.disable_forwarding ||
 		    (!want_reply && fwd.listen_port == 0)) {
 			success = 0;
 			ssh_packet_send_debug(ssh, "Server has disabled port forwarding.");
+		} else if (!auth_opts->permit_port_forwarding_flag) {
+			success = 0;
+			ssh_packet_send_debug(ssh, 
+			    "Authentication options do not permit port forwarding.");
 		} else {
 			/* Start listening on the port */
 			success = channel_setup_remote_fwd_listener(ssh, &fwd,
@@ -790,12 +793,15 @@ server_input_global_request(int type, u_int32_t seq, struct ssh *ssh)
 		    fwd.listen_path);
 
 		/* check permissions */
-		if ((options.allow_streamlocal_forwarding & FORWARD_REMOTE) == 0
-		    || !auth_opts->permit_port_forwarding_flag ||
+		if ((options.allow_streamlocal_forwarding & FORWARD_REMOTE) == 0 ||
 		    options.disable_forwarding) {
 			success = 0;
 			ssh_packet_send_debug(ssh, "Server has disabled "
 			    "streamlocal forwarding.");
+		} else if (!auth_opts->permit_port_forwarding_flag) {
+			success = 0;
+			ssh_packet_send_debug(ssh, 
+			    "Authentication options do not permit streamlocal forwarding.");
 		} else {
 			/* Start listening on the socket */
 			success = channel_setup_remote_fwd_listener(ssh,


### PR DESCRIPTION
I was battling an issue where I wasn't able to port forward with one way of logging in versus another. Eventually figured out that the server was incorrectly telling me that port forwarding was disabled by the server, whereas it was actually disabled due to my SSH certificate options/extensions, as it was missing the "permit-port-forwarding" extension.