### PR TITLE
regress: skip old-format checks for ssh-mldsa44-ed25519 in keygen-comment

### DIFF
--- a/regress/keygen-comment.sh
+++ b/regress/keygen-comment.sh
@@ -27,10 +27,11 @@ for fmt in '' RFC4716 PKCS8 PEM; do
 		case "$fmt" in
 		PKCS8|PEM) oldfmt=1 ;;
 		esac
-		# Some key types like ssh-ed25519 and *@openssh.com are never
-		# stored in old formats.
+		# Some key types like ssh-ed25519, ssh-mldsa44-ed25519 and
+		# *@openssh.com are never stored in old formats.
 		case "$t" in
-		ssh-ed25519|*openssh.com) test -z "$oldfmt" || continue ;;
+		ssh-ed25519|ssh-mldsa44-ed25519|*openssh.com)
+			test -z "$oldfmt" || continue ;;
 		esac
 		comment="foo bar"
 		fmtarg=""


### PR DESCRIPTION
keygen-comment.sh has been failing since `ssh-mldsa44-ed25519` was put back into the default proposal. The key type list is built from `ssh -Q key-plain`, so the test started exercising it once it was re-enabled:

```
run test keygen-comment.sh ...
comment is not correctly recovered for ssh-mldsa44-ed25519-key
comment is not correctly recovered for ssh-mldsa44-ed25519-key
failed Comment extraction from private key
```

The test expects the comment to be dropped when the key is written with `-m PKCS8` or `-m PEM`. Some types ignore the `-m` and always come out as `openssh-key-v1` (like `ssh-ed25519` and `*@openssh.com`). `ssh-mldsa44-ed25519` behaves the same way, so the comment remains and the "no comment" check fails, both for PKCS8 and for PEM.

This PR adds `ssh-mldsa44-ed25519` to the skip list.