### PR TITLE
Added option to manually specify key exchange banner for sshd

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -1233,7 +1233,7 @@ send_error(struct ssh *ssh, char *msg)
  */
 int
 kex_exchange_identification(struct ssh *ssh, int timeout_ms,
-    const char *version_addendum)
+    const char *version_addendum, const char *banner_override)
 {
 	int remote_major, remote_minor, mismatch, oerrno = 0;
 	size_t len, n;
@@ -1250,10 +1250,10 @@ kex_exchange_identification(struct ssh *ssh, int timeout_ms,
 	sshbuf_reset(our_version);
 	if (version_addendum != NULL && *version_addendum == '\0')
 		version_addendum = NULL;
-	if ((r = sshbuf_putf(our_version, "SSH-%d.%d-%s%s%s\r\n",
+	if ((r = banner_override == NULL ? sshbuf_putf(our_version, "SSH-%d.%d-%s%s%s\r\n",
 	    PROTOCOL_MAJOR_2, PROTOCOL_MINOR_2, SSH_VERSION,
 	    version_addendum == NULL ? "" : " ",
-	    version_addendum == NULL ? "" : version_addendum)) != 0) {
+	    version_addendum == NULL ? "" : version_addendum) : sshbuf_putf(our_version, "SSH-%d.%d-%s\r\n", PROTOCOL_MAJOR_2, PROTOCOL_MINOR_2, banner_override)) != 0) {
 		oerrno = errno;
 		error_fr(r, "sshbuf_putf");
 		goto out;

--- a/kex.h
+++ b/kex.h
@@ -198,7 +198,7 @@ void	 kex_proposal_populate_entries(struct ssh *, char *prop[PROPOSAL_MAX],
     const char *, const char *, const char *, const char *, const char *);
 void	 kex_proposal_free_entries(char *prop[PROPOSAL_MAX]);
 
-int	 kex_exchange_identification(struct ssh *, int, const char *);
+int	 kex_exchange_identification(struct ssh *, int, const char *, const char *);
 
 struct kex *kex_new(void);
 int	 kex_ready(struct ssh *, char *[PROPOSAL_MAX]);

--- a/servconf.c
+++ b/servconf.c
@@ -217,6 +217,7 @@ initialize_server_options(ServerOptions *options)
 	options->sshd_session_path = NULL;
 	options->sshd_auth_path = NULL;
 	options->refuse_connection = -1;
+	options->banner_override = NULL;
 }
 
 /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
@@ -582,7 +583,7 @@ typedef enum {
 	sExposeAuthInfo, sRDomain, sPubkeyAuthOptions, sSecurityKeyProvider,
 	sRequiredRSASize, sChannelTimeout, sUnusedConnectionTimeout,
 	sSshdSessionPath, sSshdAuthPath, sRefuseConnection,
-	sDeprecated, sIgnore, sUnsupported
+	sDeprecated, sIgnore, sUnsupported, sBannerOverride
 } ServerOpCodes;
 
 #define SSHCFG_GLOBAL		0x01	/* allowed in main section of config */
@@ -751,6 +752,7 @@ static struct {
 	{ "sshdsessionpath", sSshdSessionPath, SSHCFG_GLOBAL },
 	{ "sshdauthpath", sSshdAuthPath, SSHCFG_GLOBAL },
 	{ "refuseconnection", sRefuseConnection, SSHCFG_ALL },
+	{ "banneroverride", sBannerOverride, SSHCFG_ALL },
 	{ NULL, sBadOption, 0 }
 };
 
@@ -2729,6 +2731,14 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 		multistate_ptr = multistate_flag;
 		goto parse_multistate;
 
+	case sBannerOverride:
+		charptr = &options->banner_override;
+		len = strspn(str, WHITESPACE);
+		if (*activep && *charptr == NULL)
+			*charptr = xstrdup(str + len);
+		argv_consume(&ac);
+		break;
+
 	case sDeprecated:
 	case sIgnore:
 	case sUnsupported:
@@ -3313,6 +3323,7 @@ dump_config(ServerOptions *o)
 	dump_cfg_string(sSshdSessionPath, o->sshd_session_path);
 	dump_cfg_string(sSshdAuthPath, o->sshd_auth_path);
 	dump_cfg_string(sPerSourcePenaltyExemptList, o->per_source_penalty_exempt);
+	dump_cfg_string(sBannerOverride, o->banner_override);
 
 	/* string arguments requiring a lookup */
 	dump_cfg_string(sLogLevel, log_level_name(o->log_level));

--- a/servconf.h
+++ b/servconf.h
@@ -252,6 +252,8 @@ typedef struct {
 	char   *sshd_auth_path;
 
 	int	refuse_connection;
+
+	char	*banner_override;
 }       ServerOptions;
 
 /* Information about the incoming connection as used by Match */

--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1605,7 +1605,7 @@ ssh_login(struct ssh *ssh, Sensitive *sensitive, const char *orighost,
 
 	/* Exchange protocol version identification strings with the server. */
 	if ((r = kex_exchange_identification(ssh, timeout_ms,
-	    options.version_addendum)) != 0)
+	    options.version_addendum, NULL)) != 0)
 		sshpkt_fatal(ssh, r, "banner exchange");
 
 	/* Put the connection into non-blocking mode. */

--- a/sshd-session.c
+++ b/sshd-session.c
@@ -1269,7 +1269,7 @@ main(int ac, char **av)
 	}
 
 	if ((r = kex_exchange_identification(ssh, -1,
-	    options.version_addendum)) != 0)
+	    options.version_addendum, options.banner_override)) != 0)
 		sshpkt_fatal(ssh, r, "banner exchange");
 
 	ssh_packet_set_nonblocking(ssh);

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -629,6 +629,8 @@ or
 .Cm no .
 The default is
 .Cm yes .
+.It Cm BannerOverride
+Specifies a different version banner to be used during key exchange (server-only).
 .It Cm DenyGroups
 This keyword can be followed by a list of group name patterns, separated
 by spaces.


### PR DESCRIPTION
### The Problem
SSH key exchange identification works in such a way that as soon as a TCP connection is established, the SSH server writes its key exchange banner in the TCP connection. This (according to RFC 4253) always follows the following pattern `SSH-protoversion-softwareversion SP comments CR LF`. In the case of OpenSSH this translates to `SSH-2.0-OpenSSH_<version><CR><LF>`. This however makes it trivial to enumerate the SSH server being OpenSSH as well as its exact version. This makes servers which are running older versions and therefore may be lacking security fixes easy to detect and these servers may be targeted by automated attack scripts as a result. In addition, it may allow others to build a profile on your updating habits.
As a result, some users may want to specify a custom key exchange banner in order to not propagate the server software in its exact version.

### The Solution
This patch proposes the addition of a new `BannerOverride` config key in the sshd_config. If this key is set, the key exchange identification banner will be replaced by whatever value BannerOverride holds. (e.g. `SSH-2.0-Foobar<CR><LF>`). There is no change to the current behavior if the key is unset.