### PR TITLE
ssh-agent: fix file descriptor inheritance (bug #3835)

### DIFF
--- a/ssh-agent.c
+++ b/ssh-agent.c
@@ -2466,8 +2466,6 @@ main(int ac, char **av)
 		umask(prev_mask);
 	}
 
-	closefrom(sock == -1 ? STDERR_FILENO + 1 : sock + 1);
-
 	/*
 	 * Create socket early so it will exist before command gets run from
 	 * the parent.


### PR DESCRIPTION
Remove `closefrom()` call which breaks user-provided command when it relies on inherited file descriptors.
This is a regression introduced in commit 66e9868 which introduces `closefrom()` call closing all file descriptors above stderr (or open socket) which breaks file descriptor inheritance for any processes spawned by ssh-agent, is undocumented behavior, is mismatched from how upstream ssh-agent behaves and has no benefit.

ssh-agent allows specifying arbitrary commands to be run:
1) immediately, conventionally for user session to which the lifetime of ssh-agent is tied to
2) for prompting for passphrases and confirmations using the ssh-askpass protocol

Either of those can rely on pre-opened file descriptors as a means of communication or access control, especially in restricted environments (pledge, capsicum, seccomp-based sandboxes) where arbitrary open() and connect() are not available.
When running user-provided commands it's best practice to change the inherited process state as little as possible.