### PR TITLE
Fix debug logging of user_specific_delay

### DIFF
--- a/auth2.c
+++ b/auth2.c
@@ -238,7 +238,7 @@ user_specific_delay(const char *user)
 	/* 0-4.2 ms of delay */
 	delay = (double)PEEK_U32(hash) / 1000 / 1000 / 1000 / 1000;
 	freezero(hash, len);
-	debug3_f("user specific delay %0.3lfms", delay/1000);
+	debug3_f("user specific delay %0.3lfms", delay*1000);
 	return MIN_FAIL_DELAY_SECONDS + delay;
 }
 


### PR DESCRIPTION
In debug log, user_specific_delay always erroneously reports
```
debug3: user_specific_delay: user specific delay 0.000ms [preauth]
```
Maybe the debug log should also add `MIN_FAIL_DELAY_SECONDS`, to really report the returned value?
