### PR TITLE
mdoc2man: process `Dl` macros

### DIFF
--- a/mdoc2man.awk
+++ b/mdoc2man.awk
@@ -95,6 +95,8 @@ function add(str) {
     } else if(match(words[w],"^Ed$")) {
       skip=1
       literal=0
+    } else if(match(words[w],"^Dl$")) {
+      skip=1
     } else if(match(words[w],"^Ns$")) {
       skip=1
       if(!nospace)


### PR DESCRIPTION
`Dl` marks a single line as 'literal'. Since we don't output single lines differently in literal vs regular mode (we only insert line breaks for multi-line blocks in literal mode), we can just skip it.