### PR TITLE
Adjust X11 display search range to support larger x11_display_offset values

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -5010,7 +5010,7 @@ x11_create_display_inet(struct ssh *ssh, int x11_display_offset,
 		return -1;
 
 	for (display_number = x11_display_offset;
-	    display_number < MAX_DISPLAYS;
+	    display_number < x11_display_offset + MAX_DISPLAYS;
 	    display_number++) {
 		port = X11_BASE_PORT + display_number;
 		memset(&hints, 0, sizeof(hints));
@@ -5065,7 +5065,7 @@ x11_create_display_inet(struct ssh *ssh, int x11_display_offset,
 		if (num_socks > 0)
 			break;
 	}
-	if (display_number >= MAX_DISPLAYS) {
+	if (display_number >= x11_display_offset + MAX_DISPLAYS) {
 		error("Failed to allocate internet-domain X11 display socket.");
 		return -1;
 	}


### PR DESCRIPTION
**Description:**
This pull request modifies the X11 display search logic in x11_create_display_inet to allow the x11_display_offset parameter to exceed 1000, addressing a limitation in the current implementation.
**Problem**
Currently, setting x11_display_offset to a value greater than 1000 prevents the function from entering the for loop, as the condition display_number < MAX_DISPLAYS (where MAX_DISPLAYS is 1000) fails immediately. Execution then proceeds to the check if (display_number >= MAX_DISPLAYS), resulting in an error: "Failed to allocate internet-domain X11 display socket." This behavior is incorrect because it unnecessarily restricts the usable range of x11_display_offset, limiting the port range to 6000–7000.
**Solution**
The changes in this PR adjust the loop condition from display_number < MAX_DISPLAYS to display_number < x11_display_offset + MAX_DISPLAYS, and update the subsequent check accordingly. This ensures the loop iterates over a range of MAX_DISPLAYS (1000) displays starting from x11_display_offset, rather than being capped at a fixed maximum of 1000. As a result, users can specify a higher x11_display_offset to select a more convenient port range (e.g., beyond 7000).
**Safety**
The modification is safe because the existing check x11_display_offset > UINT16_MAX - X11_BASE_PORT - MAX_DISPLAYS already enforces an upper bound. For X11_BASE_PORT = 6000 and MAX_DISPLAYS = 1000, this limits x11_display_offset to 58535, ensuring the maximum port (6000 + 58535 + 999 = 65534) stays within the valid range of 65535. Thus, these changes align with the existing safety constraints while improving flexibility.
**Benefits**
This adjustment allows users to configure x11_display_offset more freely, enabling X11 forwarding on a broader and more customizable range of ports, rather than being restricted to 6000–7000.
Let me know if further clarification or adjustments are needed!