### PR TITLE
Debugging AWS-LC CI 

### DIFF
--- a/.github/setup_ci.sh
+++ b/.github/setup_ci.sh
@@ -247,8 +247,10 @@ fi
 if [ ! -z "${INSTALL_AWSLC}" ]; then
     (cd ${HOME} && git clone --depth 1 --branch v1.46.1 https://github.com/aws/aws-lc.git &&
      cd ${HOME}/aws-lc && mkdir build && cd build &&
-     cmake -GNinja -DCMAKE_INSTALL_PREFIX="/opt/aws-lc" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. && 
-     ninja install)
+     cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. && ninja &&
+     mkdir -p /opt/aws-lc/lib &&
+     cp ${HOME}/aws-lc/build/crypto/libcrypto.a /opt/aws-lc/lib &&
+     cp -r ${HOME}/aws-lc/include /opt/aws-lc)
 fi
 
 if [ ! -z "${INSTALL_ZLIB}" ]; then

--- a/.github/setup_ci.sh
+++ b/.github/setup_ci.sh
@@ -245,12 +245,10 @@ if [ ! -z "${INSTALL_BORINGSSL}" ]; then
 fi
 
 if [ ! -z "${INSTALL_AWSLC}" ]; then
-    (cd ${HOME} && git clone --depth 1 --branch v1.42.0 https://github.com/aws/aws-lc.git &&
+    (cd ${HOME} && git clone --depth 1 --branch v1.46.1 https://github.com/aws/aws-lc.git &&
      cd ${HOME}/aws-lc && mkdir build && cd build &&
-     cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. && ninja &&
-     mkdir -p /opt/aws-lc/lib &&
-     cp ${HOME}/aws-lc/build/crypto/libcrypto.a /opt/aws-lc/lib &&
-     cp -r ${HOME}/aws-lc/include /opt/aws-lc)
+     cmake -GNinja -DCMAKE_INSTALL_PREFIX="/opt/aws-lc" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. && 
+     ninja install)
 fi
 
 if [ ! -z "${INSTALL_ZLIB}" ]; then

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
         # First we test all OSes in the default configuration.
         target:
           - ubuntu-20.04
-          - ubuntu-22.04
+          # - ubuntu-22.04
           # - macos-13
           # - macos-14
           # - macos-15

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,95 +17,95 @@ jobs:
         target:
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-13
-          - macos-14
-          - macos-15
-          - windows-2019
-          - windows-2022
+          # - macos-13
+          # - macos-14
+          # - macos-15
+          # - windows-2019
+          # - windows-2022
         config: [default]
         # Then we include any extra configs we want to test for specific VMs.
         # Valgrind slows things down quite a bit, so start them first.
         include:
