### PR TITLE
log: keep fallback syslog open between messages

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -699,6 +699,7 @@ UNITTESTS_TEST_MISC_OBJS=\
 	regress/unittests/misc/test_hpdelim.o \
 	regress/unittests/misc/test_ptimeout.o \
 	regress/unittests/misc/test_xextendf.o \
+	regress/unittests/misc/test_log.o \
 	regress/unittests/misc/test_misc.o
 
 regress/unittests/misc/test_misc$(EXEEXT): \

--- a/log.c
+++ b/log.c
@@ -63,6 +63,10 @@ static log_handler_fn *log_handler;
 static void *log_handler_ctx;
 static char **log_verbose;
 static size_t nlog_verbose;
+#if !(defined(HAVE_OPENLOG_R) && defined(SYSLOG_DATA_INIT))
+/* Track process-global syslog state left open by this module. */
+static int syslog_open;
+#endif
 extern char *__progname;
 
 #define LOG_SYSLOG_VIS	(VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL)
@@ -209,6 +213,12 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
 	log_handler = NULL;
 	log_handler_ctx = NULL;
 
+#if !(defined(HAVE_OPENLOG_R) && defined(SYSLOG_DATA_INIT))
+	if (syslog_open) {
+		closelog();
+		syslog_open = 0;
+	}
+#endif
 	log_on_stderr = on_stderr;
 	if (on_stderr)
 		return;
@@ -262,14 +272,14 @@ log_init(const char *av0, LogLevel level, SyslogFacility facility,
 	/*
 	 * If an external library (eg libwrap) attempts to use syslog
 	 * immediately after reexec, syslog may be pointing to the wrong
-	 * facility, so we force an open/close of syslog here.
+	 * facility, so we force a syslog reinitialisation here.
 	 */
 #if defined(HAVE_OPENLOG_R) && defined(SYSLOG_DATA_INIT)
 	openlog_r(argv0 ? argv0 : __progname, LOG_PID, log_facility, &sdata);
 	closelog_r(&sdata);
 #else
 	openlog(argv0 ? argv0 : __progname, LOG_PID, log_facility);
-	closelog();
+	syslog_open = 1;
 #endif
 }
 
@@ -416,9 +426,10 @@ do_log(LogLevel level, int force, const char *suffix, const char *fmt,
 		syslog_r(pri, &sdata, "%.500s", fmtbuf);
 		closelog_r(&sdata);
 #else
+		/* Restore OpenSSH ident/facility before using global syslog. */
 		openlog(progname, LOG_PID, log_facility);
+		syslog_open = 1;
 		syslog(pri, "%.500s", fmtbuf);
-		closelog();
 #endif
 	}
 	errno = saved_errno;

--- a/regress/unittests/misc/Makefile
+++ b/regress/unittests/misc/Makefile
@@ -11,6 +11,7 @@ SRCS+=	test_strdelim.c
 SRCS+=	test_hpdelim.c
 SRCS+=	test_ptimeout.c
 SRCS+=	test_xextendf.c
+SRCS+=	test_log.c
 
 # From usr.bin/ssh/Makefile.inc
 SRCS+=	sshbuf.c

