### PR TITLE
MaxStartups parsing fix and refactor

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -2015,12 +2015,12 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 				    filename, linenum, keyword);
 		} else if (n == 1) {
 			value3 = value;
-			value = value2 = -1;
+			value2 = -1;
 		} else {
 			fatal("%s line %d: Invalid %s spec.",
 			    filename, linenum, keyword);
 		}
-		if (value3 <= 0 || (value2 != -1 && value <= 0))
+		if (value <= 0 || value3 <= 0)
 			fatal("%s line %d: Invalid %s spec.",
 			    filename, linenum, keyword);
 		if (*activep && options->max_startups == -1) {

--- a/servconf.c
+++ b/servconf.c
@@ -410,7 +410,7 @@ fill_default_server_options(ServerOptions *options)
 	if (options->max_startups == -1)
 		options->max_startups = 100;
 	if (options->max_startups_rate == -1)
-		options->max_startups_rate = 30;		/* 30% */
+		options->max_startups_rate = DEFAULT_MAX_STARTUP_RATE;
 	if (options->max_startups_begin == -1)
 		options->max_startups_begin = 10;
 	if (options->per_source_max_startups == -1)
@@ -2008,19 +2008,17 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			fatal("%s line %d: %s missing argument.",
 			    filename, linenum, keyword);
 		/* begin:rate:max */
-		if ((n = sscanf(arg, "%d:%d:%d",
-		    &value, &value2, &value3)) == 3) {
-			if (value > value3 || value2 > 100 || value2 < 1)
-				fatal("%s line %d: Invalid %s spec.",
-				    filename, linenum, keyword);
-		} else if (n == 1) {
+		n = sscanf(arg, "%d:%d:%d", &value, &value2, &value3);
+		if (n == 1) {
+			/* convert from old style MaxStartups setting (one int) */
 			value3 = value;
-			value2 = -1;
-		} else {
+			value2 = DEFAULT_MAX_STARTUP_RATE;
+		} else if (n != 3) {
 			fatal("%s line %d: Invalid %s spec.",
 			    filename, linenum, keyword);
 		}
-		if (value <= 0 || value3 <= 0)
+		if (value <= 0 || value3 <= 0 || value > value3 ||
+		    value2 > 100 || value2 < 1)
 			fatal("%s line %d: Invalid %s spec.",
 			    filename, linenum, keyword);
 		if (*activep && options->max_startups == -1) {

--- a/servconf.h
+++ b/servconf.h
@@ -39,6 +39,8 @@
 #define DEFAULT_AUTH_FAIL_MAX	6	/* Default for MaxAuthTries */
 #define DEFAULT_SESSIONS_MAX	10	/* Default for MaxSessions */
 
+#define DEFAULT_MAX_STARTUP_RATE	30	/* 30% */
+
 /* Magic name for internal sftp-server */
 #define INTERNAL_SFTP_NAME	"internal-sftp"
 


### PR DESCRIPTION
The commit 683d0ab introduced a conversion issue, which converted
"MaxStartups 3" into "10:30:3".  This is wrong, as value1 > value3 and
it causes side effects leading to crash of sshd when MaxStartups
functionality is triggered with this error:
"error: mm_reap: child terminated by signal 15"

Please find fix proposal and a proposal for refactoring the parsing part to be more robust against such issues.