### PR TITLE
sk-usbhid: preserve UV requirement for resident keys

### DIFF
--- a/sk-usbhid.c
+++ b/sk-usbhid.c
@@ -1261,7 +1261,7 @@ static int
 read_rks(struct sk_usbhid *sk, const char *pin,
     struct sk_resident_key ***rksp, size_t *nrksp)
 {
-	int ret = SSH_SK_ERR_GENERAL, r = -1, internal_uv;
+	int ret = SSH_SK_ERR_GENERAL, r = -1;
 	uint32_t alg;
 	fido_credman_metadata_t *metadata = NULL;
 	fido_credman_rp_t *rp = NULL;
@@ -1281,11 +1281,6 @@ read_rks(struct sk_usbhid *sk, const char *pin,
 		skdebug(__func__, "alloc failed");
 		goto out;
 	}
-	if (check_sk_options(sk->dev, "uv", &internal_uv) != 0) {
-		skdebug(__func__, "check_sk_options failed");
-		goto out;
-	}
-
 	if ((r = fido_credman_get_dev_metadata(sk->dev, metadata, pin)) != 0) {
 		if (r == FIDO_ERR_INVALID_COMMAND) {
 			skdebug(__func__, "device %s does not support "
@@ -1392,9 +1387,11 @@ read_rks(struct sk_usbhid *sk, const char *pin,
 			if (srk->user_id_len != 0)
 				memcpy(srk->user_id, user_id, srk->user_id_len);
 
-			if (fido_cred_prot(cred) == FIDO_CRED_PROT_UV_REQUIRED
-			    && internal_uv == -1)
+#ifdef HAVE_FIDO_CRED_PROT
+			if (fido_cred_prot(cred) ==
+			    FIDO_CRED_PROT_UV_REQUIRED)
 				srk->flags |=  SSH_SK_USER_VERIFICATION_REQD;
+#endif
 
 			if ((r = pack_public_key(srk->alg, cred,
 			    &srk->key)) != 0) {


### PR DESCRIPTION
## What changed

Derive `SSH_SK_USER_VERIFICATION_REQD` directly from a resident credential's
`credProtect` policy when loading it from an authenticator.

Set the flag only when the credential reports
`FIDO_CRED_PROT_UV_REQUIRED`, independently of whether the authenticator
currently advertises built-in user verification through the `uv` option.

The policy check is guarded by `HAVE_FIDO_CRED_PROT` for compatibility with
older libfido2 versions.

## Why

Resident credentials created with `verify-required` store
`FIDO_CRED_PROT_UV_REQUIRED` as a per-credential policy on the authenticator.

During `ssh-keygen -K` and `ssh-add -K`, `read_rks()` currently propagates this
policy as `SSH_SK_USER_VERIFICATION_REQD` only when the authenticator does not
advertise the `uv` capability.

As a result, authenticators with built-in user verification download
`verify-required` resident keys with flags `0x21` instead of `0x25`.

The authenticator's `uv` option describes a device capability, while
`credProtect` describes the policy of an individual credential. The credential
policy should therefore be preserved independently of the authenticator's
current UV capabilities.

## Compatibility

Older FIDO 2.0 authenticators and credentials that do not expose a
`credProtect` policy are unaffected. In that case, libfido2 reports no matching
`FIDO_CRED_PROT_UV_REQUIRED` value, so the OpenSSH UV-required flag is not added.

When OpenSSH is built against a libfido2 version without
`fido_cred_prot()`, policy inference is skipped. This also avoids treating the
compatibility fallback value for an unavailable `credProtect` API as
`UV_REQUIRED`.

The change only affects reconstruction of flags while loading resident keys
through `ssh-keygen -K` and `ssh-add -K`. Credential enrollment, signing, and
non-resident credentials are unchanged.

## Validation

Built the portable tree with `--with-security-key-builtin` and libfido2 1.16.

Tested on an authenticator with built-in user verification:

- A resident credential with `UV_OPTIONAL_WITH_ID` (`0x02`) downloaded with
  OpenSSH flags `0x21`.
- A resident credential with `UV_REQUIRED` (`0x03`) downloaded with OpenSSH
  flags `0x25`.
- Enrolled a new resident credential with `verify-required` and confirmed that
  it downloaded with flags `0x25`.
- Confirmed that signing with the downloaded key still required user
  verification and user presence and completed successfully.