### PR TITLE
Ignore bad hostkeys in known_hosts file

### DIFF
--- a/hostfile.h
+++ b/hostfile.h
@@ -119,5 +119,6 @@ int hostkeys_foreach_file(const char *path, FILE *f,
     const char *host, const char *ip, u_int options, u_int note);
 
 void hostfile_create_user_ssh_dir(const char *, int);
+void hostfile_set_minimum_rsa_size(int);
 
 #endif

--- a/ssh.c
+++ b/ssh.c
@@ -109,6 +109,7 @@
 #include "ssherr.h"
 #include "myproposal.h"
 #include "utf8.h"
+#include "hostfile.h"
 
 #ifdef ENABLE_PKCS11
 #include "ssh-pkcs11.h"
@@ -1386,6 +1387,7 @@ main(int ac, char **av)
 			options.update_hostkeys = 0;
 		}
 	}
+	hostfile_set_minimum_rsa_size(options.required_rsa_size);
 	if (options.connection_attempts <= 0)
 		fatal("Invalid number of ConnectionAttempts");
 


### PR DESCRIPTION
When a short ssh-rsa hostkey is present in known_hosts, the connection will fail with the following error: `Bad server host key: Invalid key length`
What happens is that the ssh-rsa key is found in known_hosts file and is picked as prefered keyalg. Then when server sends its short rsa key, the verify_hostkey check fails and the error is printed. The connection fails even if valid keys are present on the server.

This patch changes the behavior to ignore bad hostkeys when scanning known_hosts file. The result is that a helpful message is printed into debug (example: `debug2: record_hostkey: /root/.ssh/known_hosts:1: ignoring hostkey: Invalid key length`) and the connection can be established by accepting new keys.