--- a/regress/unittests/misc/test_log.c
+++ b/regress/unittests/misc/test_log.c
@@ -1,0 +1,264 @@
+/* 	$OpenBSD$ */
+/*
+ * Regress tests for log.c syslog lifecycle.
+ *
+ * Placed in the public domain.
+ */
+
+#include "includes.h"
+
+#include <sys/types.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+
+#ifdef syslog
+# undef syslog
+#endif
+
+#include "../test_helper/test_helper.h"
+
+#include "log.h"
+
+#if !(defined(HAVE_OPENLOG_R) && defined(SYSLOG_DATA_INIT))
+
+#define MAX_FAKE_SYSLOG_MSGS 16
+
+struct fake_syslog_msg {
+	char ident[64];
+	int facility;
+	int priority;
+	char msg[256];
+};
+
+static int fake_syslog_is_open;
+static char fake_ident[64];
+static int fake_facility;
+static int fake_openlog_calls;
+static int fake_closelog_calls;
+static int fake_socket_opens;
+static int fake_syslog_calls;
+static struct fake_syslog_msg fake_msgs[MAX_FAKE_SYSLOG_MSGS];
+
+static int fake_handler_calls;
+static char fake_handler_msg[256];
+
+void
+openlog(const char *ident, int option, int facility)
+{
+	(void)option;
+
+	fake_openlog_calls++;
+	if (!fake_syslog_is_open) {
+		fake_socket_opens++;
+		fake_syslog_is_open = 1;
+	}
+	strlcpy(fake_ident, ident == NULL ? "" : ident, sizeof(fake_ident));
+	fake_facility = facility;
+}
+
+void
+closelog(void)
+{
+	fake_closelog_calls++;
+	fake_syslog_is_open = 0;
+	fake_ident[0] = '\0';
+	fake_facility = 0;
+}
+
+static void
+fake_vsyslog(int priority, const char *fmt, va_list ap)
+{
+	struct fake_syslog_msg *m;
+
+	ASSERT_INT_EQ(fake_syslog_is_open, 1);
+	ASSERT_INT_LT(fake_syslog_calls, MAX_FAKE_SYSLOG_MSGS);
+	m = &fake_msgs[fake_syslog_calls++];
+	strlcpy(m->ident, fake_ident, sizeof(m->ident));
+	m->facility = fake_facility;
+	m->priority = priority;
+	vsnprintf(m->msg, sizeof(m->msg), fmt, ap);
+}
+
+void
+syslog(int priority, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fake_vsyslog(priority, fmt, ap);
+	va_end(ap);
+}
+
+void
+__syslog_chk(int priority, int flag, const char *fmt, ...)
+{
+	va_list ap;
+
+	(void)flag;
+	va_start(ap, fmt);
+	fake_vsyslog(priority, fmt, ap);
+	va_end(ap);
+}
+
+void
+vsyslog(int priority, const char *fmt, va_list ap)
+{
+	fake_vsyslog(priority, fmt, ap);
+}
+
+void
+__vsyslog_chk(int priority, int flag, const char *fmt, va_list ap)
+{
+	(void)flag;
+	fake_vsyslog(priority, fmt, ap);
+}
+
+static void
+fake_reset(void)
+{
+	fake_syslog_is_open = 0;
+	fake_ident[0] = '\0';
+	fake_facility = 0;
+	fake_openlog_calls = 0;
+	fake_closelog_calls = 0;
+	fake_socket_opens = 0;
+	fake_syslog_calls = 0;
+	memset(fake_msgs, 0, sizeof(fake_msgs));
+	fake_handler_calls = 0;
+	fake_handler_msg[0] = '\0';
+}
+
+static void
+reset_log_state(void)
+{
+	log_init("test_misc", SYSLOG_LEVEL_QUIET, SYSLOG_FACILITY_AUTH, 1);
+	fake_reset();
+}
+
+static void
+fake_log_handler(LogLevel level, int force, const char *msg, void *ctx)
+{
+	(void)force;
+	(void)ctx;
+
+	fake_handler_calls++;
+	ASSERT_INT_EQ(level, SYSLOG_LEVEL_INFO);
+	strlcpy(fake_handler_msg, msg, sizeof(fake_handler_msg));
+}
+
+static void
+test_syslog_kept_open_between_messages(void)
+{
+	TEST_START("syslog kept open between messages");
+	reset_log_state();
+
+	log_init("openssh-auth", SYSLOG_LEVEL_INFO, SYSLOG_FACILITY_AUTH, 0);
+	ASSERT_INT_EQ(fake_openlog_calls, 1);
+	ASSERT_INT_EQ(fake_socket_opens, 1);
+	ASSERT_INT_EQ(fake_closelog_calls, 0);
+
+	do_log2(SYSLOG_LEVEL_INFO, "first message");
+	do_log2(SYSLOG_LEVEL_ERROR, "second message");
+
+	ASSERT_INT_EQ(fake_syslog_calls, 2);
+	ASSERT_INT_EQ(fake_socket_opens, 1);
+	ASSERT_INT_EQ(fake_closelog_calls, 0);
+	ASSERT_STRING_EQ(fake_msgs[0].ident, "openssh-auth");
+	ASSERT_INT_EQ(fake_msgs[0].facility, LOG_AUTH);
+	ASSERT_INT_EQ(fake_msgs[0].priority, LOG_INFO);
+	ASSERT_STRING_EQ(fake_msgs[0].msg, "first message");
+	ASSERT_STRING_EQ(fake_msgs[1].ident, "openssh-auth");
+	ASSERT_INT_EQ(fake_msgs[1].facility, LOG_AUTH);
+	ASSERT_INT_EQ(fake_msgs[1].priority, LOG_ERR);
+	ASSERT_STRING_EQ(fake_msgs[1].msg, "error: second message");
+
+	TEST_DONE();
+}
+
+static void
+test_log_init_reopens_on_facility_change(void)
+{
+	TEST_START("log_init reopens on facility change");
+	reset_log_state();
+
+	log_init("openssh-auth", SYSLOG_LEVEL_INFO, SYSLOG_FACILITY_AUTH, 0);
+	do_log2(SYSLOG_LEVEL_INFO, "auth message");
+	log_init("openssh-user", SYSLOG_LEVEL_INFO, SYSLOG_FACILITY_USER, 0);
+	do_log2(SYSLOG_LEVEL_INFO, "user message");
+
+	ASSERT_INT_EQ(fake_closelog_calls, 1);
+	ASSERT_INT_EQ(fake_socket_opens, 2);
+	ASSERT_INT_EQ(fake_syslog_calls, 2);
+	ASSERT_STRING_EQ(fake_msgs[0].ident, "openssh-auth");
+	ASSERT_INT_EQ(fake_msgs[0].facility, LOG_AUTH);
+	ASSERT_STRING_EQ(fake_msgs[1].ident, "openssh-user");
+	ASSERT_INT_EQ(fake_msgs[1].facility, LOG_USER);
+	ASSERT_STRING_EQ(fake_msgs[1].msg, "user message");
+
+	TEST_DONE();
+}
+
+static void
+test_foreign_syslog_use_is_overwritten(void)
+{
+	TEST_START("foreign syslog use is overwritten");
+	reset_log_state();
+
+	log_init("openssh-auth", SYSLOG_LEVEL_INFO, SYSLOG_FACILITY_AUTH, 0);
+	do_log2(SYSLOG_LEVEL_INFO, "before foreign");
+
+	openlog("foreign", LOG_PID, LOG_DAEMON);
+	syslog(LOG_INFO, "%s", "foreign message");
+	closelog();
+	do_log2(SYSLOG_LEVEL_INFO, "after foreign");
+
+	ASSERT_INT_EQ(fake_syslog_calls, 3);
+	ASSERT_STRING_EQ(fake_msgs[0].ident, "openssh-auth");
+	ASSERT_INT_EQ(fake_msgs[0].facility, LOG_AUTH);
+	ASSERT_STRING_EQ(fake_msgs[1].ident, "foreign");
+	ASSERT_INT_EQ(fake_msgs[1].facility, LOG_DAEMON);
+	ASSERT_STRING_EQ(fake_msgs[2].ident, "openssh-auth");
+	ASSERT_INT_EQ(fake_msgs[2].facility, LOG_AUTH);
+	ASSERT_STRING_EQ(fake_msgs[2].msg, "after foreign");
+
+	TEST_DONE();
+}
+
+static void
+test_log_handler_bypasses_syslog(void)
+{
+	TEST_START("log handler bypasses syslog");
+	reset_log_state();
+
+	log_init("openssh-auth", SYSLOG_LEVEL_INFO, SYSLOG_FACILITY_AUTH, 0);
+	set_log_handler(fake_log_handler, NULL);
+	do_log2(SYSLOG_LEVEL_INFO, "handler message");
+
+	ASSERT_INT_EQ(fake_handler_calls, 1);
+	ASSERT_STRING_EQ(fake_handler_msg, "handler message");
+	ASSERT_INT_EQ(fake_syslog_calls, 0);
+
+	TEST_DONE();
+}
+
+void
+test_log(void)
+{
+	test_syslog_kept_open_between_messages();
+	test_log_init_reopens_on_facility_change();
+	test_foreign_syslog_use_is_overwritten();
+	test_log_handler_bypasses_syslog();
+	log_init("test_misc", SYSLOG_LEVEL_QUIET, SYSLOG_FACILITY_AUTH, 1);
+}
+
+#else
+
+void
+test_log(void)
+{
+}
+
+#endif

