### PR TITLE
sk-usbhid: skip unsupported key types in read_rks()

### DIFF
--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -1262,6 +1262,7 @@ read_rks(struct sk_usbhid *sk, const char *pin,
     struct sk_resident_key ***rksp, size_t *nrksp)
 {
 	int ret = SSH_SK_ERR_GENERAL, r = -1, internal_uv;
+	uint32_t alg;
 	fido_credman_metadata_t *metadata = NULL;
 	fido_credman_rp_t *rp = NULL;
 	fido_credman_rk_t *rk = NULL;
@@ -1358,6 +1359,20 @@ read_rks(struct sk_usbhid *sk, const char *pin,
 			    user_id_len, j, fido_cred_type(cred),
 			    fido_cred_flags(cred), fido_cred_prot(cred));
 
+			/* Determine key algorithm */
+			switch (fido_cred_type(cred)) {
+			case COSE_ES256:
+				alg = SSH_SK_ECDSA;
+				break;
+			case COSE_EDDSA:
+				alg = SSH_SK_ED25519;
+				break;
+			default:
+				skdebug(__func__, "unsupported key type %d",
+				    fido_cred_type(cred));
+				continue;
+			}
+
 			/* build response entry */
 			if ((srk = calloc(1, sizeof(*srk))) == NULL ||
 			    (srk->key.key_handle = calloc(1,
@@ -1369,25 +1384,13 @@ read_rks(struct sk_usbhid *sk, const char *pin,
 				goto out;
 			}
 
+			srk->alg = alg;
 			srk->key.key_handle_len = fido_cred_id_len(cred);
 			memcpy(srk->key.key_handle, fido_cred_id_ptr(cred),
 			    srk->key.key_handle_len);
 			srk->user_id_len = user_id_len;
 			if (srk->user_id_len != 0)
 				memcpy(srk->user_id, user_id, srk->user_id_len);
-
-			switch (fido_cred_type(cred)) {
-			case COSE_ES256:
-				srk->alg = SSH_SK_ECDSA;
-				break;
-			case COSE_EDDSA:
-				srk->alg = SSH_SK_ED25519;
-				break;
-			default:
-				skdebug(__func__, "unsupported key type %d",
-				    fido_cred_type(cred));
-				goto out; /* XXX free rk and continue */
-			}
 
 			if (fido_cred_prot(cred) == FIDO_CRED_PROT_UV_REQUIRED
 			    && internal_uv == -1)


### PR DESCRIPTION
## Summary

- In `read_rks()`, encountering a resident credential with an unsupported COSE key type (anything other than ES256 or EdDSA) causes `goto out`, aborting the entire resident key enumeration. All valid keys - both already collected and remaining - are discarded.
- This means a single unsupported credential on a FIDO2 token causes `ssh-add -K` / `ssh-keygen -K` to return zero keys, even if other valid ecdsa-sk or ed25519-sk credentials exist.
- The fix moves the key type check before the per-credential allocation, so unsupported types are skipped with `continue` instead of aborting the loop. No memory is allocated before the check, so `continue` is safe without additional cleanup.
- The existing `XXX` comment at the old `goto out` site (`/* XXX free rk and continue */`) documents the intended fix.

## Details

The old code allocated `srk` (including `key_handle`, `application`, `user_id`) *before* checking the key type. When the switch hit the default case, `goto out` jumped past the `ret = 0` assignment, returning `SSH_SK_ERR_GENERAL`. The caller `sk_load_resident_keys()` then freed all previously collected keys and returned an error.

The new code checks `fido_cred_type()` first, stores the result in a local `uint32_t alg`, and only proceeds with allocation if the type is supported. For supported types, behavior is unchanged.

## Test plan

- Compiled with `./configure --with-security-key-builtin && make` - zero warnings with `-Wall -Wextra -Wuninitialized -Wsign-compare`
- Existing regression test suite passes
- Wrote a standalone C test modeling the exact loop structure that proves: old code aborts on unsupported key type (losing valid keys), new code skips and continues (preserving valid keys)
- Verified no behavior change when all credentials use supported types