### PR TITLE
mdoc2man: balance nested square brackets

### DIFF
--- a/mdoc2man.awk
+++ b/mdoc2man.awk
@@ -239,7 +239,7 @@ function add(str) {
       while(w<nwords&&match(words[w+1],"^[\\.,:;)]"))
 	add(words[++w])
     } else if(match(words[w],"^Op$")) {
-      option=1
+      option++
       if(!nospace)
 	nospace=1
       add("[")
@@ -358,7 +358,7 @@ function add(str) {
     add(")")
   if(angles)
     add(">")
-  if(option)
+  for(;option;option--)
     add("]")
   if(ext&&!extopt&&!match(line," $"))
     add(OFS)


### PR DESCRIPTION
I noticed the square brackets in `destination [command [argument...]` in the synopsis for the `ssh.1` manpage were not balanced, this balances them.

(I also proposed this as a patch on the openssh-unix-dev mailing list, Oct 20th, message id 811cbc01-1c58-4ed8-82fb-bcb34364016f@app.fastmail.com, but not sure if that's still on someone's radar or got lost)