### PR TITLE
channels: use computed poll events for distinct socket fd

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -2858,7 +2858,7 @@ channel_prepare_pollfd(Channel *c, u_int *next_pollfd,
 		if (ev != 0) {
 			c->pfds[3] = p;
 			pfd[p].fd = c->sock;
-			pfd[p].events = 0;
+			pfd[p].events = ev;
 			dump_channel_poll(__func__, "sock", c, p, &pfd[p]);
 			p++;
 		}


### PR DESCRIPTION
## Summary

channel_prepare_pollfd() computes a pollfd event mask for a channel socket, but the branch for a socket fd distinct from rfd stores zero in the pollfd events field.

This stores the computed mask instead, matching the rfd, wfd, and efd branches.

## Details

With events set to zero, poll()/ppoll() will not report normal read or write readiness for that socket; only exceptional conditions such as HUP, ERR, or NVAL can wake the entry. channel_after_poll() already filters readiness through the corresponding SSH_CHAN_IO_SOCK_R and SSH_CHAN_IO_SOCK_W masks, so this only arms the events the channel already requested.

This was found while reviewing an sshd-session channel wait-loop symptom, but this PR only claims the local channel polling bug fixed here.

## Validation

- autoreconf
- ./configure
- make channels.o
- make -j2
- git diff --check -- channels.c