### PR TITLE
Fix out-of-tree build failure for standalone sk-libfido2

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -279,8 +279,8 @@ libssh-pic.a: $(LIBSSH_PIC_OBJS)
 	$(AR) rv $@ $(LIBSSH_PIC_OBJS)
 	$(RANLIB) $@
 
-$(SK_STANDALONE): sk-usbhid.c $(LIBCOMPAT) libssh-pic.a
-	$(CC) -o $@ -shared $(CFLAGS_NOPIE) $(CPPFLAGS) -DSK_STANDALONE $(PICFLAG) sk-usbhid.c \
+$(SK_STANDALONE): $(srcdir)/sk-usbhid.c $(LIBCOMPAT) libssh-pic.a
+	$(CC) -o $@ -shared $(CFLAGS_NOPIE) $(CPPFLAGS) -DSK_STANDALONE $(PICFLAG) $(srcdir)/sk-usbhid.c \
 	libssh-pic.a $(LDFLAGS_NOPIE) -lopenbsd-compat $(LIBS) $(LIBFIDO2) $(CHANNELLIBS)
 
 $(MANPAGES): $(MANPAGES_IN)


### PR DESCRIPTION
The compiler can't find `sk-usbhid.c` when building out-of-tree.

This fixes the issue by provide the explicit path of `sk-usbhid.c` in compile command.