### PR TITLE
Upgrade ssh_connection_hash from SHA1 to SHA256

### DIFF
--- a/regress/percent.sh
+++ b/regress/percent.sh
@@ -107,7 +107,8 @@ for i in matchexec localcommand remotecommand controlpath identityagent \
 	# Matches implementation in readconf.c:ssh_connection_hash()
 	if [ ! -z "${OPENSSL_BIN}" ]; then
 		HASH=`printf "${HOSTNAME}127.0.0.1${PORT}${REMUSER}" |
-		    $OPENSSL_BIN sha1 | cut -f2 -d' '`
+		    $OPENSSL_BIN sha256 -binary |
+		    $OPENSSL_BIN base64 | tr '+/' '-_' | tr -d =`
 		trial $i '%C' $HASH
 	fi
 	trial $i '%%' '%'

--- a/ssh.c
+++ b/ssh.c
@@ -626,7 +626,7 @@ ssh_conn_info_free(struct ssh_conn_info *cinfo)
 {
 	if (cinfo == NULL)
 		return;
-	free(cinfo->conn_hash_hex);
+	free(cinfo->conn_hash_urlb64);
 	free(cinfo->shorthost);
 	free(cinfo->uidstr);
 	free(cinfo->keyalias);
@@ -1495,7 +1495,7 @@ main(int ac, char **av)
 
 	/* Now User is expanded, store it and calculate hash. */
 	cinfo->remuser = xstrdup(options.user);
-	cinfo->conn_hash_hex = ssh_connection_hash(cinfo->thishost,
+	cinfo->conn_hash_urlb64 = ssh_connection_hash(cinfo->thishost,
 	    cinfo->remhost, cinfo->portstr, cinfo->remuser, cinfo->jmphost);
 
 	/*

--- a/sshconnect.h
+++ b/sshconnect.h
@@ -33,7 +33,7 @@ struct Sensitive {
 };
 
 struct ssh_conn_info {
-	char *conn_hash_hex;
+	char *conn_hash_urlb64;
 	char *shorthost;
 	char *uidstr;
 	char *keyalias;
@@ -68,7 +68,7 @@ struct ssh_conn_info;
 /* same plus remote user and hash which has user as a component */
 #define DEFAULT_CLIENT_PERCENT_EXPAND_ARGS(conn_info) \
 	DEFAULT_CLIENT_PERCENT_EXPAND_ARGS_NOUSER(conn_info), \
-	"C", conn_info->conn_hash_hex, \
+	"C", conn_info->conn_hash_urlb64, \
 	"r", conn_info->remuser
 
 int	 ssh_connect(struct ssh *, const char *, const char *,


### PR DESCRIPTION
Upgrade ssh_connection_hash from SHA1 to SHA256. Due to increased
length, instead of using hex encoding, use base64url encoding, which
for SHA256 is only slightly longer than hex SHA1.

This change enables building and using ssh completely without SHA1.
