### PR TITLE
fix memory leak in mux_client_request_stdio_fwd

### DIFF
--- a/mux.c
+++ b/mux.c
@@ -2202,8 +2202,10 @@ mux_client_request_stdio_fwd(int fd)
 	sshbuf_reset(m);
 	if (mux_client_read_packet(fd, m) != 0) {
 		if (errno == EPIPE ||
-		    (errno == EINTR && muxclient_terminate != 0))
+		    (errno == EINTR && muxclient_terminate != 0)) {
+			sshbuf_free(m);
 			return 0;
+		}
 		fatal_f("mux_client_read_packet: %s", strerror(errno));
 	}
 	fatal_f("master returned unexpected message %u", type);


### PR DESCRIPTION
mux_client_request_stdio_fwd() leaked memory: on EPIPE or EINTR after mux_client_read_packet() the function returned early without freeing the sshbuf allocated with sshbuf_new()

Found with SVACE static analyzer