### PR TITLE
Do not disable post-quantum warning when kex algorithms are set

### DIFF
--- a/sshconnect.c
+++ b/sshconnect.c
@@ -1616,7 +1616,7 @@ ssh_login(struct ssh *ssh, Sensitive *sensitive, const char *orighost,
 	/* authenticate user */
 	debug("Authenticating to %s:%d as '%s'", host, port, server_user);
 	ssh_kex2(ssh, host, hostaddr, port, cinfo);
-	if (!options.kex_algorithms_set && ssh->kex != NULL &&
+	if (ssh->kex != NULL &&
 	    ssh->kex->name != NULL && options.warn_weak_crypto &&
 	    !kex_is_pq_from_name(ssh->kex->name))
 		warn_nonpq_kex();


### PR DESCRIPTION
Setting the `KexAlgorithms` should not prevent seeing the post-quantum warning, at least not when explicitly requested. This should be a simple fix for this problem. (Looks like the other occurrences of `kex_algorithms_set` can be deleted as well, but I'm not 100% sure.)

On the mailinglist, someone wrote about this issue in more detail: https://lists.mindrot.org/pipermail/openssh-unix-dev/2026-March/042381.html