### PR TITLE
regress/key-options.sh: do not run test with 2038 expiry date on 64 bit time_t systems

### DIFF
--- a/regress/key-options.sh
+++ b/regress/key-options.sh
@@ -120,7 +120,8 @@ check_valid_before() {
 check_valid_before "default"	""				"pass"
 check_valid_before "invalid"	'expiry-time="INVALID"'		"fail"
 check_valid_before "expired"	'expiry-time="19990101"'	"fail"
+if config_defined "SIZEOF_TIME_T 4"; then
 check_valid_before "valid"	'expiry-time="20380101"'	"pass"
-if ! config_defined "SIZEOF_TIME_T 4"; then
+else
 check_valid_before "valid-64b"	'expiry-time="25250101"'	"pass"
 fi


### PR DESCRIPTION
This allows testing Y2038 with system time set to after that (i.e. 2040), so that actual Y2038 issues can be exposed, and not masked by key expiry errors.