### PR TITLE
mdoc2man: support `Ns` inside `Ic`

### DIFF
--- a/mdoc2man.awk
+++ b/mdoc2man.awk
@@ -281,6 +281,12 @@ function add(str) {
 	  add("[")
 	  words[nwords]=words[nwords] "]"
 	}
+	if(match(words[w],"^Ns$")) {
+	  w++
+	  if(!nospace)
+	    nospace=1
+	  sub(" $","",line)
+	}
 	if(match(words[w],"^Ar$")) {
 	  add("\\fI" words[++w] "\\fP")
 	} else if(match(words[w],"^[\\.,]")) {


### PR DESCRIPTION
When encountering an `Ns` mdoc macro ('no space') inside an `Ic` block ('command'), such as for 'lines=number' in ssh-keygen.1, `mdoc2man` just output the macro instead of processing it.

This adds processing for `Ns` when seen inside an `Ic` block.