### PR TITLE
Fix a critical vulnerability that could lead to system dumping and in…

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -1376,6 +1376,13 @@ x11_open_helper(struct ssh *ssh, struct sshbuf *b)
 	u_char *ucp;
 	u_int proto_len, data_len;
 
+	/* Null check. */
+    if (sc->x11_saved_proto == NULL) {
+        debug2("X11 open received before x11-req sent");
+        return -1;
+    }
+
+
 	/* Is this being called after the refusal deadline? */
 	if (sc->x11_refuse_time != 0 &&
 	    monotime() >= sc->x11_refuse_time) {


### PR DESCRIPTION
…fo disclosure via ssh -X

A vulnerability that dates back to 1999 that led to a null crash vulnerability causing info disclosure from a crash dump file from an unauthenticated user when you try ssh-X to connect to a server. someone running a malicious ssh server can trigger this by sending SSH2_MSG_CHANNEL_OPEN(x11) before the client sends x11-req, causing strlen(NULL) in x11_open_helper(). ... Leading to key's being leaked, an potential system hijack.

NULL Pointer Dereference → SIGSEGV → Information Disclosure → Key Theft → RCE

[exploit.py](https://github.com/user-attachments/files/28431889/exploit.py)
