### PR TITLE
support SocketProtocol for both the client and server

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -179,7 +179,7 @@ typedef enum {
 	oPubkeyAcceptedAlgorithms, oCASignatureAlgorithms, oProxyJump,
 	oSecurityKeyProvider, oKnownHostsCommand, oRequiredRSASize,
 	oEnableEscapeCommandline, oObscureKeystrokeTiming, oChannelTimeout,
-	oVersionAddendum,
+	oVersionAddendum, oSocketProtocol,
 	oIgnore, oIgnoredUnknownOption, oDeprecated, oUnsupported
 } OpCodes;
 
@@ -331,6 +331,7 @@ static struct {
 	{ "obscurekeystroketiming", oObscureKeystrokeTiming },
 	{ "channeltimeout", oChannelTimeout },
 	{ "versionaddendum", oVersionAddendum },
+	{ "socketprotocol", oSocketProtocol },
 
 	{ NULL, oBadOption }
 };
@@ -2464,6 +2465,10 @@ parse_pubkey_algos:
 		argv_consume(&ac);
 		break;
 
+	case oSocketProtocol:
+		intptr = &options->socket_protocol;
+		goto parse_int;
+
 	case oDeprecated:
 		debug("%s line %d: Deprecated option \"%s\"",
 		    filename, linenum, keyword);
@@ -2721,6 +2726,7 @@ initialize_options(Options * options)
 	options->channel_timeouts = NULL;
 	options->num_channel_timeouts = 0;
 	options->version_addendum = NULL;
+	options->socket_protocol = -1;
 }
 
 /*
@@ -2927,6 +2933,8 @@ fill_default_options(Options * options)
 		options->obscure_keystroke_timing_interval =
 		    SSH_KEYSTROKE_DEFAULT_INTERVAL_MS;
 	}
+	if (options->socket_protocol == -1)
+		options->socket_protocol = 0;
 
 	/* Expand KEX name lists */
 	all_cipher = cipher_alg_list(',', 0);
@@ -3646,6 +3654,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_int(oRequiredRSASize, o->required_rsa_size);
 	dump_cfg_int(oObscureKeystrokeTiming,
 	    o->obscure_keystroke_timing_interval);
+	dump_cfg_int(oSocketProtocol, o->socket_protocol);
 
 	/* String options */
 	dump_cfg_string(oBindAddress, o->bind_address);

--- a/readconf.h
+++ b/readconf.h
@@ -186,6 +186,8 @@ typedef struct {
 
 	char	*version_addendum;
 
+	int	socket_protocol;
+
 	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
 }       Options;
 

--- a/scp.1
+++ b/scp.1
@@ -247,6 +247,7 @@ For full details of the options listed below, and their possible values, see
 .It ServerAliveInterval
 .It SessionType
 .It SetEnv
+.It SocketProtocol
 .It StdinNull
 .It StreamLocalBindMask
 .It StreamLocalBindUnlink

--- a/servconf.c
+++ b/servconf.c
@@ -216,6 +216,7 @@ initialize_server_options(ServerOptions *options)
 	options->sshd_session_path = NULL;
 	options->sshd_auth_path = NULL;
 	options->refuse_connection = -1;
+	options->socket_protocol = -1;
 }
 
 /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
@@ -498,6 +499,8 @@ fill_default_server_options(ServerOptions *options)
 		options->sshd_auth_path = xstrdup(_PATH_SSHD_AUTH);
 	if (options->refuse_connection == -1)
 		options->refuse_connection = 0;
+	if (options->socket_protocol == -1)
+		options->socket_protocol = 0;
 
 	assemble_algorithms(options);
 
@@ -580,7 +583,7 @@ typedef enum {
 	sAllowStreamLocalForwarding, sFingerprintHash, sDisableForwarding,
 	sExposeAuthInfo, sRDomain, sPubkeyAuthOptions, sSecurityKeyProvider,
 	sRequiredRSASize, sChannelTimeout, sUnusedConnectionTimeout,
-	sSshdSessionPath, sSshdAuthPath, sRefuseConnection,
+	sSshdSessionPath, sSshdAuthPath, sRefuseConnection, sSocketProtocol,
 	sDeprecated, sIgnore, sUnsupported
 } ServerOpCodes;
 
@@ -750,6 +753,7 @@ static struct {
 	{ "sshdsessionpath", sSshdSessionPath, SSHCFG_GLOBAL },
 	{ "sshdauthpath", sSshdAuthPath, SSHCFG_GLOBAL },
 	{ "refuseconnection", sRefuseConnection, SSHCFG_ALL },
+	{ "socketprotocol", sSocketProtocol, SSHCFG_GLOBAL },
 	{ NULL, sBadOption, 0 }
 };
 
@@ -2716,6 +2720,10 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		multistate_ptr = multistate_flag;
 		goto parse_multistate;
 
+	case sSocketProtocol:
+		intptr = &options->socket_protocol;
+		goto parse_int;
+
 	case sDeprecated:
 	case sIgnore:
 	case sUnsupported:
