### PR TITLE
validate restored cipher key and IV lengths

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -2548,6 +2548,11 @@ newkeys_from_blob(struct sshbuf *m, struct ssh *ssh, int mode)
 		r = SSH_ERR_INVALID_FORMAT;
 		goto out;
 	}
+	if (keylen != cipher_keylen(enc->cipher) ||
+	    ivlen != cipher_ivlen(enc->cipher)) {
+		r = SSH_ERR_INVALID_FORMAT;
+		goto out;
+	}
 	if (cipher_authlen(enc->cipher) == 0) {
 		if ((r = sshbuf_get_cstring(b, &mac->name, NULL)) != 0)
 			goto out;


### PR DESCRIPTION
### Summary

Validate restored cipher key and IV lengths during transport state deserialization.

### Changes

* Reject transport state when the serialized cipher key length does not match the negotiated cipher's expected key length.
* Reject transport state when the serialized IV length does not match the negotiated cipher's expected IV length.
* Perform validation at the deserialization boundary in `newkeys_from_blob()` before cipher initialization.

### Benefits

* Enforces the same key/IV length invariants already guaranteed by the normal key exchange path.
* Prevents malformed transport state from reaching cipher backends.
* Keeps transport state validation consistent with existing checks for cipher properties and MAC key lengths.
* Improves robustness of state restoration with no behavior change for valid sessions.