-          - { target: windows-2019, config: cygwin-release }
-          - { target: windows-2022, config: cygwin-release }
-          - { target: ubuntu-20.04, config: valgrind-1 }
-          - { target: ubuntu-20.04, config: valgrind-2 }
-          - { target: ubuntu-20.04, config: valgrind-3 }
-          - { target: ubuntu-20.04, config: valgrind-4 }
-          - { target: ubuntu-20.04, config: valgrind-unit }
-          - { target: ubuntu-20.04, config: c89 }
-          - { target: ubuntu-20.04, config: clang-6.0 }
-          - { target: ubuntu-20.04, config: clang-8 }
-          - { target: ubuntu-20.04, config: clang-9 }
-          - { target: ubuntu-20.04, config: clang-10 }
-          - { target: ubuntu-20.04, config: clang-11 }
-          - { target: ubuntu-20.04, config: clang-12-Werror }
-          - { target: ubuntu-20.04, config: clang-sanitize-address }
-          - { target: ubuntu-20.04, config: clang-sanitize-undefined }
-          - { target: ubuntu-20.04, config: gcc-sanitize-address }
-          - { target: ubuntu-20.04, config: gcc-sanitize-undefined }
-          - { target: ubuntu-20.04, config: gcc-7 }
-          - { target: ubuntu-20.04, config: gcc-8 }
-          - { target: ubuntu-20.04, config: gcc-10 }
-          - { target: ubuntu-22.04, config: gcc-11-Werror }
-          - { target: ubuntu-22.04, config: gcc-12-Werror }
-          - { target: ubuntu-20.04, config: pam }
-          - { target: ubuntu-20.04, config: kitchensink }
-          - { target: ubuntu-22.04, config: hardenedmalloc }
-          - { target: ubuntu-20.04, config: tcmalloc }
-          - { target: ubuntu-20.04, config: musl }
-          - { target: ubuntu-latest, config: boringssl }
+          # - { target: windows-2019, config: cygwin-release }
+          # - { target: windows-2022, config: cygwin-release }
+          # - { target: ubuntu-20.04, config: valgrind-1 }
+          # - { target: ubuntu-20.04, config: valgrind-2 }
+          # - { target: ubuntu-20.04, config: valgrind-3 }
+          # - { target: ubuntu-20.04, config: valgrind-4 }
+          # - { target: ubuntu-20.04, config: valgrind-unit }
+          # - { target: ubuntu-20.04, config: c89 }
+          # - { target: ubuntu-20.04, config: clang-6.0 }
+          # - { target: ubuntu-20.04, config: clang-8 }
+          # - { target: ubuntu-20.04, config: clang-9 }
+          # - { target: ubuntu-20.04, config: clang-10 }
+          # - { target: ubuntu-20.04, config: clang-11 }
+          # - { target: ubuntu-20.04, config: clang-12-Werror }
+          # - { target: ubuntu-20.04, config: clang-sanitize-address }
+          # - { target: ubuntu-20.04, config: clang-sanitize-undefined }
+          # - { target: ubuntu-20.04, config: gcc-sanitize-address }
+          # - { target: ubuntu-20.04, config: gcc-sanitize-undefined }
+          # - { target: ubuntu-20.04, config: gcc-7 }
+          # - { target: ubuntu-20.04, config: gcc-8 }
+          # - { target: ubuntu-20.04, config: gcc-10 }
+          # - { target: ubuntu-22.04, config: gcc-11-Werror }
+          # - { target: ubuntu-22.04, config: gcc-12-Werror }
+          # - { target: ubuntu-20.04, config: pam }
+          # - { target: ubuntu-20.04, config: kitchensink }
+          # - { target: ubuntu-22.04, config: hardenedmalloc }
+          # - { target: ubuntu-20.04, config: tcmalloc }
+          # - { target: ubuntu-20.04, config: musl }
+          # - { target: ubuntu-latest, config: boringssl }
           - { target: ubuntu-latest, config: aws-lc }
