### PR TITLE
openpty: mark inputs const

### DIFF
--- a/openbsd-compat/bsd-openpty.c
+++ b/openbsd-compat/bsd-openpty.c
@@ -126,8 +126,8 @@ openpty_streams(int *amaster, int *aslave)
 #endif
 
 int
-openpty(int *amaster, int *aslave, char *name, struct termios *termp,
-   struct winsize *winp)
+openpty(int *amaster, int *aslave, char *name, const struct termios *termp,
+   const struct winsize *winp)
 {
 #if defined(HAVE__GETPTY)
 	/*

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -247,7 +247,8 @@ int asprintf(char **, const char *, ...);
 
 #ifndef HAVE_OPENPTY
 # include <sys/ioctl.h>	/* for struct winsize */
-int openpty(int *, int *, char *, struct termios *, struct winsize *);
+int openpty(int *, int *, char *, const struct termios *,
+    const struct winsize *);
 #endif /* HAVE_OPENPTY */
 
 #ifndef HAVE_SNPRINTF


### PR DESCRIPTION
This matches BSD & GNU implementations.