### PR TITLE
Make ci work^Wattempt to run for OpenSSL 4 variants

### DIFF
--- a/.github/install_libcrypto.sh
+++ b/.github/install_libcrypto.sh
@@ -51,7 +51,7 @@ if [ "${abi_compat_test}" = "y" ]; then
 		ver="${major}.$((${minor} + 1))"
 		echo selecting next release branch ${ver}
 		;;
-	openssl-3.*.*)
+	openssl-[34].*.*)
 		major=$(echo ${ver} | cut -f1 -d.)
 		minor=$(echo ${ver} | cut -f2 -d.)
 		patch=$(echo ${ver} | cut -f3 -d.)


### PR DESCRIPTION
Assuming I did this right this is correct for 4 going forward and maintains the bypass for the 3.X version
breakage. 