### PR TITLE
Pass -oControlMaster=no in scp

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -505,6 +505,7 @@ main(int argc, char **argv)
 	addargs(&args, "-oClearAllForwardings=yes");
 	addargs(&args, "-oRemoteCommand=none");
 	addargs(&args, "-oRequestTTY=no");
+	addargs(&args, "-oControlMaster=no");
 
 	fflag = Tflag = tflag = 0;
 	while ((ch = getopt(argc, argv,


### PR DESCRIPTION
Otherwise, some options (I noticed particularly ForwardAgent=no) will get applied across all future sessions on that control socket if the user has configured ControlMaster=auto for that host and we happen to be the session to start the socket.

I'm not 100% sure if I picked the right place to put this; maybe it belongs after ForwardAgent=no is appended later.