### PR TITLE
digest-openssl: improve OpenSSL v3 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3210,7 +3210,7 @@ if test "x$openssl" = "xyes" ; then
 	)
 
 	# Check for various EVP support in OpenSSL
-	AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 EVP_chacha20])
+	AC_CHECK_FUNCS([EVP_sha256 EVP_sha384 EVP_sha512 EVP_chacha20 EVP_MD_fetch])
 
 	# Check complete ECC support in OpenSSL
 	AC_MSG_CHECKING([whether OpenSSL has NID_X9_62_prime256v1])

--- a/sshkey.c
+++ b/sshkey.c
@@ -35,6 +35,8 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
+/* Returns the OpenSSL EVP_MD for a digest identifier */
+const EVP_MD *ssh_digest_alg_evpmd(int alg);
 #endif
 
 #include "crypto_api.h"
@@ -485,17 +487,11 @@ sshkey_type_certified(int type)
 static const EVP_MD *
 ssh_digest_to_md(int hash_alg)
 {
-	switch (hash_alg) {
-	case SSH_DIGEST_SHA1:
-		return EVP_sha1();
-	case SSH_DIGEST_SHA256:
-		return EVP_sha256();
-	case SSH_DIGEST_SHA384:
-		return EVP_sha384();
-	case SSH_DIGEST_SHA512:
-		return EVP_sha512();
-	}
-	return NULL;
+	/* Block MD5 for signatures */
+	if (hash_alg < SSH_DIGEST_SHA1)
+		return NULL;
+
+	return ssh_digest_alg_evpmd(hash_alg);
 }
 
 int


### PR DESCRIPTION
From OpenSSL v3 documentation https://docs.openssl.org/3.0/man3/EVP_sha1/#notes:

  Developers should be aware of the negative performance implications
  of calling this function multiple times and should consider using
  EVP_MD_fetch(3) with EVP_MD-SHA1(7) instead. See "Performance" in
  crypto(7) for further information.

https://docs.openssl.org/3.0/man7/crypto/#performance:

  If the prefetched object is not passed to operations, then any
  implicit fetch will use the internally cached prefetched object, but
  it will still be slower than passing the prefetched object directly.

Thus update digest-openssl.c digests[] to support above. When
EVP_MD_fetch() is available, upon first use of digests, prefetch them
all. And subsequently pass the prefetched EVP_MD implementations.

There is no other obvious place to prefetch and cache digest
implementations. Note they are reference-counted, and should be freed
when no longer needed, which would be at shutdown. But there is no
obvious cleanup/frees anywhere in many of the binaries as often exit
is simply called. Thus just leave the fetched implementations as is
without ever calling EVP_MD_free(), as they are fetched only ones.

Also do the same in sshkey, which currently has own implementation of
fetching EVP_sha1 onwards. Instead, switch it to use the cached EVP_MD
implementations as well.

Continue to support SSL implementations without EVP_MD_fetch by still
using the efficient EVP_<sha> like they were in OpenSSL 1.1.1 and
before.

When fetching MD5 and SHA1 use non-default property query string
"?fips=yes", this helps interoperability with OpenSSL configured with
FIPS+default providers on multiple distributions with FIPS support
(RHEL, ubuntu, SUSE, Chainguard, Keypair, Microsoft, etc). The "?"
prefix means prefer, but do not require the subsequent property. Thus
if system is configured with FIPS and non-FIPS algorithms, prefer the
FIPS ones, if there is any, otherwise fallback to non-FIPS one. This
has no effect on systems with a single provider, ie. the
default. Depending on the system configuration they can offer MD5 and
SHA1 on opt-in basis. Note this can really help in case digest
calculation is allowed (for example to calculate fingerprints) but
only when explicitly fetched like that. This is similar to how python,
dotnet, s2n-tls and many other software already fetch MD5 and
SHA1. This is crucial to future proof sshd to work with FIPS providers
without SHA1 in approved mode as in development for 2030 NIST SP
800-131A Rev3 IPD https://csrc.nist.gov/pubs/sp/800/131/a/r3/ipd, as
it deprecates SHA1 usage, and yet sshd uses SHA1 for
non-cryptographically secure purposes, for example
ssh_connection_hash() but also in other places.
