### PR TITLE
ci: match all OpenSSL versions in setup_ci.sh, not just 3.x

### DIFF
--- a/.github/setup_ci.sh
+++ b/.github/setup_ci.sh
@@ -143,7 +143,7 @@ for TARGET in $TARGETS; do
         case ${INSTALL_OPENSSL} in
           1.1.1_stable)	INSTALL_OPENSSL="OpenSSL_1_1_1-stable" ;;
           1.*)	INSTALL_OPENSSL="OpenSSL_$(echo ${INSTALL_OPENSSL} | tr . _)" ;;
-          3.*)	INSTALL_OPENSSL="openssl-${INSTALL_OPENSSL}" ;;
+          *)	INSTALL_OPENSSL="openssl-${INSTALL_OPENSSL}" ;;
         esac
         PACKAGES="${PACKAGES} putty-tools dropbear-bin"
        ;;


### PR DESCRIPTION
The case pattern for constructing the OpenSSL target only matched versions starting with 3. Change to a wildcard default so future OpenSSL major versions (e.g. 4.x) work without further edits.