### PR TITLE
Add/enhance audit support on AIX

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -113,8 +113,10 @@ P11OBJS= ssh-pkcs11-client.o
 
 SKOBJS=	ssh-sk-client.o
 
+AUDOBJ= audit.o
+
 SSHOBJS= ssh.o readconf.o clientloop.o sshtty.o \
-	sshconnect.o sshconnect2.o mux.o ssh-pkcs11.o $(SKOBJS)
+	sshconnect.o sshconnect2.o mux.o ssh-pkcs11.o $(SKOBJS) $(AUDOBJ)
 
 SSHDOBJS=sshd.o \
 	platform-listen.o \
@@ -123,7 +125,7 @@ SSHDOBJS=sshd.o \
 	$(P11OBJS) $(SKOBJS)
 
 SSHD_SESSION_OBJS=sshd-session.o auth-rhosts.o auth-passwd.o \
-	audit.o audit-bsm.o audit-linux.o platform.o \
+	audit-bsm.o audit-linux.o audit-aix.o audit.o platform.o \
 	sshpty.o sshlogin.o servconf.o serverloop.o \
 	auth.o auth2.o auth2-methods.o auth-options.o session.o \
 	auth2-chall.o groupaccess.o \
@@ -143,7 +145,7 @@ SSHD_AUTH_OBJS=sshd-auth.o \
 	auth2-none.o auth2-passwd.o auth2-pubkey.o auth2-pubkeyfile.o \
 	auth2-gss.o gss-serv.o gss-serv-krb5.o \
 	monitor_wrap.o auth-krb5.o \
-	audit.o audit-bsm.o audit-linux.o platform.o \
+	audit-bsm.o audit-linux.o audit-aix.o audit.o platform.o \
 	loginrec.o auth-pam.o auth-shadow.o auth-sia.o \
 	sandbox-null.o sandbox-rlimit.o sandbox-darwin.o \
 	sandbox-seccomp-filter.o sandbox-capsicum.o  sandbox-solaris.o \

--- a/Makefile.in
+++ b/Makefile.in
@@ -113,7 +113,7 @@ P11OBJS= ssh-pkcs11-client.o
 
 SKOBJS=	ssh-sk-client.o
 
-AUDOBJ= audit.o
+AUDOBJ= audit-aix.o audit.o
 
 SSHOBJS= ssh.o readconf.o clientloop.o sshtty.o \
 	sshconnect.o sshconnect2.o mux.o ssh-pkcs11.o $(SKOBJS) $(AUDOBJ)
@@ -168,7 +168,7 @@ P11HELPER_OBJS=	ssh-pkcs11-helper.o ssh-pkcs11.o $(SKOBJS)
 
 SKHELPER_OBJS=	ssh-sk-helper.o ssh-sk.o sk-usbhid.o ssherr-nolibcrypto.o
 
-SSHKEYSCAN_OBJS=ssh-keyscan.o $(P11OBJS) $(SKOBJS)
+SSHKEYSCAN_OBJS=ssh-keyscan.o $(P11OBJS) $(SKOBJS) $(AUDOBJ)
 
 SFTPSERVER_OBJS=sftp-common.o sftp-server.o sftp-server-main.o ssherr-nolibcrypto.o
 

