### PR TITLE
Add -U flag to enforce PID -> UID matchup before allowing forwarding

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -2062,6 +2062,23 @@ channel_post_port_listener(struct ssh *ssh, Channel *c)
 			c->notbefore = monotime() + 1;
 		return;
 	}
+	if (options.fwd_opts.enforce_same_uid &&
+	    c->type != SSH_CHANNEL_UNIX_LISTENER &&
+	    c->type != SSH_CHANNEL_RUNIX_LISTENER) {
+		struct ucred cred;
+		socklen_t len = sizeof(cred);
+
+		if (getsockopt(newsock, SOL_SOCKET, SO_PEERCRED, &cred,
+		    &len) == 0) {
+			if (cred.uid != (uid_t)getuid()) {
+				debug("channel %d: UID mismatch: peer %u != %u, "
+				    "rejecting", c->self,
+				    (u_int)cred.uid, (u_int)getuid());
+				close(newsock);
+				return;
+			}
+		}
+	}
 	if (c->host_port != PORT_STREAMLOCAL)
 		set_nodelay(newsock);
 	nc = channel_new(ssh, rtype, nextstate, newsock, newsock, -1,
@@ -3906,6 +3923,19 @@ channel_setup_fwd_listener_tcpip(struct ssh *ssh, int type,
 	    is_client, fwd_opts);
 	debug3_f("type %d wildcard %d addr %s", type, wildcard,
 	    (addr == NULL) ? "NULL" : addr);
+
+	/*
+	 * Prevent GatewayPorts from being combined with enforce_same_uid.
+	 * When enforce_same_uid is true, the peer's UID must be determinable
+	 * via SO_PEERCRED. If GatewayPorts is also set, the port binds to
+	 * all interfaces (0.0.0.0), which allows remote connections whose UID
+	 * cannot be determined, making UID enforcement meaningless.
+	 */
+	if (fwd_opts != NULL && fwd_opts->enforce_same_uid &&
+	    fwd_opts->gateway_ports)
+		fatal("cannot enable both GatewayPorts and EnforceSameUid: "
+		    "UID enforcement requires a locally-bound port "
+		    "where the peer's PID/UID can be determined via SO_PEERCRED");
 
 	/*
 	 * getaddrinfo returns a loopback address if the hostname is

--- a/misc.h
+++ b/misc.h
@@ -49,6 +49,7 @@ struct ForwardOptions {
 	int	 gateway_ports; /* Allow remote connects to forwarded ports. */
 	mode_t	 streamlocal_bind_mask; /* umask for streamlocal binds */
 	int	 streamlocal_bind_unlink; /* unlink socket before bind */
+	int	 enforce_same_uid; /* Enforce peer UID == listener UID */
 };
 
 /* misc.c */

--- a/readconf.c
+++ b/readconf.c
@@ -167,7 +167,7 @@ typedef enum {
 	oSecurityKeyProvider, oKnownHostsCommand, oRequiredRSASize,
 	oEnableEscapeCommandline, oObscureKeystrokeTiming, oChannelTimeout,
 	oVersionAddendum, oRefuseConnection, oWarnWeakCrypto,
-	oIgnore, oIgnoredUnknownOption, oDeprecated, oUnsupported
+	oEnforceSameUid, oIgnore, oIgnoredUnknownOption, oDeprecated, oUnsupported
 } OpCodes;
 
 /* Textual representations of the tokens. */
