### PR TITLE
avoid deprecated ERR_load_crypto_strings API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3189,7 +3189,7 @@ if test "x$openssl" = "xyes" ; then
 	AC_MSG_CHECKING([if programs using OpenSSL functions will link])
 	AC_LINK_IFELSE(
 		[AC_LANG_PROGRAM([[ #include <openssl/err.h> ]],
-		[[ ERR_load_crypto_strings(); ]])],
+		[[ OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL); ]])],
 		[
 			AC_MSG_RESULT([yes])
 		],
@@ -3199,7 +3199,7 @@ if test "x$openssl" = "xyes" ; then
 			AC_MSG_CHECKING([if programs using OpenSSL need -ldl])
 			AC_LINK_IFELSE(
 				[AC_LANG_PROGRAM([[ #include <openssl/err.h> ]],
-				[[ ERR_load_crypto_strings(); ]])],
+				[[ OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL); ]])],
 				[
 					AC_MSG_RESULT([yes])
 					CHANNELLIBS="$CHANNELLIBS -ldl"

--- a/regress/misc/ssh-verify-attestation/ssh-verify-attestation.c
+++ b/regress/misc/ssh-verify-attestation/ssh-verify-attestation.c
@@ -339,7 +339,7 @@ main(int argc, char **argv)
 	extern int optind;
 	/* extern char *optarg; */
 
-	ERR_load_crypto_strings();
+	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 
 	sanitise_stdfd();
 	log_init(__progname, log_level, SYSLOG_FACILITY_AUTH, 1);

--- a/regress/unittests/sshsig/tests.c
+++ b/regress/unittests/sshsig/tests.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #ifdef WITH_OPENSSL
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #endif
@@ -85,7 +86,7 @@ tests(void)
 
 #ifdef WITH_OPENSSL
 	OpenSSL_add_all_algorithms();
-	ERR_load_crypto_strings();
+	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 #endif
 
 	TEST_START("load data");

--- a/regress/unittests/test_helper/test_helper.c
+++ b/regress/unittests/test_helper/test_helper.c
@@ -151,7 +151,7 @@ main(int argc, char **argv)
 
 	seed_rng();
 #ifdef WITH_OPENSSL
-	ERR_load_crypto_strings();
+	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 #endif
 
 	/* Handle systems without __progname */

--- a/ssherr-libcrypto.c
+++ b/ssherr-libcrypto.c
@@ -36,7 +36,7 @@ ssherr_libcrypto(void)
 	const char *reason = NULL, *file, *data;
 	int ln, fl;
 
-	ERR_load_crypto_strings();
+	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 	while ((e = ERR_get_error_line_data(&file, &ln, &data, &fl)) != 0) {
 		ERR_error_string_n(e, buf, sizeof(buf));
 		snprintf(msg, sizeof(msg), "%s:%s:%d:%s", buf, file, ln,


### PR DESCRIPTION
This function was deprecated in 1.1.0 which setting OpenSSL API compt to 0x10100000L disables the API.  Trying to build with OpenSSL 1.1.1w fails now with:
```
ssherr-libcrypto.c:39:2: error:
  call to undeclared function 'ERR_load_crypto_strings';
  ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   39 |         ERR_load_crypto_strings();
      |         ^
```

From the [OpenSSL CHANGES file](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1w/CHANGES#L2196-L2201):
> However, applications are strongly advised to compile their source files with `-DOPENSSL_API_COMPAT=0x10100000L`, which **hides the declarations of all interfaces deprecated in** 0.9.8, 1.0.0 or the **1.1.0 releases**.

Switch to the replacement API which is available in OpenSSL 1.1.1 (the oldest OpenSSH supports) and all current versions.