### PR TITLE
fix: prevent OOM when pw_gecos is NULL on Android.

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -513,7 +513,7 @@ pwcopy(struct passwd *pw)
 	copy->pw_name = xstrdup(pw->pw_name);
 	copy->pw_passwd = xstrdup(pw->pw_passwd == NULL ? "*" : pw->pw_passwd);
 #ifdef HAVE_STRUCT_PASSWD_PW_GECOS
-	copy->pw_gecos = xstrdup(pw->pw_gecos);
+	copy->pw_gecos = xstrdup(pw->pw_gecos == NULL ? "" : pw->pw_gecos);
 #endif
 	copy->pw_uid = pw->pw_uid;
 	copy->pw_gid = pw->pw_gid;
@@ -524,10 +524,10 @@ pwcopy(struct passwd *pw)
 	copy->pw_change = pw->pw_change;
 #endif
 #ifdef HAVE_STRUCT_PASSWD_PW_CLASS
-	copy->pw_class = xstrdup(pw->pw_class);
+	copy->pw_class = xstrdup(pw->pw_class == NULL ? "" : pw->pw_class);
 #endif
-	copy->pw_dir = xstrdup(pw->pw_dir);
-	copy->pw_shell = xstrdup(pw->pw_shell);
+	copy->pw_dir = xstrdup(pw->pw_dir == NULL ? "" : pw->pw_dir);
+	copy->pw_shell = xstrdup(pw->pw_shell == NULL ? "" : pw->pw_shell);
 	return copy;
 }
 


### PR DESCRIPTION
This PR addresses a **segmentation fault** caused by accessing an uninitialized `pw_gecos` field in `struct passwd` when using the Android NDK cross-compilation toolchain (`android-ndk-r26c`). While the macro `HAVE_STRUCT_PASSWD_PW_GECOS` is defined (indicating support for the `pw_gecos` field), Android's Bionic libc implementation returns `NULL` for `pw_gecos` in `getpwuid()`. This discrepancy leads to a crash in functions `xtrdup call strlen(str)` when dereferencing the null pointer.