### PR TITLE
fix compatibility-layer correctness and robustness issues

### DIFF
--- a/openbsd-compat/bsd-cygwin_util.c
+++ b/openbsd-compat/bsd-cygwin_util.c
@@ -198,8 +198,10 @@ _match_pattern(const char *s, const char *pattern)
 		return 0;
 	ws = (wchar_t *) xcalloc(len + 1, sizeof (wchar_t));
 	mbstowcs(ws, s, len + 1);
-	if ((len = mbstowcs(NULL, pattern, 0)) == (size_t) -1)
+	if ((len = mbstowcs(NULL, pattern, 0)) == (size_t) -1) {
+		free(ws);
 		return 0;
+	}
 	wpattern = (wchar_t *) xcalloc(len + 1, sizeof (wchar_t));
 	mbstowcs(wpattern, pattern, len + 1);
 	ret = __match_pattern (ws, wpattern);
@@ -220,7 +222,7 @@ cygwin_ug_match_pattern_list(const char *string, const char *pattern)
 	char sub[1024];
 	int negated;
 	int got_positive;
-	u_int i, subi, len = strlen(pattern);
+	size_t i, subi, len = strlen(pattern);
 
 	got_positive = 0;
 	for (i = 0; i < len;) {

--- a/openbsd-compat/bsd-misc.c
+++ b/openbsd-compat/bsd-misc.c
@@ -455,7 +455,7 @@ bzero(void *b, size_t n)
 int
 raise(int sig)
 {
-	kill(getpid(), sig);
+	return kill(getpid(), sig);
 }
 #endif
 

--- a/openbsd-compat/fake-rfc2553.c
+++ b/openbsd-compat/fake-rfc2553.c
@@ -53,6 +53,8 @@ int getnameinfo(const struct sockaddr *sa, size_t salen, char *host,
 
 	if (sa->sa_family != AF_UNSPEC && sa->sa_family != AF_INET)
 		return (EAI_FAMILY);
+	if (salen < sizeof(struct sockaddr_in))
+		return (EAI_FAMILY);
 	if (serv != NULL) {
 		snprintf(tmpserv, sizeof(tmpserv), "%d", ntohs(sin->sin_port));
 		if (strlcpy(serv, tmpserv, servlen) >= servlen)

--- a/openbsd-compat/getrrsetbyname-ldns.c
+++ b/openbsd-compat/getrrsetbyname-ldns.c
@@ -235,10 +235,12 @@ getrrsetbyname(const char *hostname, unsigned int rdclass,
 	}
 
 	*res = rrset;
+	rrset = NULL;	/* ownership transferred to caller via *res */
 	result = ERRSET_SUCCESS;
 
 fail:
-	/* freerrset(rrset); */
+	/* On the error paths rrset is still owned here; free it. */
+	freerrset(rrset);
 	ldns_rdf_deep_free(domain);
 	ldns_pkt_free(pkt);
 	ldns_rr_list_deep_free(rrsigs);

--- a/openbsd-compat/port-aix.c
+++ b/openbsd-compat/port-aix.c
@@ -75,7 +75,7 @@ static char old_registry[REGISTRY_SIZE] = "";
 void
 aix_usrinfo(struct passwd *pw)
 {
-	u_int i;
+	int i;
 	size_t len;
 	char *cp;
 
@@ -84,6 +84,8 @@ aix_usrinfo(struct passwd *pw)
 
 	i = snprintf(cp, len, "LOGNAME=%s%cNAME=%s%c", pw->pw_name, '\0',
 	    pw->pw_name, '\0');
+	if (i < 0 || (size_t)i >= len)
+		fatal("%s: snprintf failed", __func__);
 	if (usrinfo(SETUINFO, cp, i) == -1)
 		fatal("Couldn't set usrinfo: %s", strerror(errno));
 	debug3("AIX/UsrInfo: set len %d", i);
@@ -100,7 +102,7 @@ aix_usrinfo(struct passwd *pw)
 void
 aix_remove_embedded_newlines(char *p)
 {
-	if (p == NULL)
+	if (p == NULL || *p == '\0')
 		return;
 
 	for (; *p; p++) {

--- a/openbsd-compat/port-prngd.c
+++ b/openbsd-compat/port-prngd.c
@@ -148,6 +148,13 @@ done:
 int
 seed_from_prngd(unsigned char *buf, size_t bytes)
 {
+	/*
+	 * get_random_bytes_prngd() takes an int length and rejects > 255;
+	 * reject oversize requests here so the size_t->int narrowing below
+	 * can never silently truncate into an in-range (short read) value.
+	 */
+	if (bytes > 255)
+		return -1;
 #ifdef PRNGD_PORT
 	debug("trying egd/prngd port %d", PRNGD_PORT);
 	if (get_random_bytes_prngd(buf, bytes, PRNGD_PORT, NULL) == 0)


### PR DESCRIPTION
This PR fixes several correctness and robustness issues in `openbsd-compat/`.

The changes are limited to portability-layer code and include fixes for error handling, bounds validation, ownership cleanup, type-safety, and edge-case handling.

## Changes

### bsd-misc.c

* Return the result of `kill()` from the `raise()` compatibility wrapper instead of falling off the end of a non-void function.

### port-aix.c

* Guard `aix_remove_embedded_newlines()` against empty strings to avoid decrementing past the start of the buffer.
* Improve `snprintf()` result handling in `aix_usrinfo()` by using a signed return type and validating the result before passing it to `usrinfo()`.

### fake-rfc2553.c

* Validate that the supplied socket address length is large enough for `struct sockaddr_in` before accessing address fields.

### port-prngd.c

* Reject requests larger than the maximum length accepted by `get_random_bytes_prngd()` to prevent problematic size narrowing from `size_t` to `int`.

### bsd-cygwin_util.c

* Free allocated memory when pattern conversion fails in `_match_pattern()`.
* Use `size_t` instead of `u_int` for string-length based iteration.

### getrrsetbyname-ldns.c

* Clarify ownership transfer after successful assignment to `*res`.
* Ensure resources are released correctly on error paths.

## Testing

* Verified that the changes are localized to `openbsd-compat/`.
* Reviewed affected control flow, ownership handling, and boundary conditions.
* Platform-specific code paths (AIX, Cygwin, LDNS, PRNGD compatibility code) were inspected for correctness, but were not compile-tested on their respective target platforms.