### PR TITLE
Provide better error for non-supported private keys

### DIFF
--- a/sshkey.c
+++ b/sshkey.c
@@ -3476,6 +3476,8 @@ translate_libcrypto_error(unsigned long pem_err)
 		}
 	case ERR_LIB_ASN1:
 		return SSH_ERR_INVALID_FORMAT;
+	case ERR_LIB_OSSL_DECODER:
+		return SSH_ERR_INVALID_FORMAT;
 	}
 	return SSH_ERR_LIBCRYPTO_ERROR;
 }


### PR DESCRIPTION
If I try to use a PuTTY key (".ppk" format) ssh prints the following error:
```
debug1: Trying private key: ./test.ppk
Load key "./test.ppk": error in libcrypto
```
after some analysis it seems that when using unsupported private key the following call to `PEM_read_bio_PrivateKey` fails:
https://github.com/openssh/openssh-portable/blob/master/sshkey.c#L3544
returned error is of type `ERR_GET_LIB(pem_err) = ERR_LIB_OSSL_DECODER`.
In `translate_libcrypto_error()` function this type of error is unrecognized and will default to `SSH_ERR_LIBCRYPTO_ERROR`.
This patch changes the error output to:
```
debug1: Trying private key: ./test.ppk
Load key "./test.ppk": invalid format
```