-          - { target: ubuntu-latest, config: libressl-master }
-          - { target: ubuntu-latest, config: libressl-3.2.6 }
-          - { target: ubuntu-latest, config: libressl-3.3.6 }
-          - { target: ubuntu-latest, config: libressl-3.4.3 }
-          - { target: ubuntu-latest, config: libressl-3.5.3 }
-          - { target: ubuntu-latest, config: libressl-3.6.1 }
-          - { target: ubuntu-latest, config: libressl-3.7.2 }
-          - { target: ubuntu-latest, config: libressl-3.8.4 }
-          - { target: ubuntu-latest, config: libressl-3.9.2 }
-          - { target: ubuntu-latest, config: libressl-4.0.0 }
-          - { target: ubuntu-latest, config: openssl-master }
-          - { target: ubuntu-latest, config: openssl-noec }
-          - { target: ubuntu-latest, config: openssl-1.1.1 }
-          - { target: ubuntu-latest, config: openssl-1.1.1t }
-          - { target: ubuntu-latest, config: openssl-1.1.1w }
-          - { target: ubuntu-latest, config: openssl-3.0.0 }
-          - { target: ubuntu-latest, config: openssl-3.0.15 }
-          - { target: ubuntu-latest, config: openssl-3.1.0 }
-          - { target: ubuntu-latest, config: openssl-3.1.7 }
-          - { target: ubuntu-latest, config: openssl-3.2.3 }
-          - { target: ubuntu-latest, config: openssl-3.3.2 }
-          - { target: ubuntu-latest, config: openssl-3.4.0 }
-          - { target: ubuntu-latest, config: openssl-1.1.1_stable }
-          - { target: ubuntu-latest, config: openssl-3.0 }  # stable branch
-          - { target: ubuntu-latest, config: openssl-3.1 }  # stable branch
-          - { target: ubuntu-latest, config: openssl-3.2 }  # stable branch
-          - { target: ubuntu-latest, config: openssl-3.3 }  # stable branch
-          - { target: ubuntu-latest, config: putty-0.71 }
-          - { target: ubuntu-latest, config: putty-0.72 }
-          - { target: ubuntu-latest, config: putty-0.73 }
-          - { target: ubuntu-latest, config: putty-0.74 }
-          - { target: ubuntu-latest, config: putty-0.75 }
-          - { target: ubuntu-latest, config: putty-0.76 }
-          - { target: ubuntu-latest, config: putty-0.77 }
-          - { target: ubuntu-latest, config: putty-0.78 }
-          - { target: ubuntu-latest, config: putty-0.79 }
-          - { target: ubuntu-latest, config: putty-0.80 }
-          - { target: ubuntu-latest, config: putty-snapshot }
-          - { target: ubuntu-latest, config: zlib-develop }
-          - { target: ubuntu-22.04, config: pam }
-          - { target: ubuntu-22.04, config: krb5 }
-          - { target: ubuntu-22.04, config: heimdal }
-          - { target: ubuntu-22.04, config: libedit }
-          - { target: ubuntu-22.04, config: sk }
-          - { target: ubuntu-22.04, config: selinux }
-          - { target: ubuntu-22.04, config: kitchensink }
-          - { target: ubuntu-22.04, config: without-openssl }
-          - { target: macos-13, config: pam }
-          - { target: macos-14, config: pam }
-          - { target: macos-15, config: pam }
+          # - { target: ubuntu-latest, config: libressl-master }
+          # - { target: ubuntu-latest, config: libressl-3.2.6 }
+          # - { target: ubuntu-latest, config: libressl-3.3.6 }
+          # - { target: ubuntu-latest, config: libressl-3.4.3 }
+          # - { target: ubuntu-latest, config: libressl-3.5.3 }
+          # - { target: ubuntu-latest, config: libressl-3.6.1 }
+          # - { target: ubuntu-latest, config: libressl-3.7.2 }
+          # - { target: ubuntu-latest, config: libressl-3.8.4 }
+          # - { target: ubuntu-latest, config: libressl-3.9.2 }
+          # - { target: ubuntu-latest, config: libressl-4.0.0 }
+          # - { target: ubuntu-latest, config: openssl-master }
+          # - { target: ubuntu-latest, config: openssl-noec }
+          # - { target: ubuntu-latest, config: openssl-1.1.1 }
+          # - { target: ubuntu-latest, config: openssl-1.1.1t }
+          # - { target: ubuntu-latest, config: openssl-1.1.1w }
+          # - { target: ubuntu-latest, config: openssl-3.0.0 }
+          # - { target: ubuntu-latest, config: openssl-3.0.15 }
+          # - { target: ubuntu-latest, config: openssl-3.1.0 }
+          # - { target: ubuntu-latest, config: openssl-3.1.7 }
+          # - { target: ubuntu-latest, config: openssl-3.2.3 }
+          # - { target: ubuntu-latest, config: openssl-3.3.2 }
+          # - { target: ubuntu-latest, config: openssl-3.4.0 }
+          # - { target: ubuntu-latest, config: openssl-1.1.1_stable }
+          # - { target: ubuntu-latest, config: openssl-3.0 }  # stable branch
+          # - { target: ubuntu-latest, config: openssl-3.1 }  # stable branch
+          # - { target: ubuntu-latest, config: openssl-3.2 }  # stable branch
+          # - { target: ubuntu-latest, config: openssl-3.3 }  # stable branch
+          # - { target: ubuntu-latest, config: putty-0.71 }
+          # - { target: ubuntu-latest, config: putty-0.72 }
+          # - { target: ubuntu-latest, config: putty-0.73 }
+          # - { target: ubuntu-latest, config: putty-0.74 }
+          # - { target: ubuntu-latest, config: putty-0.75 }
+          # - { target: ubuntu-latest, config: putty-0.76 }
+          # - { target: ubuntu-latest, config: putty-0.77 }
+          # - { target: ubuntu-latest, config: putty-0.78 }
+          # - { target: ubuntu-latest, config: putty-0.79 }
+          # - { target: ubuntu-latest, config: putty-0.80 }
+          # - { target: ubuntu-latest, config: putty-snapshot }
+          # - { target: ubuntu-latest, config: zlib-develop }
+          # - { target: ubuntu-22.04, config: pam }
+          # - { target: ubuntu-22.04, config: krb5 }
+          # - { target: ubuntu-22.04, config: heimdal }
+          # - { target: ubuntu-22.04, config: libedit }
+          # - { target: ubuntu-22.04, config: sk }
+          # - { target: ubuntu-22.04, config: selinux }
+          # - { target: ubuntu-22.04, config: kitchensink }
+          # - { target: ubuntu-22.04, config: without-openssl }
+          # - { target: macos-13, config: pam }
+          # - { target: macos-14, config: pam }
+          # - { target: macos-15, config: pam }
     runs-on: ${{ matrix.target }}
     steps:
     - name: set cygwin git params

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,96 +16,96 @@ jobs:
         # First we test all OSes in the default configuration.
         target:
           - ubuntu-20.04
