### PR TITLE
Make it possible to have multiple tags on a configuration block.

### DIFF
--- a/readconf.h
+++ b/readconf.h
@@ -70,7 +70,8 @@ typedef struct {
 	char   *kex_algorithms;	/* SSH2 kex methods in order of preference. */
 	char   *ca_sign_algorithms;	/* Allowed CA signature algorithms */
 	char   *hostname;	/* Real host to connect. */
-	char   *tag;		/* Configuration tag name. */
+	u_int	num_tag;	/* Configuration tag names. */
+	char	**tag;
 	char   *host_key_alias;	/* hostname alias for .ssh/known_hosts */
 	char   *proxy_command;	/* Proxy command for connecting the host. */
 	char   *user;		/* User to log in as. */

--- a/ssh.c
+++ b/ssh.c
@@ -811,8 +811,11 @@ main(int ac, char **av)
 				fatal("Invalid multiplex command.");
 			break;
 		case 'P':
-			if (options.tag == NULL)
-				options.tag = xstrdup(optarg);
+			options.tag = xrecallocarray(options.tag,
+			    options.num_tag, options.num_tag + 1,
+			    sizeof(*options.tag));
+			options.tag[options.num_tag] = xstrdup(optarg);
+			options.num_tag++;
 			break;
 		case 'Q':
 			cp = NULL;


### PR DESCRIPTION
This patch allows for multiple tags on a configuration block.
For instance, with this configuration:

```
Host test-host
  Tag change-hostname change-port-and-user
  Tag jump-to-mybox

Match tagged change-hostname
  Hostname new-hostname

Match tagged change-port-and-user
  Port 12345
  Tag change-user

Match tagged change-user
  User bilbo

Match tagged jump-to-mybox
  ProxyJump mybox

Match tagged nocheck
  StrictHostKeyChecking false
  UserKnownHostsFile /dev/null

Match tagged frodo-identity
  IdentityFile ~/.ssh/id_ed25519_frodo
```

the following parameters can be obtained:

```
gandalf@mybox $ ssh -P nocheck -P frodo-identity test-host -G |
> grep -E "^(user|hostname|port|stricthostkeychecking|identityfile|`
>         `userknownhostsfile|tag|proxyjump) "
user bilbo
hostname new-hostname
port 12345
stricthostkeychecking false
identityfile ~/.ssh/id_ed25519_frodo
userknownhostsfile /dev/null
tag nocheck
tag frodo-identity
tag change-hostname
tag change-port-and-user
tag jump-to-mybox
tag change-user
proxyjump mybox
gandalf@mybox $
```
