### PR TITLE
sshconnect: print network errors of every attempt

### DIFF
--- a/sshconnect.c
+++ b/sshconnect.c
@@ -509,7 +509,7 @@ ssh_connect_direct(struct ssh *ssh, const char *host, struct addrinfo *aitop,
 				break;
 			} else {
 				oerrno = errno;
-				debug("connect to address %s port %s: %s",
+				logit("connect to address %s port %s: %s",
 				    ntop, strport, strerror(errno));
 				close(sock);
 				sock = -1;


### PR DESCRIPTION
OpenSSH currently only outputs the error from the last address it has tried, which can be confusing for the user. For instance, if connection is blocked by a firewall on IPv4 and no gateway is set for IPv6, ssh will only display "No route to host" as an error message, hinting to a connectivity issue what is actually a filtering issue.

Printing the error message by default makes it obvious to the user what the problem is, easing debugging and making them more productive as a result.