### PR TITLE
session: validate xauth strings at point of use in do_rc_files

### DIFF
--- a/session.c
+++ b/session.c
@@ -1164,7 +1164,8 @@ do_rc_files(struct ssh *ssh, Session *s, const char *shell)
 	struct stat st;
 
 	do_xauth =
-	    s->display != NULL && s->auth_proto != NULL && s->auth_data != NULL;
+	    s->display != NULL && s->auth_proto != NULL && s->auth_data != NULL &&
+	    xauth_valid_string(s->auth_proto) && xauth_valid_string(s->auth_data);
 	xasprintf(&user_rc, "%s/%s", s->pw->pw_dir, _PATH_SSH_USER_RC);
 
 	/* ignore _PATH_SSH_USER_RC for subsystems and admin forced commands */


### PR DESCRIPTION
do_rc_files() relied on auth_proto and auth_data being non-NULL as the sole guard before writing them to external processes (user rc, system rc, and the direct xauth invocation). xauth_valid_string() was already being called upstream in session_x11_req(), but that single gate means any future code path that sets auth_proto/auth_data without going through session_x11_req() would reach the write sinks without content validation.

This change adds xauth_valid_string() checks to the do_xauth guard in do_rc_files() so the validation is enforced at the point of use, covering all three write paths regardless of how session state was reached.