### PR TITLE
Attach to FreeBSD jails

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1160,6 +1160,10 @@ mips-sony-bsd|mips-sony-newsos4)
 	# and will crash if they cannot be opened.
 	AC_DEFINE([SANDBOX_SKIP_RLIMIT_NOFILE], [1],
 	    [define if setrlimit RLIMIT_NOFILE breaks things])
+	AC_CHECK_LIB([jail], [jail_attach],
+	    AC_CHECK_HEADER([jail.h],
+	        AC_DEFINE([HAVE_JAIL], [1], [FreeBSD jail support])
+	        SSHDLIBS="$SSHDLIBS -ljail" ))
 	case "$host" in
 	*-*-freebsd9.*|*-*-freebsd10.*)
 		# Capsicum on 9 and 10 do not allow ppoll() so don't auto-enable.

--- a/misc.c
+++ b/misc.c
@@ -529,6 +529,18 @@ struct passwd *
 pwcopy(struct passwd *pw)
 {
 	struct passwd *copy = xcalloc(1, sizeof(*copy));
+	if (copy == NULL)
+		return NULL;
+
+	pwcopyto(pw, copy);
+	return copy;
+}
+
+void
+pwcopyto(struct passwd *pw, struct passwd *copy)
+{
+	if ((pw == NULL) || (copy == NULL))
+		return;
 
 	copy->pw_name = xstrdup(pw->pw_name);
 	copy->pw_passwd = xstrdup(pw->pw_passwd == NULL ? "*" : pw->pw_passwd);
@@ -548,11 +560,10 @@ pwcopy(struct passwd *pw)
 #endif
 	copy->pw_dir = xstrdup(pw->pw_dir == NULL ? "" : pw->pw_dir);
 	copy->pw_shell = xstrdup(pw->pw_shell == NULL ? "" : pw->pw_shell);
-	return copy;
 }
 
 void
-pwfree(struct passwd *pw)
+pwclear(struct passwd *pw)
 {
 	if (pw == NULL)
 		return;
@@ -567,6 +578,14 @@ pwfree(struct passwd *pw)
 #endif
 	free(pw->pw_dir);
 	free(pw->pw_shell);
+}
+
+void
+pwfree(struct passwd *pw)
+{
+	if (pw == NULL)
+		return;
+	pwclear(pw);
 	freezero(pw, sizeof(*pw));
 }
 

--- a/misc.h
+++ b/misc.h
@@ -117,6 +117,8 @@ char	*get_homedir(void);
 void	 sock_set_v6only(int);
 
 struct passwd *pwcopy(struct passwd *);
+void	 pwcopyto(struct passwd *pw, struct passwd *copy);
+void	 pwclear(struct passwd *);
 void	 pwfree(struct passwd *); /* NB. only use with pwcopy */
 
 const char *ssh_gai_strerror(int);

--- a/servconf.c
+++ b/servconf.c
@@ -435,6 +435,9 @@ fill_default_server_options(ServerOptions *options)
 	CLEAR_ON_NONE(options->authorized_principals_file);
 	CLEAR_ON_NONE(options->adm_forced_command);
 	CLEAR_ON_NONE(options->chroot_directory);
+#ifdef HAVE_JAIL
+	CLEAR_ON_NONE(options->jail_name);
+#endif
 	CLEAR_ON_NONE(options->routing_domain);
 	CLEAR_ON_NONE(options->host_key_agent);
 	CLEAR_ON_NONE(options->per_source_penalty_exempt);
@@ -2297,6 +2300,19 @@ process_server_config_line_depth(ServerOptions *options, char *line,
 			*charptr = xstrdup(arg);
 		break;
 
+#ifdef HAVE_JAIL
+	case sJailName:
+		charptr = &options->jail_name;
+
+		arg = argv_next(&ac, &av);
+		if (!arg || *arg == '\0')
+			fatal("%s line %d: %s missing argument.",
+			    filename, linenum, keyword);
+		if (*activep && *charptr == NULL)
+			*charptr = xstrdup(arg);
+		break;
+#endif
+
 	case sTrustedUserCAKeys:
 		charptr = &options->trusted_user_ca_keys;
 		goto parse_filename;
@@ -3969,6 +3985,14 @@ copy_set_server_options(ServerOptions *dst, ServerOptions *src, int preauth)
 		free(dst->chroot_directory);
 		dst->chroot_directory = NULL;
 	}
+#ifdef HAVE_JAIL
+	copy_server_option_string(&dst->jail_name,
+	    src->jail_name);
+	if (option_clear_or_none(dst->jail_name)) {
+		free(dst->jail_name);
+		dst->jail_name = NULL;
+	}
+#endif
 
 	/* Subsystems require merging. */
 	servconf_merge_subsystems(dst, src);
