### PR TITLE
sshd: Suppress host key loading error when using a PKCS#11 based HostKey

### DIFF
--- a/sshd.c
+++ b/sshd.c
@@ -1591,7 +1591,8 @@ main(int ac, char **av)
 		if (options.host_key_files[i] == NULL)
 			continue;
 		if ((r = sshkey_load_private(options.host_key_files[i], "",
-		    &key, NULL)) != 0 && r != SSH_ERR_SYSTEM_ERROR)
+		    &key, NULL)) != 0 && r != SSH_ERR_SYSTEM_ERROR &&
+		    !have_agent)
 			do_log2_r(r, ll, "Unable to load host key \"%s\"",
 			    options.host_key_files[i]);
 		if (sshkey_is_sk(key) &&


### PR DESCRIPTION
This is an attempt to fix the problem reported in https://bugzilla.mindrot.org/show_bug.cgi?id=3964

**Problem details (copied from bugzilla);**

I am using a PKCS11 based hostkey for SSHD.
I am starting an ssh-agent on the host, then add the PKCS#11 provider and its key via 'ssh-add -s /path/to/pkcs11-provider' (one EC P-256 key gets added). Then I create the public SSH key from it using 'ssh-keygen -D /path/to/pkcs11-provider > /path/to/ssh_host_pkcs11_key.pub'. 

Then I edit the SSHD config file as follows:

  HostKey /path/to/ssh_host_pkcs11_key.pub
  HostKeyAgent SSH_AUTH_SOCK

So the key specified with HostKey is a public key, and not a private key.
Environment variable SSH_AUTH_SOCK is set to the agent socket address.

When staring sshd, I get 'Unable to load host key "/path/to/ssh_host_pkcs11_key.pub": error in libcrypto'. However, processing continues and sshd is finally up fine. 

Turning on debug (-d option) shows that it recognizes the agent key later on: 

   debug1: will rely on agent for hostkey /path/to/ssh_host_pkcs11_key.pub
   debug1: agent host key #0: ecdsa-sha2-nistp256 SHA256:<fingerprint>

So its not a functional problem, but the error message 'Unable to load host key "/path/to/ssh_host_pkcs11_key.pub": error in libcrypto' is confusing.

The doc at https://man.openbsd.org/sshd_config#HostKey states "It is also possible to specify public host key files instead. In this case operations on the private key will be delegated to an ssh-agent(1).". So it seems legit to specify a public key here when an agent based host key is used. 

**Fix:**

Suppress the confusing error message when attempting to load the private host key when an agent is used.

