### PR TITLE
ssh-agent: exit 0 from SIGTERM under systemd socket-activation

### DIFF
--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -2238,6 +2238,7 @@ main(int ac, char **av)
 	size_t npfd = 0;
 	u_int maxfds;
 	sigset_t nsigset, osigset;
+	int socket_activated = 0;
 
 	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null */
 	sanitise_stdfd();
@@ -2389,6 +2390,7 @@ main(int ac, char **av)
 			fatal("bad LISTEN_PID: %d vs pid %d", pid, getpid());
 		debug("using socket activation on fd=3");
 		sock = 3;
+		socket_activated = 1;
 	}
 
 	/* Otherwise, create private directory for agent socket */
@@ -2522,7 +2524,7 @@ skip:
 		sigprocmask(SIG_BLOCK, &nsigset, &osigset);
 		if (signalled_exit != 0) {
 			logit("exiting on signal %d", (int)signalled_exit);
-			cleanup_exit(2);
+			cleanup_exit((signalled_exit == SIGTERM && socket_activated) ? 0 : 2);
 		}
 		if (signalled_keydrop) {
 			logit("signal %d received; removing all keys",


### PR DESCRIPTION
When the ssh-agent service is configured to be launched under systemd socket-activation, the user can inspect the status of the agent with something like:

    systemctl --user status ssh-agent.service

If the user does:

    systemctl --user stop ssh-agent.service

it causes the `systemd --user` supervisor to send a SIGTERM to the agent, which terminates while leaving the systemd-managed socket in place.  That's good, and as expected. (If the user wants to close the socket, they can do "systemctl --user stop ssh-agent.socket" instead)

But because ssh-agent exits with code 2 in response to a SIGTERM, the supervisor marks the service as "failed", even though the state of the supervised service is exactly the same as during session startup (not running, ready to launch when a client connects to the socket).

This change makes ssh-agent exit cleanly (code 0) in response to a SIGTERM when launched under socket activation. This aligns the systemd supervisor's understanding of the state of supervised ssh-agent with reality.

This was also [reported on the mailing list](https://lists.mindrot.org/pipermail/openssh-unix-dev/2025-April/041884.html).