### PR TITLE
include openssl/bn.h explicitly in more places

### DIFF
--- a/kexdh.c
+++ b/kexdh.c
@@ -34,6 +34,7 @@
 #include <signal.h>
 
 #include "openbsd-compat/openssl-compat.h"
+#include <openssl/bn.h>
 #include <openssl/dh.h>
 
 #include "sshkey.h"

--- a/kexecdh.c
+++ b/kexecdh.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <signal.h>
 
+#include <openssl/bn.h>
 #include <openssl/ecdh.h>
 
 #include "sshkey.h"

--- a/kexgexc.c
+++ b/kexgexc.c
@@ -30,6 +30,7 @@
 
 #include <sys/types.h>
 
+#include <openssl/bn.h>
 #include <openssl/dh.h>
 
 #include <stdarg.h>

--- a/kexgexs.c
+++ b/kexgexs.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <signal.h>
 
+#include <openssl/bn.h>
 #include <openssl/dh.h>
 
 #include "openbsd-compat/openssl-compat.h"

--- a/openbsd-compat/openssl-compat.h
+++ b/openbsd-compat/openssl-compat.h
@@ -20,6 +20,7 @@
 #include "includes.h"
 #ifdef WITH_OPENSSL
 
+#include <openssl/bn.h>
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
 #include <openssl/evp.h>

--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 
 #ifdef WITH_OPENSSL
+#include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include "openbsd-compat/openssl-compat.h"

--- a/ssh-pkcs11.c
+++ b/ssh-pkcs11.c
@@ -34,6 +34,7 @@
 #include "openbsd-compat/openssl-compat.h"
 
 #ifdef WITH_OPENSSL
+#include <openssl/bn.h>
 #include <openssl/ecdsa.h>
 #include <openssl/x509.h>
 #include <openssl/err.h>

--- a/ssh-rsa.c
+++ b/ssh-rsa.c
@@ -21,6 +21,7 @@
 
 #include <sys/types.h>
 
+#include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 

--- a/sshkey.c
+++ b/sshkey.c
@@ -32,6 +32,7 @@
 #include <netinet/in.h>
 
 #ifdef WITH_OPENSSL
+#include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
These files use BN APIs, so explicitly include bn.h rather than rely on other openssl headers (sometimes) including it for us.