-          # - ubuntu-22.04
-          # - macos-13
-          # - macos-14
-          # - macos-15
-          # - windows-2019
-          # - windows-2022
+          - ubuntu-22.04
+          - macos-13
+          - macos-14
+          - macos-15
+          - windows-2019
+          - windows-2022
         config: [default]
         # Then we include any extra configs we want to test for specific VMs.
         # Valgrind slows things down quite a bit, so start them first.
         include:
-          # - { target: windows-2019, config: cygwin-release }
-          # - { target: windows-2022, config: cygwin-release }
-          # - { target: ubuntu-20.04, config: valgrind-1 }
-          # - { target: ubuntu-20.04, config: valgrind-2 }
-          # - { target: ubuntu-20.04, config: valgrind-3 }
-          # - { target: ubuntu-20.04, config: valgrind-4 }
-          # - { target: ubuntu-20.04, config: valgrind-unit }
-          # - { target: ubuntu-20.04, config: c89 }
-          # - { target: ubuntu-20.04, config: clang-6.0 }
-          # - { target: ubuntu-20.04, config: clang-8 }
-          # - { target: ubuntu-20.04, config: clang-9 }
-          # - { target: ubuntu-20.04, config: clang-10 }
-          # - { target: ubuntu-20.04, config: clang-11 }
-          # - { target: ubuntu-20.04, config: clang-12-Werror }
-          # - { target: ubuntu-20.04, config: clang-sanitize-address }
-          # - { target: ubuntu-20.04, config: clang-sanitize-undefined }
-          # - { target: ubuntu-20.04, config: gcc-sanitize-address }
-          # - { target: ubuntu-20.04, config: gcc-sanitize-undefined }
-          # - { target: ubuntu-20.04, config: gcc-7 }
-          # - { target: ubuntu-20.04, config: gcc-8 }
-          # - { target: ubuntu-20.04, config: gcc-10 }
-          # - { target: ubuntu-22.04, config: gcc-11-Werror }
-          # - { target: ubuntu-22.04, config: gcc-12-Werror }
-          # - { target: ubuntu-20.04, config: pam }
-          # - { target: ubuntu-20.04, config: kitchensink }
-          # - { target: ubuntu-22.04, config: hardenedmalloc }
-          # - { target: ubuntu-20.04, config: tcmalloc }
-          # - { target: ubuntu-20.04, config: musl }
-          # - { target: ubuntu-latest, config: boringssl }
+          - { target: windows-2019, config: cygwin-release }
+          - { target: windows-2022, config: cygwin-release }
+          - { target: ubuntu-20.04, config: valgrind-1 }
+          - { target: ubuntu-20.04, config: valgrind-2 }
+          - { target: ubuntu-20.04, config: valgrind-3 }
+          - { target: ubuntu-20.04, config: valgrind-4 }
+          - { target: ubuntu-20.04, config: valgrind-unit }
+          - { target: ubuntu-20.04, config: c89 }
+          - { target: ubuntu-20.04, config: clang-6.0 }
+          - { target: ubuntu-20.04, config: clang-8 }
+          - { target: ubuntu-20.04, config: clang-9 }
+          - { target: ubuntu-20.04, config: clang-10 }
+          - { target: ubuntu-20.04, config: clang-11 }
+          - { target: ubuntu-20.04, config: clang-12-Werror }
+          - { target: ubuntu-20.04, config: clang-sanitize-address }
+          - { target: ubuntu-20.04, config: clang-sanitize-undefined }
+          - { target: ubuntu-20.04, config: gcc-sanitize-address }
+          - { target: ubuntu-20.04, config: gcc-sanitize-undefined }
+          - { target: ubuntu-20.04, config: gcc-7 }
+          - { target: ubuntu-20.04, config: gcc-8 }
+          - { target: ubuntu-20.04, config: gcc-10 }
+          - { target: ubuntu-22.04, config: gcc-11-Werror }
+          - { target: ubuntu-22.04, config: gcc-12-Werror }
+          - { target: ubuntu-20.04, config: pam }
+          - { target: ubuntu-20.04, config: kitchensink }
+          - { target: ubuntu-22.04, config: hardenedmalloc }
+          - { target: ubuntu-20.04, config: tcmalloc }
+          - { target: ubuntu-20.04, config: musl }
+          - { target: ubuntu-latest, config: boringssl }
           - { target: ubuntu-latest, config: aws-lc }
