### PR TITLE
Fix unsafe atoi() usage in get_sock_port()

### DIFF
--- a/canohost.c
+++ b/canohost.c
@@ -192,7 +192,7 @@ get_sock_port(int sock, int local)
 	    strport, sizeof(strport), NI_NUMERICSERV)) != 0)
 		fatal_f("getnameinfo NI_NUMERICSERV failed: %s",
 		    ssh_gai_strerror(r));
-	return atoi(strport);
+	return (int)strtonum(strport, 0, UINT16_MAX, NULL);
 }
 
 int


### PR DESCRIPTION
Replace atoi() with strtonum() for safer port number conversion. atoi() has undefined behavior on overflow and no error detection, while strtonum() provides proper bounds validation and error reporting.