@@ -4253,6 +4277,9 @@ dump_config(ServerOptions *o)
 	dump_cfg_string(sBanner, o->banner);
 	dump_cfg_string(sForceCommand, o->adm_forced_command);
 	dump_cfg_string(sChrootDirectory, o->chroot_directory);
+#ifdef HAVE_JAIL
+	dump_cfg_string(sJailName, o->jail_name);
+#endif
 	dump_cfg_string(sTrustedUserCAKeys, o->trusted_user_ca_keys);
 	dump_cfg_string(sSecurityKeyProvider, o->sk_provider);
 	dump_cfg_string(sAuthorizedPrincipalsFile,

--- a/servconf.h
+++ b/servconf.h
@@ -326,10 +326,19 @@ SSHCONF_UNSUPPORTED_INT(gss_deleg_creds, GssDelegateCreds, SSHCFG_GLOBAL) \
 SSHCONF_UNSUPPORTED_INT(gss_strict_acceptor, GssStrictAcceptor, SSHCFG_GLOBAL)
 #endif /* GSSAPI */
 
+#ifdef HAVE_JAIL
+#define SSHD_CONFIG_ENTRIES_OPT \
+SSHCONF_STRING(jail_name, JailName, SSHCFG_ALL, SSHCFG_COPY_MANUAL)
+#else /* JAIL **/
+#define SSHD_CONFIG_ENTRIES_OPT \
+SSHCONF_UNSUPPORTED_STRING(jail_name, JailName, SSHCFG_ALL)
+#endif
+
 #define SSHD_CONFIG_ENTRIES \
 	SSHD_CONFIG_ENTRIES_BASE \
 	SSHD_CONFIG_ENTRIES_KRB5 \
 	SSHD_CONFIG_ENTRIES_GSS \
+	SSHD_CONFIG_ENTRIES_OPT \
 
 /* Macros to declare ServerOptions member variables */
 #define SSHCONF_INT(var, conf, flags, ms, def, cp)	int var;

--- a/session.c
+++ b/session.c
@@ -59,6 +59,10 @@
 #include <unistd.h>
 #include <limits.h>
 
+#ifdef HAVE_JAIL
+#include <jail.h>
+#endif
+
 #include "xmalloc.h"
 #include "ssh.h"
 #include "ssh2.h"
@@ -162,6 +166,9 @@ login_cap_t *lc;
 
 static int is_child = 0;
 static int in_chroot = 0;
+#ifdef HAVE_JAIL
+static int in_jail = 0;
+#endif
 
 /* File containing userauth info, if ExposeAuthInfo set */
 static char *auth_info_file = NULL;
@@ -1257,6 +1264,57 @@ do_nologin(struct passwd *pw)
 	exit(254);
 }
 
