### PR TITLE
Allow sftp to download to a pipe when there is only a single request

### DIFF
--- a/sftp-client.c
+++ b/sftp-client.c
@@ -1739,7 +1739,7 @@ sftp_download(struct sftp_conn *conn, const char *remote_path,
 				seen_zerolen = 1;
 			}
 			lmodified = 1;
-			if ((lseek(local_fd, req->offset, SEEK_SET) == -1 ||
+			if (((conn->num_requests > 1 && lseek(local_fd, req->offset, SEEK_SET) == -1) ||
 			    atomicio(vwrite, local_fd, data, len) != len) &&
 			    !write_error) {
 				write_errno = errno;


### PR DESCRIPTION
sftp does lseek on local fd which prevents it from working with virtual files that do not support lseek (such as pipe).

This change avoids the lseek if there is only a single request pending, so we can use

sftp -R 1 ... | <other-program>

to download a file and feed to other programs on the fly.
