### PR TITLE
Fix security keys without attestation

### DIFF
--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -961,13 +961,15 @@ sk_enroll(uint32_t alg, const uint8_t *challenge, size_t challenge_len,
 			    fido_strerr(r));
 			goto out;
 		}
-	} else {
+	} else if (strcmp(fido_cred_fmt(cred), "none") != 0) {
 		skdebug(__func__, "self-attested credential");
 		if ((r = fido_cred_verify_self(cred)) != FIDO_OK) {
 			skdebug(__func__, "fido_cred_verify_self: %s",
 			    fido_strerr(r));
 			goto out;
 		}
+	} else {
+		skdebug(__func__, "no attestation data");
 	}
 	if ((response = calloc(1, sizeof(*response))) == NULL) {
 		skdebug(__func__, "calloc response failed");


### PR DESCRIPTION
Using libfido2 with windows://hello results in security key returning no attestation data. This currently fails due to fido_cred_verify_self failing.

According to https://github.com/Yubico/libfido2/issues/840 this is not a bug in libfido2, but openssh instead has to skip the verify call if no attestation is given.

This fixes the issue by skipping attestation verification during key generation if there is no attestation.

Fixes https://github.com/PowerShell/Win32-OpenSSH/issues/2040 and https://github.com/PowerShell/Win32-OpenSSH/issues/2279