--- a/audit-aix.c
+++ b/audit-aix.c
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2026 IBM Ajay Kini.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "includes.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
+#include <pwd.h>
+
+#ifdef USE_AIX_AUDIT
+# include <sys/audit.h>
+# include <usersec.h>
+
+
+#include "audit.h"
+#include "log.h"
+#include "hostfile.h"
+#include "auth.h"
+
+/*
+ * Care must be taken when using this since it WILL NOT be initialized when
+ * audit_connection_from() is called and MAY NOT be initialized when
+ * audit_event(CONNECTION_ABANDON) is called.  Test for NULL before using.
+ */
+extern Authctxt *the_authctxt;
+
+/* Maybe add the audit class to struct Authmethod? */
+ssh_audit_event_t
+audit_classify_auth(const char *method)
+{
+	if (strcmp(method, "none") == 0)
+		return SSH_AUTH_FAIL_NONE;
+	else if (strcmp(method, "password") == 0)
+		return SSH_AUTH_FAIL_PASSWD;
+	else if (strcmp(method, "publickey") == 0 ||
+	    strcmp(method, "rsa") == 0)
+		return SSH_AUTH_FAIL_PUBKEY;
+	else if (strncmp(method, "keyboard-interactive", 20) == 0 ||
+	    strcmp(method, "challenge-response") == 0)
+		return SSH_AUTH_FAIL_KBDINT;
+	else if (strcmp(method, "hostbased") == 0 ||
+	    strcmp(method, "rhosts-rsa") == 0)
+		return SSH_AUTH_FAIL_HOSTBASED;
+	else if (strcmp(method, "gssapi-with-mic") == 0)
+		return SSH_AUTH_FAIL_GSSAPI;
+	else
+		return SSH_AUDIT_UNKNOWN;
+}
+
+/* helper to return supplied username */
+const char *
+audit_username(void)
+{
+	static const char unknownuser[] = "(unknown user)";
+	static const char invaliduser[] = "(invalid user)";
+
+	if (the_authctxt == NULL || the_authctxt->user == NULL)
+		return (unknownuser);
+	if(the_authctxt->user != NULL)
+			return (the_authctxt->user);
+	if (!the_authctxt->valid)
+			return (invaliduser);	
+	
+	return (the_authctxt->user);
+}
+
+const char *
+audit_event_lookup(ssh_audit_event_t ev)
+{
+	int i;
+	static struct event_lookup_struct {
+		ssh_audit_event_t event;
+		const char *name;
+	} event_lookup[] = {
+		/* These envent names comply with AIX audit requirements */
+		{SSH_LOGIN_EXCEED_MAXTRIES,	"SSH_exceedmtrix"},
+		{SSH_LOGIN_ROOT_DENIED,		"SSH_rootdned"},
+		{SSH_AUTH_SUCCESS,		"SSH_authsuccess"},
+		{SSH_AUTH_FAIL_NONE,		"SSH_failnone"},
+		{SSH_AUTH_FAIL_PASSWD,		"SSH_failpasswd"},
+		{SSH_AUTH_FAIL_KBDINT,		"SSH_failkbdint"},
+		{SSH_AUTH_FAIL_PUBKEY,		"SSH_failpubkey"},
+		{SSH_AUTH_FAIL_HOSTBASED,	"SSH_failhstbsd"},
+		{SSH_AUTH_FAIL_GSSAPI,		"SSH_failgssapi"},
+		{SSH_INVALID_USER,		"SSH_invldusr"},
+		{SSH_NOLOGIN,			"SSH_nologin"},
+		{SSH_CONNECTION_CLOSE,		"SSH_connclose"},
+		{SSH_CONNECTION_ABANDON,	"SSH_connabndn"},
+		{SSH_BAD_PCKT,					"SSH_badpckt"},
+		{SSH_CIPHER_NO_MATCH,			"SSH_cipmismatch"},
+		{SSH_SESSION_OPEN,				"SSH_sessionopn"},
+		{SSH_AUDIT_UNKNOWN,		"SSH_auditknwn"}
+	};
+
+	for (i = 0; event_lookup[i].event != SSH_AUDIT_UNKNOWN; i++)
+		if (event_lookup[i].event == ev)
+			break;
+	return (event_lookup[i].name);
+}
+
+/*
+ * Null implementations of audit functions.
+ * These get used if SSH_AUDIT_EVENTS is defined but no audit module is enabled.
+ */
+
+/*
+ * Called after a connection has been accepted but before any authentication
+ * has been attempted.
+ */
+void
+audit_connection_from(const char *host, int port)
+{
+	debug("audit connection from %s port %d euid %d", host, port,
+	    (int)geteuid());
+}
+
+/*
+ * Called when various events occur (see audit.h for a list of possible
+ * events and what they mean).
+ */
+void
+audit_event(struct ssh *ssh, ssh_audit_event_t event)
+{
+	char buf[1024];
+	const char *username;
+	const char *event_name;
+	const char *remote_ip;
+	int ret;
+	uid_t auth_uid;  /* UID of the user attempting authentication */
+	int res = 0;  /* AIX audit result code: 0 = success */
+
+	/* Debug: Log that audit_event was called */
+	debug("audit_event: called with event=%d", event);
+	
+	/* Get username from authctxt */
+	username = audit_username();
+	
+	/* Get the UID of the authenticating user */
+	auth_uid = (uid_t)-1;  /* Default to -1 if user doesn't exist */
+	
+	/* On AIX, use getuserattr to get UID from username */
+	if (the_authctxt != NULL && the_authctxt->user != NULL) {
+		int uid_val;
+		if (getuserattr(the_authctxt->user, S_ID, &uid_val, SEC_INT) == 0) {
+			auth_uid = (uid_t)uid_val;
+		}
+	}
+
+	/* On other systems, use getpwnam or authctxt->pw */
+	if (the_authctxt != NULL && the_authctxt->pw != NULL) {
+		auth_uid = the_authctxt->pw->pw_uid;
+	} else if (the_authctxt != NULL && the_authctxt->user != NULL) {
+		struct passwd *pw = getpwnam(the_authctxt->user);
+		if (pw != NULL) {
+			auth_uid = pw->pw_uid;
+		}
+	}
+	
+	event_name = audit_event_lookup(event);
+	
+	/* Set audit result code based on event type */
+	switch (event) {
+	case SSH_AUTH_FAIL_NONE:
+	case SSH_AUTH_FAIL_PASSWD:
+	case SSH_AUTH_FAIL_KBDINT:
+	case SSH_AUTH_FAIL_PUBKEY:
+	case SSH_AUTH_FAIL_HOSTBASED:
+	case SSH_AUTH_FAIL_GSSAPI:
+	case SSH_INVALID_USER:
+	case SSH_BAD_PCKT:
+	case SSH_CIPHER_NO_MATCH:
+		res = 1;  /* Failure */
+		break;
+	default:
+		res = 0;  /* Success */
+		break;
+	}
+	
+	/* Handle NULL ssh pointer gracefully */
+	if (ssh != NULL) {
+		remote_ip = ssh_remote_ipaddr(ssh);
+	} else {
+		remote_ip = "(unknown)";
+	}
+
+	/* Build audit message with proper error checking */
+	if (auth_uid == (uid_t)-1) {
+		ret = snprintf(buf, sizeof(buf),
+		    "audit event for user %s event %d (%s) remote ip (%s)",
+		     username, event, event_name, remote_ip);
+	} else {
+		ret = snprintf(buf, sizeof(buf),
+		    "audit event auth_uid %u user %s event %d (%s) remote ip (%s)",
+		    (unsigned int)auth_uid, username, event, event_name, remote_ip);
+	}
+
+	/* Check for truncation */
+	if (ret < 0 || (size_t)ret >= sizeof(buf)) {
+		debug("audit_event: message truncated (needed %d bytes)", ret);
+	}
+
+	/* Log to debug output */
+	if (auth_uid == (uid_t)-1) {
+		debug("audit event auth_uid -1 user %s event %d (%s) remote ip (%s)", 
+			username, event, event_name, remote_ip);
+	} else {
+		debug("audit event auth_uid %u user %s event %d (%s) remote ip (%s)",
+		    (unsigned int)auth_uid, username, event, event_name, remote_ip);
+	}
+
+	/* Write to AIX audit subsystem with required format */
+	if (auditwrite(event_name, res, buf, strlen(buf) + 1, 0) < 0) {
+		error("auditwrite failed for event %s: %s",
+		    event_name, strerror(errno));
+	}
+}
+
+/*
+ * Called when a user session is started.  Argument is the tty allocated to
+ * the session, or NULL if no tty was allocated.
+ *
+ * Note that this may be called multiple times if multiple sessions are used
+ * within a single connection.
+ */
+void
+audit_session_open(struct logininfo *li)
+{
+	const char *t = li->line ? li->line : "(no tty)";
+	const char *username;
+	const char *hostname;
+	const char *event_name;
+	char buf[1024];
+	int ret;
+	uid_t auth_uid;
+
+	int res = 0;  /* AIX audit result code: 0 = success for session open */
+	
+	/* Use username from logininfo if available, otherwise from authctxt */
+	if (li->username[0] != '\0') {
+		username = li->username;
+	} else {
+		username = audit_username();
+	}
+	
+	/* Use hostname from logininfo if available */
+	if (li->hostname[0] != '\0') {
+		hostname = li->hostname;
+	} else {
+		hostname = "(unknown)";
+	}
+	
+	/* Get the UID from logininfo */
+	auth_uid = li->uid;
+	
+	event_name = audit_event_lookup(SSH_SESSION_OPEN);
+
+	/* Build audit message with logininfo details */
+	if (auth_uid == (uid_t)-1) {
+		ret = snprintf(buf, sizeof(buf),
+		    "audit session open auth_uid -1 user %s tty %s hostname %s pid %ld",
+			 username, t, hostname, (long)li->pid);
+	} else {
+		ret = snprintf(buf, sizeof(buf),
+		    "audit session open auth_uid %u user %s tty %s hostname %s pid %ld",
+		    (unsigned int)auth_uid, username, t, hostname, (long)li->pid);
+	}
+
+	/* Check for truncation */
+	if (ret < 0 || (size_t)ret >= sizeof(buf)) {
+		debug("audit_session_open: message truncated (needed %d bytes)", ret);
+	}
+
+	/* Log to debug output */
+	if (auth_uid == (uid_t)-1) {
+		debug("audit session open auth_uid -1 user %s tty %s hostname %s pid %ld",
+			 username, t, hostname, (long)li->pid);
+	} else {
+		debug("audit session open auth_uid %u user %s tty %s hostname %s pid %ld",
+		    (unsigned int)auth_uid, username, t, hostname, (long)li->pid);
+	}
+
+	/* Write to AIX audit subsystem */
+	if (auditwrite(event_name, res, buf, strlen(buf) + 1, 0) < 0) {
+		error("auditwrite failed for event %s: %s",
+		    event_name, strerror(errno));
+	}
+}
+
+/*
+ * Called when a user session is closed.  Argument is the tty allocated to
+ * the session, or NULL if no tty was allocated.
+ *
+ * Note that this may be called multiple times if multiple sessions are used
+ * within a single connection.
+ */
+void
+audit_session_close(struct logininfo *li)
+{
+	const char *t = li->line ? li->line : "(no tty)";
+
+	debug("audit session close euid %d user %s tty name %s", geteuid(),
+	    audit_username(), t);
+}
+
+/*
+ * This will be called when a user runs a non-interactive command.  Note that
+ * it may be called multiple times for a single connection since SSH2 allows
+ * multiple sessions within a single connection.
+ */
+void
+audit_run_command(const char *command)
+{
+	debug("audit run command euid %d user %s command '%.200s'", geteuid(),
+	    audit_username(), command);
+}
+
+#endif /* USE_AIX_AUDIT  */

