### PR TITLE
Don't log audit messages with UNKNOWN hostname

### DIFF
--- a/audit-linux.c
+++ b/audit-linux.c
@@ -51,6 +51,8 @@ linux_audit_record_event(int uid, const char *username, const char *hostname,
 		else
 			return 0; /* Must prevent login */
 	}
+        if (hostname != NULL && strcmp(hostname, "UNKNOWN") == 0)
+                hostname = NULL;
 	rc = audit_log_acct_message(audit_fd, AUDIT_USER_LOGIN,
 	    NULL, "login", username ? username : "(unknown)",
 	    username == NULL ? uid : -1, hostname, ip, ttyn, success);


### PR DESCRIPTION
The `host` parameter to audit_log_acct_message() is documented as follows:

      host - The hostname if known. If not available pass a NULL.

but we pass the string "UNKNOWN" in case we don't know the hostname. Make sure we pass NULL instead.

This avoids having the audit system attempt to perform a DNS lookup on the hostname "UNKNOWN", which tends to result in long delays when attempting to login.