### PR TITLE
mux: fix incorrect return value check in local forward cancellation

### DIFF
--- a/mux.c
+++ b/mux.c
@@ -931,7 +931,7 @@ mux_master_process_close_fwd(struct ssh *ssh, u_int rid,
 	} else {	/* local and dynamic forwards */
 		/* Ditto */
 		if (channel_cancel_lport_listener(ssh, &fwd, fwd.connect_port,
-		    &options.fwd_opts) == -1)
+		    &options.fwd_opts) != 1)
 			error_reason = "port not found";
 	}
 


### PR DESCRIPTION
channel_cancel_lport_listener() returns 1 on success and 0 on failure. The previous code incorrectly checked for `== -1`, a value the function never returns, so failure was not detected and the "port not found" error message was never shown when cancelling dynamic or local port forwards.