--- a/audit.c
+++ b/audit.c
@@ -28,11 +28,12 @@
 #include <string.h>
 #include <unistd.h>
 
-#if defined(SSH_AUDIT_EVENTS) || defined(USE_AIX_AUDIT)
+#if defined(SSH_AUDIT_EVENTS)
 
 #include "audit.h"
 #include "log.h"
 #include "hostfile.h"
+#ifndef CUSTOM_SSH_AUDIT_EVENTS
 #include "auth.h"
 
 /*
@@ -40,7 +41,6 @@
  * audit_connection_from() is called and MAY NOT be initialized when
  * audit_event(CONNECTION_ABANDON) is called.  Test for NULL before using.
  */
-#ifdef DEBUG_AUDIT_EVENTS
 extern Authctxt *the_authctxt;
 #endif
 
@@ -74,7 +74,7 @@ audit_username(void)
 	static const char unknownuser[] = "(unknown user)";
 	static const char invaliduser[] = "(invalid user)";
 
-#ifdef DEBUG_AUDIT_EVENTS
+#ifndef CUSTOM_SSH_AUDIT_EVENTS
 	if (the_authctxt == NULL || the_authctxt->user == NULL)
 		return (unknownuser);
 	if (!the_authctxt->valid)
@@ -118,7 +118,7 @@ audit_event_lookup(ssh_audit_event_t ev)
 	return(event_lookup[i].name);
 }
 
