### PR TITLE
sshbuf_dup_string: fix incorrect overflow check for l + 1

### DIFF
--- a/sshbuf-misc.c
+++ b/sshbuf-misc.c
@@ -254,7 +254,7 @@ sshbuf_dup_string(struct sshbuf *buf)
 	size_t l = sshbuf_len(buf);
 	char *r;
 
-	if (s == NULL || l > SIZE_MAX)
+	if (s == NULL || l >= SIZE_MAX)
 		return NULL;
 	/* accept a nul only as the last character in the buffer */
 	if (l > 0 && (p = memchr(s, '\0', l)) != NULL) {


### PR DESCRIPTION
This PR removes a dead-code overflow check in sshbuf_dup_string() and replaces it with a correct guard.

**What was wrong**

- l is a size_t; the expression l > SIZE_MAX is always false, so the protection never triggered.
- If l == SIZE_MAX, the expression l + 1 overflows to 0; allocating 0 bytes and then copying l bytes invokes undefined  behavior 

**Alternative considered — remove the length check entirely**

The sshbuf layer already enforces the invariant len <= SSHBUF_SIZE_MAX, so in normal operation l can never reach SIZE_MAX. In principle we could therefore drop the overflow guard and keep only the s == NULL test. 