### PR TITLE
doc: mention additional RekeyLimit suffixes

### DIFF
--- a/ssh_config.5
+++ b/ssh_config.5
@@ -1736,9 +1736,13 @@ amount of time that may pass before the session key is renegotiated.
 The first argument is specified in bytes and may have a suffix of
 .Sq K ,
 .Sq M ,
+.Sq G ,
+.Sq T ,
+.Sq P ,
 or
-.Sq G
-to indicate Kilobytes, Megabytes, or Gigabytes, respectively.
+.Sq E
+to indicate Kilobytes, Megabytes, Gigabytes, Terabytes, Petabytes, or
+Exabytes, respectively.
 The default is between
 .Sq 1G
 and

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1817,9 +1817,13 @@ amount of time that may pass before the session key is renegotiated.
 The first argument is specified in bytes and may have a suffix of
 .Sq K ,
 .Sq M ,
+.Sq G ,
+.Sq T ,
+.Sq P ,
 or
-.Sq G
-to indicate Kilobytes, Megabytes, or Gigabytes, respectively.
+.Sq E
+to indicate Kilobytes, Megabytes, Gigabytes, Terabytes, Petabytes, or
+Exabytes, respectively.
 The default is between
 .Sq 1G
 and


### PR DESCRIPTION
`RekeyLimit` is currently documented as accepting `K`, `M`, and `G`, but OpenSSH parses size values via `scan_scaled()`, which also accepts `T`, `P`, and `E`.
