### PR TITLE
Include fcntl.h so AT_FDCWD does not get redefined.

### DIFF
--- a/includes.h
+++ b/includes.h
@@ -49,6 +49,9 @@
 #ifdef HAVE_PATHS_H
 # include <paths.h>
 #endif
+#ifdef HAVE_FCNTL_H
+# include <fcntl.h> /* For AT_FDCWD */
+#endif
 
 /*
  *-*-nto-qnx needs these headers for strcasecmp and LASTLOG_FILE respectively


### PR DESCRIPTION
The bsd-misc.h header will define AT_FDCWD and implement the *at functions to set `errno = ENOSYS`, which is reasonable on systems lacking them.

However, before defining AT_FDCWD, <fcntl.h> should be included where POSIX requires it to be defined [1].

The following GCC warning should make things clear:
```
In file included from port-net.c:27:
/usr/include/fcntl.h:149:10: warning: "AT_FDCWD" redefined
  149 | # define AT_FDCWD               -100    /* Special value used to indicate
      |          ^~~~~~~~
In file included from ../openbsd-compat/openbsd-compat.h:218:
../openbsd-compat/bsd-misc.h:69:10: note: this is the location of the previous definition
   69 | # define AT_FDCWD (-2)
      |          ^~~~~~~~
```

configure.ac already has AC_CHECK_HEADERS([fcntl.h]), so just adding the include fixes it.

[1] https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fcntl.h.html