### PR TITLE
Fix error handling in fill_default_options

### DIFF
--- a/readconf.c
+++ b/readconf.c
@@ -2849,7 +2849,7 @@ fill_default_options(Options * options)
 {
 	char *all_cipher, *all_mac, *all_kex, *all_key, *all_sig;
 	char *def_cipher, *def_mac, *def_kex, *def_key, *def_sig;
-	int ret = 0, r;
+	int ret = 0;
 
 	if (options->forward_agent == -1)
 		options->forward_agent = 0;
@@ -3042,9 +3042,9 @@ fill_default_options(Options * options)
 	def_sig = match_filter_allowlist(SSH_ALLOWED_CA_SIGALGS, all_sig);
 #define ASSEMBLE(what, defaults, all) \
 	do { \
-		if ((r = kex_assemble_names(&options->what, \
+		if ((ret = kex_assemble_names(&options->what, \
 		    defaults, all)) != 0) { \
-			error_fr(r, "%s", #what); \
+			error_fr(ret, "%s", #what); \
 			goto fail; \
 		} \
 	} while (0)


### PR DESCRIPTION
Found during a bug investigation in CentOS 10 where our downstream patch removes kex algorithm in FIPS mode but ignores the error when encountered in `kex_names_valid` on purpose. This propagated the error further eventually hitting an error in `fill_default_options` but instead of exiting, the error is ignored and ssh keeps running in broken state.

This seems to be a bug in upstream code where `ret` is never set in `fill_default_options` even when error is encountered.
Looking at the history the `r` variable was introduced in commit 1b9dd4a where the error was fatal. Then in commit 43026da the error handling was moved outside of the function. The commit introduced `ret` variable which is never assigned into. This makes the function always return 0, even on error.