+#ifdef HAVE_JAIL
+/*
+ * jail process after checking it for safety:
+ * ensure the same username and UID match both on the jail and on the host system.
+ */
+static void
+safely_jail(const char *jail_name, struct passwd *session_pw)
+{
+	int jail_id;
+	struct passwd *jail_pw;
+
+	if (session_pw == NULL)
+		fatal("safely jail(\"%s\"): missing host user info", jail_name);
+
+#ifdef HAVE_LOGIN_CAP
+	login_close(lc);
+	lc = NULL;
+#endif
+
+	jail_id = jail_getid(jail_name);
+	if (jail_id < 0)
+		fatal("jail getid(\"%s\"): %s", jail_name, strerror(errno));
+
+	if (jail_attach(jail_id) == -1)
+		fatal("jail attach (\"%s\"): %s", jail_name, strerror(errno));
+
+	jail_pw = getpwuid(session_pw->pw_uid);
+	if (jail_pw == NULL)
+		fatal("jail user info(\"%d\"): %s", session_pw->pw_uid, strerror(errno));
+
+	if (strcmp(session_pw->pw_name, jail_pw->pw_name) != 0)
+		fatal("safely jail(\"%s\"): user \"%s\" names mismatch", jail_name, session_pw->pw_name);
+
+	/* replace session password with jail password, to later set user context and env */
+	pwclear(session_pw);
+	pwcopyto(jail_pw, session_pw);
+
+#ifdef HAVE_LOGIN_CAP
+	/* replace host login class with jail login class, to later set user context and env */
+	lc = login_getpwclass(session_pw);
+	if (lc == NULL)
+		fatal("safely jail (\"%s\"): unable to get user \"%s\" login class", jail_name, session_pw->pw_name);
+#endif
+
+	if (chdir("/") == -1)
+		fatal_f("chdir(/) after jailing: %s", strerror(errno));
+
+	verbose("Jailed into \"%s\" as user \"%s\"", jail_name, jail_pw->pw_name);
+}
+#endif
+
 /*
  * Chroot into a directory after checking it for safety: all path components
  * must be root-owned directories with strict permissions.
@@ -1320,6 +1378,17 @@ do_setusercontext(struct passwd *pw)
 	platform_setusercontext(pw);
 
 	if (platform_privileged_uidswap()) {
+#ifdef HAVE_JAIL
+		if (!in_jail && options.jail_name != NULL &&
+		    strcasecmp(options.jail_name, "none") != 0) {
+			safely_jail(options.jail_name, pw);
+			/* Make sure we don't attempt to jail again */
+			free(options.jail_name);
+			options.jail_name = NULL;
+			in_jail = 1;
+		}
+#endif
+
 #ifdef HAVE_LOGIN_CAP
 		if (setusercontext(lc, pw, pw->pw_uid,
 		    (LOGIN_SETALL & ~(LOGIN_SETPATH|LOGIN_SETUSER))) < 0) {
@@ -1343,6 +1412,11 @@ do_setusercontext(struct passwd *pw)
 
 		platform_setusercontext_post_groups(pw);
 
+#ifdef HAVE_JAIL
+		/* When already jailed, skip chroot handling. */
+		if (!in_jail)
+		{
+#endif
 		if (!in_chroot && options.chroot_directory != NULL &&
 		    strcasecmp(options.chroot_directory, "none") != 0) {
 			tmp = tilde_expand_filename(options.chroot_directory,
@@ -1359,6 +1433,9 @@ do_setusercontext(struct passwd *pw)
 			options.chroot_directory = NULL;
 			in_chroot = 1;
 		}
+#ifdef HAVE_JAIL
+		}
+#endif
 
 #ifdef HAVE_LOGIN_CAP
 		if (setusercontext(lc, pw, pw->pw_uid, LOGIN_SETUSER) < 0) {
@@ -1760,7 +1837,11 @@ session_open(Authctxt *authctxt, int chanid)
 		return 0;
 	}
 	s->authctxt = authctxt;
+#ifdef HAVE_JAIL
+	s->pw = pwcopy(authctxt->pw);
+#else
 	s->pw = authctxt->pw;
+#endif
 	if (s->pw == NULL || !authctxt->valid)
 		fatal("no user for session %d", s->self);
 	debug("session_open: session %d: link with channel %d", s->self, chanid);
@@ -2416,6 +2497,9 @@ session_close(struct ssh *ssh, Session *s)
 		}
 		free(s->env);
 	}
+#ifdef HAVE_JAIL
+	pwfree(s->pw);
+#endif
 	session_proctitle(s);
 	session_unused(s->self);
 }

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -990,6 +990,23 @@ for interactive sessions and
 .Cm none
 (the operating system default)
 for non-interactive sessions.
+.It Cm JailName
+Specifies the name of a FreeBSD jail to attach to after authentication.
+At session startup
+.Xr sshd 8
+checks that the session user id matches the same user name outside and inside the jail.
+After attaching to the jail,
+.Xr sshd 8
+changes the working directory to the user's home directory defined inside the jail.
+.Pp
+The
+.Cm JailName
+must matches the name of a running FreeBSD jail, which contain the necessary files and directories to support the
+user's session.
+.Pp
+The default is
+.Cm none ,
+indicating to remain attached to the host system.
 .It Cm KbdInteractiveAuthentication
 Specifies whether to allow keyboard-interactive authentication.
 All authentication styles from
@@ -1340,6 +1357,7 @@ Available keywords are
 .Cm IgnoreRhosts ,
 .Cm Include ,
 .Cm IPQoS ,
+.Cm JailName ,
 .Cm KbdInteractiveAuthentication ,
 .Cm KerberosAuthentication ,
 .Cm LogLevel ,
@@ -1949,6 +1967,8 @@ The default is
 .Cm yes .
 Note that this does not apply to
 .Cm ChrootDirectory ,
+or
+.Cm JailName ,
 whose permissions and ownership are checked unconditionally.
 .It Cm Subsystem
 Configures an external subsystem (e.g. file transfer daemon).


### PR DESCRIPTION
Patch aimed at FreeBSD servers:
enable a session to be attached to a running jail,
checks that the session user id matches the same user name outside and inside the jail,
and changes the working directory to the user's home directory defined inside the jail.