### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -134,10 +134,10 @@ jobs:
     - name: install cygwin
       id: cygwin_install
       if: ${{ startsWith(matrix.target, 'windows') }}
-      uses: cygwin/cygwin-install-action@master
+      uses: cygwin/cygwin-install-action@4ef15ca7fd18a18f1000989fcfd968e06d146ce8 # master
       env:
         CYGWIN: "winsymlinks:native"
-    - uses: actions/checkout@main
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # main
     - name: setup CI system
       run: |
         sh -c "timeout 1200 .github/setup_ci.sh ${{ matrix.config }} ${{ matrix.target }} || .github/setup_ci.sh ${{ matrix.config }} ${{ matrix.target }}"
@@ -148,7 +148,7 @@ jobs:
     - name: configure
       run: sh ./.github/configure.sh ${{ matrix.config }}
     - name: save config
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # main
       with:
         name: ${{ matrix.target }}-${{ matrix.config }}-config
         path: config.h
@@ -176,7 +176,7 @@ jobs:
       run: sh -c "for i in regress/failed*.log; do echo ====; echo logfile $i; echo =====; cat $i; done"
     - name: save logs
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # main
       with:
         name: ${{ matrix.target }}-${{ matrix.config }}-logs
         path: |

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -36,7 +36,7 @@ jobs:
     - name: shutdown VM if running
       run: vmshutdown
       working-directory: ${{ runner.temp }}
-    - uses: actions/checkout@main
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # main
     - name: startup VM
       run: vmstartup
       working-directory: ${{ runner.temp }}
@@ -63,7 +63,7 @@ jobs:
       run: vmrun 'for i in /usr/src/regress/usr.bin/ssh/obj/*.log; do echo ====; echo logfile $i; echo =====; cat $i; done'
     - name: save logs
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # main
       with:
         name: ${{ matrix.target }}-${{ matrix.config }}-logs
         path: |


### PR DESCRIPTION
## Summary

This PR pins all GitHub Actions workflow steps that reference mutable branch refs (`@main`, `@master`) to their full commit SHA.

### Affected workflows
- `.github/workflows/c-cpp.yml`
- `.github/workflows/upstream.yml`

### Actions pinned
| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@main` | `@df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/upload-artifact` | `@main` | `@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `cygwin/cygwin-install-action` | `@master` | `@4ef15ca7fd18a18f1000989fcfd968e06d146ce8` |

### Why
Mutable refs like `@main` mean the action version can change at any time without notice. A compromised or tampered action repository could silently inject malicious code into the CI pipeline. Pinning to a full commit SHA makes the exact version immutable — any future change would require an explicit, auditable PR update.

This is a recommended practice by [GitHub](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).