-# ifndef DEBUG_AUDIT_EVENTS
+# ifndef CUSTOM_SSH_AUDIT_EVENTS
 /*
  * Null implementations of audit functions.
  * These get used if SSH_AUDIT_EVENTS is defined but no audit module is enabled.
@@ -190,4 +190,5 @@ audit_run_command(const char *command)
 	    audit_username(), command);
 }
 # endif  /* !defined CUSTOM_SSH_AUDIT_EVENTS */
-#endif /* SSH_AUDIT_EVENTS || USE_AIX_AUDIT */
+#endif /* SSH_AUDIT_EVENTS */
+

--- a/audit.h
+++ b/audit.h
@@ -43,6 +43,9 @@ enum ssh_audit_event_type {
 	SSH_NOLOGIN,		/* denied by /etc/nologin, not implemented */
 	SSH_CONNECTION_CLOSE,	/* closed after attempting auth or session */
 	SSH_CONNECTION_ABANDON,	/* closed without completing auth */
+	SSH_BAD_PCKT,		/* bad/invalid packet received */
+	SSH_CIPHER_NO_MATCH,	/* cipher negotiation failed */
+	SSH_SESSION_OPEN,	/* session opened */
 	SSH_AUDIT_UNKNOWN
 };
 typedef enum ssh_audit_event_type ssh_audit_event_t;

