### PR TITLE
Upgrade ssh_connection_hash from SHA1 to SHA256

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -362,7 +362,7 @@ ssh_connection_hash(const char *thishost, const char *host, const char *portstr,
 	struct ssh_digest_ctx *md;
 	u_char conn_hash[SSH_DIGEST_MAX_LENGTH];
 
-	if ((md = ssh_digest_start(SSH_DIGEST_SHA1)) == NULL ||
+	if ((md = ssh_digest_start(SSH_DIGEST_SHA256)) == NULL ||
 	    ssh_digest_update(md, thishost, strlen(thishost)) < 0 ||
 	    ssh_digest_update(md, host, strlen(host)) < 0 ||
 	    ssh_digest_update(md, portstr, strlen(portstr)) < 0 ||
@@ -371,7 +371,7 @@ ssh_connection_hash(const char *thishost, const char *host, const char *portstr,
 	    ssh_digest_final(md, conn_hash, sizeof(conn_hash)) < 0)
 		fatal_f("mux digest failed");
 	ssh_digest_free(md);
-	return tohex(conn_hash, ssh_digest_bytes(SSH_DIGEST_SHA1));
+	return tohex(conn_hash, ssh_digest_bytes(SSH_DIGEST_SHA256));
 }
 
 /*

--- a/regress/percent.sh
+++ b/regress/percent.sh
@@ -107,7 +107,7 @@ for i in matchexec localcommand remotecommand controlpath identityagent \
 	# Matches implementation in readconf.c:ssh_connection_hash()
 	if [ ! -z "${OPENSSL_BIN}" ]; then
 		HASH=`printf "${HOSTNAME}127.0.0.1${PORT}${REMUSER}" |
-		    $OPENSSL_BIN sha1 | cut -f2 -d' '`
+		    $OPENSSL_BIN sha256 | cut -f2 -d' '`
 		trial $i '%C' $HASH
 	fi
 	trial $i '%%' '%'


### PR DESCRIPTION
Upgrade ssh_connection_hash from SHA1 to SHA256, if length of this
value is considered an ABI, can also keep tohex legnth as before to
thus effectively use SHA256/160.

This change enables building and using ssh completely without SHA1.
