### PR TITLE
Respect sysconfdir for ssh_host_mldsa44_ed25519_key path

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -190,6 +190,7 @@ PATHSUBS	= \
 	-e 's|/etc/ssh/ssh_host_ecdsa_key|$(sysconfdir)/ssh_host_ecdsa_key|g' \
 	-e 's|/etc/ssh/ssh_host_rsa_key|$(sysconfdir)/ssh_host_rsa_key|g' \
 	-e 's|/etc/ssh/ssh_host_ed25519_key|$(sysconfdir)/ssh_host_ed25519_key|g' \
+	-e 's|/etc/ssh/ssh_host_mldsa44_ed25519_key|$(sysconfdir)/ssh_host_mldsa44_ed25519_key|g' \
 	-e 's|/var/run/sshd.pid|$(piddir)/sshd.pid|g' \
 	-e 's|/etc/moduli|$(sysconfdir)/moduli|g' \
 	-e 's|/etc/ssh/moduli|$(sysconfdir)/moduli|g' \


### PR DESCRIPTION
This fixes an issue where the path of the host key `ssh_host_mldsa44_ed25519_key` doesn't respect `sysconfdir` in `sshd_config` and the man pages.