### PR TITLE
sftp: fix fatal when complete_match() truncates UTF8 multibyte character

### DIFF
--- a/sftp.c
+++ b/sftp.c
@@ -1876,6 +1876,7 @@ complete_ambiguous(const char *word, char **list, size_t count)
 
 	if (count > 0) {
 		u_int y, matchlen = strlen(list[0]);
+		u_int itemlen = matchlen, wordlen = strlen(word);
 
 		/* Find length of common stem */
 		for (y = 1; list[y]; y++) {
@@ -1887,6 +1888,10 @@ complete_ambiguous(const char *word, char **list, size_t count)
 
 			matchlen = x;
 		}
+
+		for (; matchlen > wordlen; matchlen--)
+			if (mblen(list[0] + matchlen, itemlen - matchlen) >= 0)
+				break;
 
 		if (matchlen > strlen(word)) {
 			char *tmp = xstrdup(list[0]);


### PR DESCRIPTION
While sftp try to auto complete multibyte UTF8 file name list, 
complete_match() compares filenames one byte by one byte, 
and may truncates a prefix contains incomplete UTF8 multibyte character which leads to the fatal. 

Fix it in complete_ambiguous(), verify the bytes after match position, go back to beginning of the last valid UTF8 character.