### PR TITLE
ci: avoid rsync dependency in NetBSD VM jobs

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -170,7 +170,7 @@ jobs:
         copyback: false
         prepare: |
           case "$(uname -r)" in
-          9.*) export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/9.0_2026Q1/All" ;;
+          9.*) export PKG_PATH="http://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/9.0_2026Q1/All" ;;
           esac
           /usr/sbin/pkg_add sudo
           openssl rand -base64 9 >$GITHUB_WORKSPACE/regress/password

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -170,7 +170,7 @@ jobs:
         copyback: false
         prepare: |
           case "$(uname -r)" in
-          9.*) export PKG_PATH="http://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/9.0_2026Q1/All" ;;
+          9.*) export PKG_PATH="ftp://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/9.0_2026Q1/All" ;;
           esac
           /usr/sbin/pkg_add sudo
           openssl rand -base64 9 >$GITHUB_WORKSPACE/regress/password

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -166,7 +166,12 @@ jobs:
       with:
         release: ${{ matrix.target }}
         usesh: true
+        sync: scp
+        copyback: false
         prepare: |
+          case "$(uname -r)" in
+          9.*) export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/9.0_2026Q1/All" ;;
+          esac
           /usr/sbin/pkg_add sudo
           openssl rand -base64 9 >$GITHUB_WORKSPACE/regress/password
           pw=$(tr -d '\n' <$GITHUB_WORKSPACE/regress/password | pwhash)
@@ -496,4 +501,3 @@ jobs:
         cd $GITHUB_WORKSPACE
         cp regress/password regress/kbdintpw
         sudo -u builder env SUDO=sudo TEST_SSH_SSHD_CONFOPTS="UsePam yes" make t-exec
-


### PR DESCRIPTION
The NetBSD VM jobs currently rely on the package path selected by the VM image and on vmactions/netbsd-vm default rsync synchronization.

For NetBSD 9.x this now fails before OpenSSH is built or tested:

- with default sync, the action tries to install rsync inside the VM before copying the workspace
- `pkg_add` looks under `cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/x86_64/9.x/All/...`
- the CDN currently redirects those paths to an unavailable/stale `9.0_2025Q4` package path
- rsync/sudo installation fails with `no pkg found`, so the workflow never reaches configure/build/tests

This PR does two narrowly scoped things for the NetBSD VM jobs:

- switches workspace synchronization to the action-supported `sync: scp` mode and disables copyback, avoiding the remote rsync dependency
- points NetBSD 9.x package installs at the live `9.0_2026Q1` package set before installing sudo

The workflow only needs to copy the checkout into the VM and then run the build/test commands there; it does not need rsync-specific behaviour or artifacts copied back to the host.

Evidence:

- failing PR #660 run showed NetBSD 9.0/9.4 failing before configure/build/test on missing rsync
- first revision of this PR showed `sync: scp` reaches source upload, then fails on the same stale NetBSD 9.x package path while installing sudo
- `https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/x86_64/9.0_2026Q1/All/` contains current sudo and rsync packages

Local verification:

- parsed `.github/workflows/vm.yml` with PyYAML
- `git diff --check`

GitHub Actions for the current revision are queued at the time of writing.