--- a/configure.ac
+++ b/configure.ac
@@ -2009,7 +2009,6 @@ AC_ARG_WITH([audit],
 		AUDIT_MODULE=debug
 		AC_MSG_RESULT([debug])
 		AC_DEFINE([SSH_AUDIT_EVENTS], [1], [Use audit debugging module])
-		AC_DEFINE([DEBUG_AUDIT_EVENTS], [1], [Use audit debugging module])
 		;;
 	  no)
 		AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -1961,7 +1961,7 @@ AC_ARG_WITH([wtmpdb],
 
 AUDIT_MODULE=none
 AC_ARG_WITH([audit],
-	[  --with-audit=module     Enable audit support (modules=debug,bsm,linux)],
+	[  --with-audit=module     Enable audit support (modules=debug,bsm,linux,aix)],
 	[
 	  AC_MSG_CHECKING([for supported audit module])
 	  case "$withval" in
@@ -1998,10 +1998,18 @@ AC_ARG_WITH([audit],
 		SSHDLIBS="$SSHDLIBS -laudit"
 		AC_DEFINE([USE_LINUX_AUDIT], [1], [Use Linux audit module])
 		;;
+	  aix)
+	  AC_MSG_RESULT([aix])
+	  AUDIT_MODULE=aix
+	   dnl    Checks for headers, libs and functions
+	   AC_CHECK_HEADERS([sys/audit.h])
+	   AC_DEFINE([USE_AIX_AUDIT], [1], [Use AIX audit module])
+	   ;;
 	  debug)
 		AUDIT_MODULE=debug
 		AC_MSG_RESULT([debug])
 		AC_DEFINE([SSH_AUDIT_EVENTS], [1], [Use audit debugging module])
+		AC_DEFINE([DEBUG_AUDIT_EVENTS], [1], [Use audit debugging module])
 		;;
 	  no)
 		AC_MSG_RESULT([no])

--- a/defines.h
+++ b/defines.h
@@ -55,6 +55,7 @@ enum
 /*
  * Definitions for IP type of service (ip_tos)
  */
+#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #ifndef IPTOS_LOWDELAY
 # define IPTOS_LOWDELAY          0x10
@@ -766,6 +767,10 @@ struct winsize {
 # define CUSTOM_SSH_AUDIT_EVENTS
 #endif
 
+#ifdef USE_AIX_AUDIT
+# define SSH_AUDIT_EVENTS
+#endif
+
 #if !defined(HAVE___func__) && defined(HAVE___FUNCTION__)
 #  define __func__ __FUNCTION__
 #elif !defined(HAVE___func__)
@@ -978,6 +983,13 @@ struct winsize {
 #  define __predict_false(exp)    ((exp) != 0)
 # endif /* gcc version */
 #endif /* __predict_true */
+
+#if defined(HAVE_GLOB_H) && defined(GLOB_HAS_ALTDIRFUNC) && \
+    defined(GLOB_HAS_GL_MATCHC) && defined(GLOB_HAS_GL_STATV) && \
+    defined(HAVE_DECL_GLOB_NOMATCH) &&  HAVE_DECL_GLOB_NOMATCH != 0 && \
+    !defined(BROKEN_GLOB)
+# define USE_SYSTEM_GLOB
+#endif
 
 /*
  * sntrup761 uses variable length arrays and c99-style declarations after code,

--- a/defines.h
+++ b/defines.h
@@ -55,7 +55,6 @@ enum
 /*
  * Definitions for IP type of service (ip_tos)
  */
-#include <netinet/in_systm.h>
 #include <netinet/ip.h>
 #ifndef IPTOS_LOWDELAY
 # define IPTOS_LOWDELAY          0x10
@@ -769,6 +768,7 @@ struct winsize {
 
 #ifdef USE_AIX_AUDIT
 # define SSH_AUDIT_EVENTS
+# define CUSTOM_SSH_AUDIT_EVENTS
 #endif
 
 #if !defined(HAVE___func__) && defined(HAVE___FUNCTION__)
@@ -983,13 +983,6 @@ struct winsize {
 #  define __predict_false(exp)    ((exp) != 0)
 # endif /* gcc version */
 #endif /* __predict_true */
-
-#if defined(HAVE_GLOB_H) && defined(GLOB_HAS_ALTDIRFUNC) && \
-    defined(GLOB_HAS_GL_MATCHC) && defined(GLOB_HAS_GL_STATV) && \
-    defined(HAVE_DECL_GLOB_NOMATCH) &&  HAVE_DECL_GLOB_NOMATCH != 0 && \
-    !defined(BROKEN_GLOB)
-# define USE_SYSTEM_GLOB
-#endif
 
 /*
  * sntrup761 uses variable length arrays and c99-style declarations after code,

--- a/openbsd-compat/bsd-setres_id.c
+++ b/openbsd-compat/bsd-setres_id.c
@@ -21,6 +21,11 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <string.h>
+#ifdef _AIX
+#include <sys/id.h>
+#include <userpriv.h>
+#include <sys/priv.h>
+#endif
 
 #include "log.h"
 
@@ -64,8 +69,11 @@ int
 setresuid(uid_t ruid, uid_t euid, uid_t suid)
 {
 	int ret = 0, saved_errno;
+#ifdef _AIX
+	privg_t set_pv;
+#endif
 
-	if (ruid != suid) {
+	if (ruid != suid) {	
 		errno = ENOSYS;
 		return -1;
 	}
@@ -86,12 +94,22 @@ setresuid(uid_t ruid, uid_t euid, uid_t suid)
 		ret = -1;
 	}
 # endif
+#ifdef _AIX
+	if (setuidx(ID_EFFECTIVE|ID_REAL|ID_SAVED,ruid) < 0)  {
+#else
 	if (setuid(ruid) < 0) {
+#endif
 		saved_errno = errno;
 		error("setuid %lu: %.100s", (u_long)ruid, strerror(errno));
 		errno = saved_errno;
 		ret = -1;
 	}
+#ifdef _AIX
+	priv_clrall(&set_pv);
+	privbit_set(&set_pv,PV_AU_);
+	setppriv(getpid(), (privg_tp)&set_pv, (privg_tp)&set_pv, (privg_tp)&set_pv, NULL);
+#endif
+
 #endif
 	return ret;
 }

--- a/packet.c
+++ b/packet.c
@@ -90,6 +90,10 @@
 #include "ssherr.h"
 #include "sshbuf.h"
 
+#if defined(SSH_AUDIT_EVENTS) || defined(USE_AIX_AUDIT)
+#include "audit.h"
+#endif
+
 #ifdef PACKET_DEBUG
 #define DBG(x) x
 #else
@@ -1658,6 +1662,9 @@ ssh_packet_read_poll2(struct ssh *ssh, u_char *typep, u_int32_t *seqnr_p)
 			sshbuf_dump(state->input, stderr);
 #endif
 			logit("Bad packet length %u.", state->packlen);
+#ifdef USE_AIX_AUDIT
+			audit_event(ssh, SSH_BAD_PCKT);
+#endif
 			if ((r = sshpkt_disconnect(ssh, "Packet corrupt")) != 0)
 				return r;
 			return SSH_ERR_CONN_CORRUPT;
@@ -1688,6 +1695,10 @@ ssh_packet_read_poll2(struct ssh *ssh, u_char *typep, u_int32_t *seqnr_p)
 			sshbuf_dump(state->incoming_packet, stderr);
 #endif
 			logit("Bad packet length %u.", state->packlen);
+#ifdef USE_AIX_AUDIT
+			audit_event(ssh, SSH_BAD_PCKT);
+#endif
+			
 			return ssh_packet_start_discard(ssh, enc, mac, 0,
 			    PACKET_MAX_SIZE);
 		}
@@ -2076,6 +2087,9 @@ sshpkt_vfatal(struct ssh *ssh, int r, const char *fmt, va_list ap)
 		}
 		/* FALLTHROUGH */
 	case SSH_ERR_NO_CIPHER_ALG_MATCH:
+#ifdef USE_AIX_AUDIT
+		audit_event(ssh, SSH_CIPHER_NO_MATCH);
+#endif
 	case SSH_ERR_NO_MAC_ALG_MATCH:
 	case SSH_ERR_NO_COMPRESS_ALG_MATCH:
 	case SSH_ERR_NO_KEX_ALG_MATCH:

--- a/packet.c
+++ b/packet.c
@@ -90,7 +90,7 @@
 #include "ssherr.h"
 #include "sshbuf.h"
 
-#if defined(SSH_AUDIT_EVENTS) || defined(USE_AIX_AUDIT)
+#if defined(SSH_AUDIT_EVENTS)
 #include "audit.h"
 #endif
 


### PR DESCRIPTION
### 1. Core Audit Implementation Changes
File: [audit.c]

Added AIX-Specific Audit Support:

**AIX Headers:** Added <sys/audit.h> and <usersec.h> for AIX audit subsystem
**Enhanced [audit_username()]:** Improved logic to handle NULL authctxt cases
**AIX Event Names:** Added AIX-compliant event names in [audit_event_lookup()]:
SSH_exceedmtrix, SSH_rootdned, SSH_authsuccess, etc.
Standard names for non-AIX: LOGIN_EXCEED_MAXTRIES, AUTH_SUCCESS, etc.
Enhanced [audit_event()] Function:

UID Tracking: Added auth_uid to track authenticating user's UID
AIX UID Retrieval: Uses getuserattr() on AIX, getpwnam() on other systems
Remote IP Handling: Safely handles NULL ssh pointer
Detailed Logging: Logs auth_uid, username, event type, and remote IP
AIX Audit Writing: Calls auditwrite() with proper result codes (0=success, 1=failure)
Error Handling: Proper buffer truncation checks and error logging
Enhanced [audit_session_open()] Function:

AIX-Specific Implementation: Complete audit trail for session opens
Detailed Context: Logs username, tty, hostname, PID, and UID
AIX Audit Integration: Writes to AIX audit subsystem with auditwrite()
Fallback for Non-AIX: Maintains simple debug logging for other platforms

### 2. Audit Header Changes
File: [audit.h]
Added New Event Types:

SSH_BAD_PCKT,           // bad/invalid packet received
SSH_CIPHER_NO_MATCH,    // cipher negotiation failed  
SSH_SESSION_OPEN,       // session opened


These events enable tracking
 of security-relevant protocol events.

### 3. Client/Server Separation Solution
File: [audit-aix.c] (NEW FILE)

Purpose:
Provides AIX specific implementations of all audit functions for Server binaries.

Key Design:
Conditional Compilation: Uses USE_AIX_AUDIT


### 4. Testing: 
Check if the audit records are getting captured post starting the audit system on AIX as different user and different use case:
```
> tail -f stream.out
event      login  status   time           command             wpar name         
--------------- -------- ----------- ------------------------ ------------------------------- ------------------------- 
S_PASSWD_READ  root   OK     Tue Feb 03 11:44:53 2026 db2fm              Global           
    audit object read event detected /etc/security/passwd
S_PASSWD_READ  root   OK     Tue Feb 03 11:44:53 2026 db2fm              Global           
    audit object read event detected /etc/security/passwd
SSH_connabndn  root   OK     Tue Feb 03 11:44:57 2026 sshd-session          Global           
    audit event euid 0 user root event 12 (SSH_connabndn) remote ip XX.XX.XX.XX)     ---------------> here 
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:00 2026 cron              Global           
    audit object read event detected /etc/security/passwd
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:00 2026 cron              Global           
    audit object read event detected /etc/security/passwd
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:04 2026 db2fm              Global           
    audit object read event detected /etc/security/passwd
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:04 2026 db2fm              Global           
    audit object read event detected /etc/security/passwd
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:05 2026 sshd-session          Global           
    audit object read event detected /etc/security/passwd
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:05 2026 sshd-session          Global           
    audit object read event detected /etc/security/passwd
SSH_authsuccess root   OK     Tue Feb 03 11:45:05 2026 sshd-session          Global      -----------------> here      
    audit event euid 0 user root event 2 (SSH_authsuccess) remote ip (XX.XX.XX.XX)
S_PASSWD_READ  root   OK     Tue Feb 03 11:45:14 2026 db2fm              Global
..
..
SSH_sessionopn  root     OK          Thu Feb 05 03:59:36 2026 sshd-session                    Global
        audit session open auth_uid 0 user root tty /dev/pts/4 hostname XX.XX.XX.XX pid 16384454
..
..
SSH_badpckt     root     FAIL        Thu Feb 05 05:04:37 2026 sshd-auth                       Global
        audit event for user (unknown user) event 13 (SSH_badpckt) remote ip (XX.XX.XX.XX)
```