-          # - { target: ubuntu-latest, config: libressl-master }
-          # - { target: ubuntu-latest, config: libressl-3.2.6 }
-          # - { target: ubuntu-latest, config: libressl-3.3.6 }
-          # - { target: ubuntu-latest, config: libressl-3.4.3 }
-          # - { target: ubuntu-latest, config: libressl-3.5.3 }
-          # - { target: ubuntu-latest, config: libressl-3.6.1 }
-          # - { target: ubuntu-latest, config: libressl-3.7.2 }
-          # - { target: ubuntu-latest, config: libressl-3.8.4 }
-          # - { target: ubuntu-latest, config: libressl-3.9.2 }
-          # - { target: ubuntu-latest, config: libressl-4.0.0 }
-          # - { target: ubuntu-latest, config: openssl-master }
-          # - { target: ubuntu-latest, config: openssl-noec }
-          # - { target: ubuntu-latest, config: openssl-1.1.1 }
-          # - { target: ubuntu-latest, config: openssl-1.1.1t }
-          # - { target: ubuntu-latest, config: openssl-1.1.1w }
-          # - { target: ubuntu-latest, config: openssl-3.0.0 }
-          # - { target: ubuntu-latest, config: openssl-3.0.15 }
-          # - { target: ubuntu-latest, config: openssl-3.1.0 }
-          # - { target: ubuntu-latest, config: openssl-3.1.7 }
-          # - { target: ubuntu-latest, config: openssl-3.2.3 }
-          # - { target: ubuntu-latest, config: openssl-3.3.2 }
-          # - { target: ubuntu-latest, config: openssl-3.4.0 }
-          # - { target: ubuntu-latest, config: openssl-1.1.1_stable }
-          # - { target: ubuntu-latest, config: openssl-3.0 }  # stable branch
-          # - { target: ubuntu-latest, config: openssl-3.1 }  # stable branch
-          # - { target: ubuntu-latest, config: openssl-3.2 }  # stable branch
-          # - { target: ubuntu-latest, config: openssl-3.3 }  # stable branch
-          # - { target: ubuntu-latest, config: putty-0.71 }
-          # - { target: ubuntu-latest, config: putty-0.72 }
-          # - { target: ubuntu-latest, config: putty-0.73 }
-          # - { target: ubuntu-latest, config: putty-0.74 }
-          # - { target: ubuntu-latest, config: putty-0.75 }
-          # - { target: ubuntu-latest, config: putty-0.76 }
-          # - { target: ubuntu-latest, config: putty-0.77 }
-          # - { target: ubuntu-latest, config: putty-0.78 }
-          # - { target: ubuntu-latest, config: putty-0.79 }
-          # - { target: ubuntu-latest, config: putty-0.80 }
-          # - { target: ubuntu-latest, config: putty-snapshot }
-          # - { target: ubuntu-latest, config: zlib-develop }
-          # - { target: ubuntu-22.04, config: pam }
-          # - { target: ubuntu-22.04, config: krb5 }
-          # - { target: ubuntu-22.04, config: heimdal }
-          # - { target: ubuntu-22.04, config: libedit }
-          # - { target: ubuntu-22.04, config: sk }
-          # - { target: ubuntu-22.04, config: selinux }
-          # - { target: ubuntu-22.04, config: kitchensink }
-          # - { target: ubuntu-22.04, config: without-openssl }
-          # - { target: macos-13, config: pam }
-          # - { target: macos-14, config: pam }
-          # - { target: macos-15, config: pam }
+          - { target: ubuntu-latest, config: libressl-master }
+          - { target: ubuntu-latest, config: libressl-3.2.6 }
+          - { target: ubuntu-latest, config: libressl-3.3.6 }
+          - { target: ubuntu-latest, config: libressl-3.4.3 }
+          - { target: ubuntu-latest, config: libressl-3.5.3 }
+          - { target: ubuntu-latest, config: libressl-3.6.1 }
+          - { target: ubuntu-latest, config: libressl-3.7.2 }
+          - { target: ubuntu-latest, config: libressl-3.8.4 }
+          - { target: ubuntu-latest, config: libressl-3.9.2 }
+          - { target: ubuntu-latest, config: libressl-4.0.0 }
+          - { target: ubuntu-latest, config: openssl-master }
+          - { target: ubuntu-latest, config: openssl-noec }
+          - { target: ubuntu-latest, config: openssl-1.1.1 }
+          - { target: ubuntu-latest, config: openssl-1.1.1t }
+          - { target: ubuntu-latest, config: openssl-1.1.1w }
+          - { target: ubuntu-latest, config: openssl-3.0.0 }
+          - { target: ubuntu-latest, config: openssl-3.0.15 }
+          - { target: ubuntu-latest, config: openssl-3.1.0 }
+          - { target: ubuntu-latest, config: openssl-3.1.7 }
+          - { target: ubuntu-latest, config: openssl-3.2.3 }
+          - { target: ubuntu-latest, config: openssl-3.3.2 }
+          - { target: ubuntu-latest, config: openssl-3.4.0 }
+          - { target: ubuntu-latest, config: openssl-1.1.1_stable }
+          - { target: ubuntu-latest, config: openssl-3.0 }  # stable branch
+          - { target: ubuntu-latest, config: openssl-3.1 }  # stable branch
+          - { target: ubuntu-latest, config: openssl-3.2 }  # stable branch
+          - { target: ubuntu-latest, config: openssl-3.3 }  # stable branch
+          - { target: ubuntu-latest, config: putty-0.71 }
+          - { target: ubuntu-latest, config: putty-0.72 }
+          - { target: ubuntu-latest, config: putty-0.73 }
+          - { target: ubuntu-latest, config: putty-0.74 }
+          - { target: ubuntu-latest, config: putty-0.75 }
+          - { target: ubuntu-latest, config: putty-0.76 }
+          - { target: ubuntu-latest, config: putty-0.77 }
+          - { target: ubuntu-latest, config: putty-0.78 }
+          - { target: ubuntu-latest, config: putty-0.79 }
+          - { target: ubuntu-latest, config: putty-0.80 }
+          - { target: ubuntu-latest, config: putty-snapshot }
+          - { target: ubuntu-latest, config: zlib-develop }
+          - { target: ubuntu-22.04, config: pam }
+          - { target: ubuntu-22.04, config: krb5 }
+          - { target: ubuntu-22.04, config: heimdal }
+          - { target: ubuntu-22.04, config: libedit }
+          - { target: ubuntu-22.04, config: sk }
+          - { target: ubuntu-22.04, config: selinux }
+          - { target: ubuntu-22.04, config: kitchensink }
+          - { target: ubuntu-22.04, config: without-openssl }
+          - { target: macos-13, config: pam }
+          - { target: macos-14, config: pam }
+          - { target: macos-15, config: pam }
     runs-on: ${{ matrix.target }}
     steps:
     - name: set cygwin git params


### PR DESCRIPTION
Debugging changes from bz3784. The AWS-LC CI is failing on the make tests step. We do not see this in our CI when building AWS-LC with OpenSSH - investigating the root cause. 

Updates: 
- Updating the ubuntu machine to 22.04 fixed the issue
- We are tripping up the seccomp filter in ubuntu 24.04 with syscall 21 (access)

Update (02/17/2025): 
We are continuing to look into alternatives for the "access" syscall and root causing why the seccomp filter only tripped up on Ubuntu 24.04 and not 22.04. 