### PR TITLE
Store forwarded TCP listen port in SSH_FWD_TCP_PORT env variable

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -100,6 +100,8 @@
 /* Per-channel callback for pre/post IO actions */
 typedef void chan_fn(struct ssh *, Channel *c);
 
+int fwd_tcp_listen_port = 0;
+
 /*
  * Data structure for storing which hosts are permitted for forward requests.
  * The local sides of any remote forwards are stored in this array to prevent
@@ -3937,6 +3939,7 @@ channel_setup_fwd_listener_tcpip(struct ssh *ssh, int type,
 			c->listening_port = *allocated_listen_port;
 		else
 			c->listening_port = fwd->listen_port;
+		fwd_tcp_listen_port = c->listening_port;
 		success = 1;
 	}
 	if (success == 0)

--- a/session.c
+++ b/session.c
@@ -149,6 +149,7 @@ extern void destroy_sensitive_data(void);
 extern struct sshbuf *loginmsg;
 extern struct sshauthopt *auth_opts;
 extern char *tun_fwd_ifnames; /* serverloop.c */
+extern int fwd_tcp_listen_port; /* channels.c */
 
 /* original command from peer. */
 const char *original_command = NULL;
@@ -1086,6 +1087,10 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
 		child_set_env(&env, &envsize, SSH_AUTHSOCKET_ENV_NAME,
 		    auth_sock_name);
 
+	if (fwd_tcp_listen_port > 0) {
+		snprintf(buf, sizeof buf, "%d", fwd_tcp_listen_port);
+		child_set_env(&env, &envsize, "SSH_FWD_TCP_PORT", buf);
+	}
 
 	/* Set custom environment options from pubkey authentication. */
 	if (options.permit_user_env) {

--- a/ssh.1
+++ b/ssh.1
@@ -1481,6 +1481,8 @@ Identifies the client and server ends of the connection.
 The variable contains
 four space-separated values: client IP address, client port number,
 server IP address, and server port number.
+.It Ev SSH_FWD_TCP_PORT
+Identifies the port number of forwarded remote TCP listen socket.
 .It Ev SSH_ORIGINAL_COMMAND
 This variable contains the original command line if a forced command
 is executed.


### PR DESCRIPTION
Using 0 for the port number with `-R` dynamically allocates a listen port on the server. The allocated port is printed to standard output, which is not very useful for automation scripts, forcing ssh users to implement workarounds:

* https://serverfault.com/questions/1074254/ssh-with-a-dynamically-allocated-remote-forwarded-port-how-to-find-the-port-n
* https://serverfault.com/questions/856280/get-local-port-when-using-ssh-forwarding-with-dynamic-0-port
* https://unix.stackexchange.com/questions/584479/recording-the-dynamically-allocated-port-number-with-ssh-remote-port-forwarding

This change stores the allocated port in SSH_FWD_TCP_PORT environment variable.