### PR TITLE
Specify the default for MaxStartups later in the text

### DIFF
--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1367,11 +1367,11 @@ SSH daemon.
 Additional connections will be dropped until authentication succeeds or the
 .Cm LoginGraceTime
 expires for a connection.
-The default is 10:30:100.
 .Pp
 Alternatively, random early drop can be enabled by specifying
 the three colon separated values
 start:rate:full (e.g. "10:30:60").
+The default is 10:30:100.
 .Xr sshd 8
 will refuse connection attempts with a probability of rate/100 (30%)
 if there are currently start (10) unauthenticated connections.


### PR DESCRIPTION
Hello. While reading about `MaxStartups` in `sshd_config(5)`, I noticed that the first paragraph explains the case where the option has a single value, then specifies the default value which has three numbers, then explains the case where the value has three numbers.

This is a little bit misleading and I think there is room for improvement. For example, the default value could be specified at the end, after the three numbers mode has been explained. This is what the MR does, but maybe it's still not good enough, as there is some redundancy between the example `e.g. "10:30:60"` and the default value which is given immediately afterwards.

(So, take the MR with a grain of salt and feel free to do any other rewording as you see it fits, it's just a way to communicate where is the problem).

Thanks.