@@ -3219,6 +3227,7 @@ dump_config(ServerOptions *o)
 	dump_cfg_int(sRequiredRSASize, o->required_rsa_size);
 	dump_cfg_oct(sStreamLocalBindMask, o->fwd_opts.streamlocal_bind_mask);
 	dump_cfg_int(sUnusedConnectionTimeout, o->unused_connection_timeout);
+	dump_cfg_int(sSocketProtocol, o->socket_protocol);
 
 	/* formatted integer arguments */
 	dump_cfg_fmtint(sPermitRootLogin, o->permit_root_login);

--- a/servconf.h
+++ b/servconf.h
@@ -252,6 +252,8 @@ typedef struct {
 	char   *sshd_auth_path;
 
 	int	refuse_connection;
+
+	int	socket_protocol;
 }       ServerOptions;
 
 /* Information about the incoming connection as used by Match */

--- a/sftp.1
+++ b/sftp.1
@@ -309,6 +309,7 @@ For full details of the options listed below, and their possible values, see
 .It ServerAliveInterval
 .It SessionType
 .It SetEnv
+.It SocketProtocol
 .It StdinNull
 .It StreamLocalBindMask
 .It StreamLocalBindUnlink

--- a/ssh.1
+++ b/ssh.1
@@ -590,6 +590,7 @@ For full details of the options listed below, and their possible values, see
 .It ServerAliveInterval
 .It SessionType
 .It SetEnv
+.It SocketProtocol
 .It StdinNull
 .It StreamLocalBindMask
 .It StreamLocalBindUnlink

--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1911,6 +1911,8 @@ Similarly to
 with the exception of the
 .Ev TERM
 variable, the server must be prepared to accept the environment variable.
+.It Cm SocketProtocol
+Specifies the protocol to be used when creating the connecting socket.
 .It Cm StdinNull
 Redirects stdin from
 .Pa /dev/null

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -359,7 +359,9 @@ ssh_create_socket(struct addrinfo *ai)
 #endif
 	char ntop[NI_MAXHOST];
 
-	sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+	sock = socket(ai->ai_family, ai->ai_socktype,
+	    options.socket_protocol > 0 ? options.socket_protocol :
+	    ai->ai_protocol);
 	if (sock == -1) {
 		error("socket: %s", strerror(errno));
 		return -1;

--- a/sshd.c
+++ b/sshd.c
@@ -757,6 +757,7 @@ listen_on_addrs(struct listenaddr *la)
 		}
 		/* Create socket for listening. */
 		listen_sock = socket(ai->ai_family, ai->ai_socktype,
+		    options.socket_protocol > 0 ? options.socket_protocol :
 		    ai->ai_protocol);
 		if (listen_sock == -1) {
 			/* kernel may not support ipv6 */

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1328,6 +1328,7 @@ Available keywords are
 .Cm RevokedKeys ,
 .Cm RDomain ,
 .Cm SetEnv ,
+.Cm SocketProtocol ,
 .Cm StreamLocalBindMask ,
 .Cm StreamLocalBindUnlink ,
 .Cm TrustedUserCAKeys ,
@@ -1853,6 +1854,8 @@ via
 .Cm AcceptEnv
 or
 .Cm PermitUserEnvironment .
+.It Cm SocketProtocol
+Specifies the protocol to be used when creating the listening socket.
 .It Cm SshdAuthPath
 Overrides the default path to the
 .Cm sshd-auth


### PR DESCRIPTION
This adds a new option called `SocketProtocol`, to allow the users to change the socket protocol, the 3rd parameter of the socket syscall.

A typical use-case is to properly enable [MPTCP](https://www.mptcp.dev) [1] support: on Linux, to support it, apps have to create a stream socket with the `IPPROTO_MPTCP` (262) protocol, that's it:

    socket(AF_INET(6), SOCK_STREAM, IPPROTO_MPTCP)

So now, to get MPTCP support with SSH commands, the `SocketProtocol` option can be set to 262, e.g.

    $ ssh -o SocketProtocol=262 my-server

Or by adding `SocketProtocol 262` in `ssh_config` or `sshd_config`.

Other protocols on other OS can then also be used that way, it is not Linux specific as #335 was.

Please note that so far, only workarounds could be used to enable MPTCP support with SSH on Linux, e.g. the `LD_PRELOAD` technique to change the behaviour of the `socket()` call. Such workaround has limitations:
- On the server side:
  - The service to launch the ssh daemon -- something that is usually not modified -- needs to be overridden, it's not just a config to set in the `sshd_config` file.
  - Also, some sysadmins don't allow `LD_PRELOAD` techniques, because all TCP sockets created by the service will be modified without sshd's knowledge.
- On the client side:
  - Each command (ssh, scp, git, etc.) needs to be executed with `LD_PRELOAD` being set. That's maybe OK for occasional commands, less for regular ones, or for GUI applications.
  - A `ProxyCommand` option could be used -- e.g. set to `ssh -W %h:%p -l %r -p %p %h` -- but it is not great because it needs to be adapted for each host to pass some options, e.g. use v4/v6 only, etc.

Hopefully this new option can help users to enable MPTCP support on both the client and server side.