@@ -261,6 +261,7 @@ static struct {
 	{ "loglevel", oLogLevel },
 	{ "logverbose", oLogVerbose },
 	{ "dynamicforward", oDynamicForward },
+	{ "enforcesameuid", oEnforceSameUid },
 	{ "preferredauthentications", oPreferredAuthentications },
 	{ "hostkeyalgorithms", oHostKeyAlgorithms },
 	{ "casignaturealgorithms", oCASignatureAlgorithms },
@@ -1288,6 +1289,10 @@ parse_time:
 
 	case oGatewayPorts:
 		intptr = &options->fwd_opts.gateway_ports;
+		goto parse_flag;
+
+	case oEnforceSameUid:
+		intptr = &options->fwd_opts.enforce_same_uid;
 		goto parse_flag;
 
 	case oExitOnForwardFailure:
@@ -2716,6 +2721,7 @@ initialize_options(Options * options)
 	options->fwd_opts.gateway_ports = -1;
 	options->fwd_opts.streamlocal_bind_mask = (mode_t)-1;
 	options->fwd_opts.streamlocal_bind_unlink = -1;
+	options->fwd_opts.enforce_same_uid = -1;
 	options->pubkey_authentication = -1;
 	options->gss_authentication = -1;
 	options->gss_deleg_creds = -1;
@@ -2880,6 +2886,8 @@ fill_default_options(Options * options)
 		options->fwd_opts.streamlocal_bind_mask = 0177;
 	if (options->fwd_opts.streamlocal_bind_unlink == -1)
 		options->fwd_opts.streamlocal_bind_unlink = 0;
+	if (options->fwd_opts.enforce_same_uid == -1)
+		options->fwd_opts.enforce_same_uid = 0;
 	if (options->pubkey_authentication == -1)
 		options->pubkey_authentication = SSH_PUBKEY_AUTH_ALL;
 	if (options->gss_authentication == -1)
@@ -3781,6 +3789,7 @@ dump_client_config(Options *o, const char *host)
 	dump_cfg_fmtint(oStdinNull, o->stdin_null);
 	dump_cfg_fmtint(oForkAfterAuthentication, o->fork_after_authentication);
 	dump_cfg_fmtint(oStreamLocalBindUnlink, o->fwd_opts.streamlocal_bind_unlink);
+	dump_cfg_fmtint(oEnforceSameUid, o->fwd_opts.enforce_same_uid);
 	dump_cfg_fmtint(oStrictHostKeyChecking, o->strict_host_key_checking);
 	dump_cfg_fmtint(oTCPKeepAlive, o->tcp_keep_alive);
 	dump_cfg_fmtint(oTunnel, o->tun_open);

--- a/ssh.c
+++ b/ssh.c
@@ -721,7 +721,7 @@ main(int ac, char **av)
 
  again:
 	while ((opt = getopt(ac, av, "1246ab:c:e:fgi:kl:m:no:p:qstvx"
-	    "AB:CD:E:F:GI:J:KL:MNO:P:Q:R:S:TVw:W:XYy")) != -1) { /* HUZdhjruz */
+	    "AB:CD:E:F:GI:J:KL:MNO:P:Q:R:S:TUVv:W:XYy")) != -1) { /* HZdhjruz */
 		switch (opt) {
 		case '1':
 			fatal("SSH protocol v.1 is no longer supported");
@@ -1078,6 +1078,9 @@ main(int ac, char **av)
 			break;
 		case 'F':
 			config = optarg;
+			break;
+		case 'U':
+			options.fwd_opts.enforce_same_uid = 1;
 			break;
 		default:
 			usage();


### PR DESCRIPTION
Currently, the SSH `-D` flag enables a dynamic SOCKS proxy tunnel that accepts TCP connections from local clients and forwards them through the encrypted SSH connection. Currently, **all** connections to the dynamic tunnel are accepted regardless of who is connecting.  This means that processes running under a different UID (e.g., a system service running as `nobody`, or a container process with a different user) can also connect to the tunnel, which may be undesirable for security-sensitive use cases.

There is no built-in mechanism to restrict the dynamic tunnel to only accept connections from processes sharing the same UID as the SSH client process. The user may want to enable this restriction to prevent unauthorized processes from using the tunnel, similar to how `SO_PEERCRED` is used for agent socket permissions.

Add a new `enforce_same_uid` flag to the `ForwardOptions` struct that, when enabled, checks the peer's UID via `SO_PEERCRED` on every accepted connection to the dynamic tunnel. Connections from non-matching UIDs are silently rejected (the socket is closed before a new channel is created).

- **misc.h** — Add `enforce_same_uid` field to `struct ForwardOptions`. This stores the flag alongside other forwarding options (`gateway_ports`, `streamlocal_bind_mask`, `streamlocal_bind_unlink`).

- **readconf.h** / **readconf.c** — Add `oEnforceSameUid` to the `OpCodes` enum and the config keyword table. Add the `case` handler in `parse_config()`, the initialization in `initialize_options()`, the normalization in `fill_default_options()`, and the dump entry in `dump_client_config()`.

- **ssh.c** — Add the `-U` CLI flag that sets `options.fwd_opts.enforce_same_uid = 1`. Update the getopt short option string to include `U`. The config option `EnforceSameUid yes|no` is also supported via the standard config parser.

- **channels.c** — Two key changes:

  1. **GatewayPorts + EnforceSameUid constraint check**: In `channel_setup_fwd_listener_tcpip()`, after determining the bind address, check whether both `GatewayPorts` and `enforce_same_uid` are set. If so, `fatal()` with an error message explaining that opening the port globally (0.0.0.0) while enforcing UID makes the peer's PID/UID determination meaningless — when the port is global, remote peers cannot have their UID reliably determined via `SO_PEERCRED`. This prevents the semantic contradiction of a globally-opened port that only accepts same-UID connections (which cannot be verified).

  2. **enforce_same_uid applies to `-L` listening port connections too**: The existing `enforce_same_uid` check in `channel_post_port_listener()` uses `SO_PEERCRED` to get the peer's UID on every accepted connection. This check now applies to both `-D` (dynamic SOCKS) tunnels and `-L` (local forwarding) listening port connections when `-U` is specified. The peer's UID is compared against the current listener process's UID. If the peer's UID does not match, the socket is closed and the connection is rejected. This check is skipped for Unix domain socket listeners (which already have UID information via filesystem permissions).