--- a/regress/unittests/misc/tests.c
+++ b/regress/unittests/misc/tests.c
@@ -27,6 +27,7 @@ void test_hpdelim(void);
 void test_ptimeout(void);
 void test_xextendf(void);
 void test_misc(void);
+void test_log(void);
 
 void
 tests(void)
@@ -40,6 +41,7 @@ tests(void)
 	test_ptimeout();
 	test_xextendf();
 	test_misc();
+	test_log();
 }
 
 void


### PR DESCRIPTION
On platforms that use the process-global syslog API, OpenSSH currently opens and closes syslog around each individual log message.

Keep that fallback syslog state open between OpenSSH log messages instead. `log_init()` still closes any OpenSSH-owned syslog state before changing ident/facility, and each log write still calls `openlog()` first so OpenSSH restores its expected ident/facility after any other library uses syslog.

The `openlog_r()` path is unchanged.

This reduces repeated fallback syslog open/close churn while preserving the lifecycle behavior that matters for reinitialization and foreign syslog users.

Regress coverage added for:
- keeping the fallback syslog state open across multiple OpenSSH log messages;
- closing/reopening on `log_init()` ident/facility changes;
- restoring OpenSSH ident/facility after foreign syslog use;
- bypassing syslog when a log handler is installed.

Tested:
- `git diff --check`
- `./regress/unittests/misc/test_misc`
- `make unit`
